### PR TITLE
feat(runtime): add shared adapter and inference SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-runtime-sdk"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "symbiote-domain",
+]
+
+[[package]]
 name = "symbiote-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host"]
+members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The Rust workspace now includes a local `symbioted` service and `symbiote` CLI b
 
 Start the local service using the [Host run instructions](docs/contracts/host.md). The Host currently targets Linux and authenticates local clients using OS peer credentials. The separate [Linux shell experiment](docs/proofs/linux-shell.md) remains a proof workload, not the production workbench.
 
+The [runtime SDK](docs/contracts/runtime-sdk.md) now defines capability-qualified agent adapters, separate inference providers and bounded session events. These contracts are prerequisites for live native/Codex integration; they do not enable agent execution in the Host yet.
+
 ```sh
 cargo test --workspace --locked
 cargo clippy --workspace --all-targets --locked -- -D warnings
@@ -16,6 +18,7 @@ cargo run -p symbiote-domain --example domain_schema
 cargo run -p symbiote-config --example config_schema
 cargo run -p symbiote-architecture --example architecture_schema
 cargo run -p symbiote-protocol --example protocol_schema
+cargo run -p symbiote-runtime-sdk --example runtime_schema
 ```
 
 Schema examples emit JSON to stdout. The generated structural schemas do not replace runtime cross-field checks. Rust 1.85 is the declared minimum; Cargo.lock pins dependencies. CI tests the minimum and current stable toolchain. Workspace code forbids unsafe Rust.

--- a/crates/symbiote-domain/src/dispatch.rs
+++ b/crates/symbiote-domain/src/dispatch.rs
@@ -27,6 +27,9 @@ impl WorkforceRuntimeContract {
     pub fn binding(&self) -> &WorkforceBinding {
         &self.binding
     }
+    pub fn enforcement(&self) -> &BTreeMap<Control, EnforcementClaim> {
+        &self.enforcement
+    }
     pub fn role(&self) -> &Role {
         &self.role
     }

--- a/crates/symbiote-runtime-sdk/Cargo.toml
+++ b/crates/symbiote-runtime-sdk/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "symbiote-runtime-sdk"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+symbiote-domain = { path = "../symbiote-domain" }
+
+[lints]
+workspace = true
+
+[[example]]
+name = "runtime_schema"
+path = "examples/schema.rs"

--- a/crates/symbiote-runtime-sdk/examples/schema.rs
+++ b/crates/symbiote-runtime-sdk/examples/schema.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let schemas = serde_json::json!({
+        "runtime_descriptor": schemars::schema_for!(symbiote_runtime_sdk::RuntimeDescriptor),
+        "runtime_event": schemars::schema_for!(symbiote_runtime_sdk::events::RuntimeEvent),
+        "provider_request": schemars::schema_for!(symbiote_runtime_sdk::provider::ProviderRequest),
+        "provider_response": schemars::schema_for!(symbiote_runtime_sdk::provider::ProviderResponse)
+    });
+    println!("{}", serde_json::to_string_pretty(&schemas).unwrap());
+}

--- a/crates/symbiote-runtime-sdk/src/adapter.rs
+++ b/crates/symbiote-runtime-sdk/src/adapter.rs
@@ -1,0 +1,219 @@
+use crate::{Capability, QualificationError, RuntimeDescriptor, qualify_dispatch};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use symbiote_domain::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AdapterOperation {
+    Detect,
+    Probe,
+    PollEvents,
+    Authenticate,
+    DiscoverProfiles,
+    ProjectConfiguration,
+    Launch,
+    Handshake,
+    Send,
+    Steer,
+    Interrupt,
+    Cancel,
+    Resume,
+    Fork,
+    Health,
+    Usage,
+    Dispose,
+    Revoke,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AdapterError {
+    Unsupported { operation: AdapterOperation },
+    Qualification { reason: QualificationError },
+    AuthorizationNotPersisted,
+    ContractMismatch,
+    InvalidInput,
+    SessionMismatch,
+    Unavailable,
+    UnknownEffect,
+}
+impl std::fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for AdapterError {}
+impl From<QualificationError> for AdapterError {
+    fn from(reason: QualificationError) -> Self {
+        Self::Qualification { reason }
+    }
+}
+
+/// A Host journal receipt, never deserialized from an agent/tool event.
+#[derive(Clone, Debug)]
+pub struct ActivationReceipt {
+    pub command_id: CommandId,
+    pub revision: Revision,
+    pub dispatch: Dispatch,
+    pub descriptor: RuntimeDescriptor,
+    pub authorized_at: Timestamp,
+}
+
+/// Implemented inside the trusted Host. Returning success means the exact
+/// immutable dispatch and qualification facts are committed before activation.
+pub trait ActivationJournal {
+    fn persist_authorization(
+        &mut self,
+        dispatch: &Dispatch,
+        descriptor: &RuntimeDescriptor,
+        at: Timestamp,
+    ) -> Result<ActivationReceipt, AdapterError>;
+}
+
+/// Preparation is data-only: no project hooks, code, providers or credentials run.
+pub struct PreparedLaunch {
+    dispatch: Dispatch,
+    descriptor: RuntimeDescriptor,
+    required_capabilities: BTreeSet<Capability>,
+}
+impl PreparedLaunch {
+    pub fn new(
+        dispatch: Dispatch,
+        descriptor: RuntimeDescriptor,
+        required_capabilities: BTreeSet<Capability>,
+        at: Timestamp,
+    ) -> Result<Self, AdapterError> {
+        qualify_dispatch(&dispatch, &descriptor, &required_capabilities, at)?;
+        Ok(Self {
+            dispatch,
+            descriptor,
+            required_capabilities,
+        })
+    }
+
+    pub fn authorize(
+        self,
+        journal: &mut impl ActivationJournal,
+        at: Timestamp,
+    ) -> Result<LaunchPermit, AdapterError> {
+        qualify_dispatch(
+            &self.dispatch,
+            &self.descriptor,
+            &self.required_capabilities,
+            at,
+        )?;
+        let receipt = journal.persist_authorization(&self.dispatch, &self.descriptor, at)?;
+        if receipt.dispatch != self.dispatch
+            || receipt.descriptor != self.descriptor
+            || receipt.authorized_at != at
+            || receipt.revision.0 == 0
+        {
+            return Err(AdapterError::ContractMismatch);
+        }
+        Ok(LaunchPermit {
+            receipt,
+            required_capabilities: self.required_capabilities,
+        })
+    }
+}
+
+/// Non-serializable, no public constructor. A worker JSON payload cannot mint it.
+/// Consumed at launch; actual one-time fencing across crashes remains Host-owned.
+pub struct LaunchPermit {
+    receipt: ActivationReceipt,
+    required_capabilities: BTreeSet<Capability>,
+}
+impl LaunchPermit {
+    pub fn dispatch(&self) -> &Dispatch {
+        &self.receipt.dispatch
+    }
+    pub fn receipt(&self) -> &ActivationReceipt {
+        &self.receipt
+    }
+    /// Adapters must recheck immediately before resource activation; preparation
+    /// or journal latency cannot keep expired enforcement proof valid.
+    pub fn validate_at(
+        &self,
+        current_descriptor: &RuntimeDescriptor,
+        at: Timestamp,
+    ) -> Result<(), AdapterError> {
+        if current_descriptor != &self.receipt.descriptor || at < self.receipt.authorized_at {
+            return Err(AdapterError::ContractMismatch);
+        }
+        qualify_dispatch(
+            &self.receipt.dispatch,
+            current_descriptor,
+            &self.required_capabilities,
+            at,
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TurnInput {
+    pub text: String,
+    pub artifacts: Vec<ArtifactId>,
+}
+impl TurnInput {
+    pub fn validate(&self) -> Result<(), AdapterError> {
+        if self.text.trim().is_empty() || self.text.len() > 64 * 1024 || self.artifacts.len() > 64 {
+            return Err(AdapterError::InvalidInput);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SessionControl {
+    Interrupt {},
+    Cancel {},
+    Resume {},
+    Fork { successor: SessionId },
+}
+
+/// Full agent-loop adapters, separate from inference-only providers. Unsupported
+/// methods are explicit errors, never successful no-ops or PTY parsing guesses.
+/// A concrete adapter must enforce session binding, input/event bounds and the
+/// permit check. Actual process containment is a prerequisite outside this SDK.
+pub trait AgentRuntimeAdapter {
+    fn descriptor(&self) -> &RuntimeDescriptor;
+    fn launch(&mut self, permit: LaunchPermit, at: Timestamp) -> Result<SessionId, AdapterError>;
+    fn send(&mut self, _session: &SessionId, _input: TurnInput) -> Result<(), AdapterError> {
+        Err(AdapterError::Unsupported {
+            operation: AdapterOperation::Send,
+        })
+    }
+    fn poll_events(
+        &mut self,
+        _session: &SessionId,
+        _after: u64,
+        _limit: u16,
+    ) -> Result<Vec<crate::events::RuntimeEvent>, AdapterError> {
+        Err(AdapterError::Unsupported {
+            operation: AdapterOperation::PollEvents,
+        })
+    }
+    fn control(
+        &mut self,
+        _session: &SessionId,
+        command: SessionControl,
+    ) -> Result<(), AdapterError> {
+        let operation = match command {
+            SessionControl::Interrupt {} => AdapterOperation::Interrupt,
+            SessionControl::Cancel {} => AdapterOperation::Cancel,
+            SessionControl::Resume {} => AdapterOperation::Resume,
+            SessionControl::Fork { .. } => AdapterOperation::Fork,
+        };
+        Err(AdapterError::Unsupported { operation })
+    }
+    fn dispose(&mut self, _session: &SessionId) -> Result<(), AdapterError> {
+        Err(AdapterError::Unsupported {
+            operation: AdapterOperation::Dispose,
+        })
+    }
+}

--- a/crates/symbiote-runtime-sdk/src/capabilities.rs
+++ b/crates/symbiote-runtime-sdk/src/capabilities.rs
@@ -1,0 +1,326 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use symbiote_domain::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Capability {
+    StructuredMessages,
+    Streaming,
+    Tools,
+    Approvals,
+    Questions,
+    Resume,
+    Fork,
+    Models,
+    Reasoning,
+    ContextLimits,
+    Usage,
+    Quotas,
+    Hooks,
+    Mcp,
+    Skills,
+    NativeTasks,
+    Images,
+    WorktreeIsolation,
+    Instructions,
+    Extensions,
+    ProfileIsolation,
+    Authentication,
+    Cancellation,
+    GoalPersistence,
+    ChildAgents,
+    ChildModelSelection,
+    ChildEvents,
+    ChildUsage,
+    AggregateBudgets,
+    DepthLimits,
+    ConcurrencyLimits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IntegrationTier {
+    TerminalCompatible,
+    Detected,
+    Managed,
+    Structured,
+    OrchestratorGrade,
+    Certified,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RuntimeOwner {
+    SymbioteNative {},
+    External { driver: HarnessDriverId },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Transport {
+    NativeLoop,
+    StructuredRpc,
+    Pty,
+}
+
+/// Metadata references to Host-verified proof, never a self-authenticating claim.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeEvidence {
+    pub artifact: EvidenceId,
+    pub adapter_id: AgentRuntimeAdapterId,
+    pub installation: Option<InstallationId>,
+    pub profile_id: RuntimeProfileId,
+    pub profile_revision: Revision,
+    pub model_id: ModelId,
+    pub host_id: HostId,
+    pub adapter_version: String,
+    pub upstream_version: String,
+    pub platform: String,
+    pub observed_at: Timestamp,
+    pub expires_at: Timestamp,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Support {
+    Supported { evidence: Box<ProbeEvidence> },
+    Unsupported,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ControlSupport {
+    pub strength: EnforcementStrength,
+    pub mechanism: String,
+    pub evidence: ProbeEvidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeContextLimits {
+    pub context_window_tokens: u32,
+    pub max_output_tokens: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeDescriptor {
+    pub sdk_version: u32,
+    pub adapter_id: AgentRuntimeAdapterId,
+    pub installation: Option<InstallationId>,
+    pub profile_id: RuntimeProfileId,
+    pub profile_revision: Revision,
+    pub model_id: ModelId,
+    pub adapter_version: String,
+    pub upstream_version: String,
+    pub runtime: RuntimeKind,
+    pub owner: RuntimeOwner,
+    pub transport: Transport,
+    /// Integration tier does not imply any individual capability or certification.
+    pub tier: IntegrationTier,
+    pub host_id: HostId,
+    pub platform: String,
+    pub capabilities: BTreeMap<Capability, Support>,
+    pub controls: BTreeMap<Control, ControlSupport>,
+    pub tools: BTreeSet<String>,
+    pub skills: BTreeSet<String>,
+    pub context_limits: Option<RuntimeContextLimits>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QualificationError {
+    UnsupportedVersion,
+    InvalidDescriptor,
+    RuntimeOwnerMismatch,
+    AdapterMismatch,
+    IneligibleHost,
+    MissingCapability(Capability),
+    UnknownCapability(Capability),
+    MissingControl(Control),
+    InsufficientControl(Control),
+    StaleEvidence,
+    InvalidContract,
+    MissingResource,
+    ContextLimitExceeded,
+}
+impl std::fmt::Display for QualificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for QualificationError {}
+
+impl RuntimeDescriptor {
+    pub fn validate(&self) -> Result<(), QualificationError> {
+        if self.sdk_version != crate::SDK_VERSION {
+            return Err(QualificationError::UnsupportedVersion);
+        }
+        for text in [
+            &self.adapter_version,
+            &self.upstream_version,
+            &self.platform,
+        ] {
+            if text.is_empty() || text.len() > 128 || text.chars().any(char::is_control) {
+                return Err(QualificationError::InvalidDescriptor);
+            }
+        }
+        if self.tools.len() > 128
+            || self.skills.len() > 128
+            || self.tools.iter().chain(&self.skills).any(|text| {
+                text.trim().is_empty() || text.len() > 128 || text.chars().any(char::is_control)
+            })
+        {
+            return Err(QualificationError::InvalidDescriptor);
+        }
+        if self.context_limits.as_ref().is_some_and(|limits| {
+            limits.max_output_tokens == 0 || limits.context_window_tokens < limits.max_output_tokens
+        }) {
+            return Err(QualificationError::InvalidDescriptor);
+        }
+        if !matches!(
+            (&self.runtime, &self.owner, &self.transport),
+            (
+                RuntimeKind::NativeSymbiote,
+                RuntimeOwner::SymbioteNative {},
+                Transport::NativeLoop
+            ) | (
+                RuntimeKind::ExternalHarness,
+                RuntimeOwner::External { .. },
+                Transport::StructuredRpc | Transport::Pty
+            )
+        ) {
+            return Err(QualificationError::RuntimeOwnerMismatch);
+        }
+        Ok(())
+    }
+    fn evidence(&self, proof: &ProbeEvidence, now: Timestamp) -> Result<(), QualificationError> {
+        if proof.adapter_id != self.adapter_id
+            || proof.installation != self.installation
+            || proof.profile_id != self.profile_id
+            || proof.profile_revision != self.profile_revision
+            || proof.model_id != self.model_id
+            || proof.host_id != self.host_id
+            || proof.adapter_version != self.adapter_version
+            || proof.upstream_version != self.upstream_version
+            || proof.platform != self.platform
+            || proof.observed_at > now
+            || proof.expires_at <= now
+            || proof.observed_at >= proof.expires_at
+        {
+            return Err(QualificationError::StaleEvidence);
+        }
+        Ok(())
+    }
+}
+
+/// Checks current facts, not adapter names or marketing tiers. The caller must
+/// authenticate referenced proof artifacts before allowing this metadata to qualify.
+pub fn qualify_profile(
+    profile: &RuntimeProfile,
+    descriptor: &RuntimeDescriptor,
+    required_capabilities: &BTreeSet<Capability>,
+    required_controls: &BTreeSet<Control>,
+    now: Timestamp,
+) -> Result<(), QualificationError> {
+    descriptor.validate()?;
+    if profile.adapter != descriptor.adapter_id
+        || profile.runtime != descriptor.runtime
+        || profile.installation != descriptor.installation
+        || profile.id != descriptor.profile_id
+        || profile.revision != descriptor.profile_revision
+        || profile.model != descriptor.model_id
+    {
+        return Err(QualificationError::AdapterMismatch);
+    }
+    if !profile.eligible_hosts.contains(&descriptor.host_id) {
+        return Err(QualificationError::IneligibleHost);
+    }
+    if profile.runtime == RuntimeKind::ExternalHarness && profile.installation.is_none() {
+        return Err(QualificationError::InvalidDescriptor);
+    }
+    for capability in required_capabilities {
+        match descriptor.capabilities.get(capability) {
+            Some(Support::Supported { evidence }) => descriptor.evidence(evidence, now)?,
+            Some(Support::Unknown) => {
+                return Err(QualificationError::UnknownCapability(capability.clone()));
+            }
+            _ => return Err(QualificationError::MissingCapability(capability.clone())),
+        }
+    }
+    for control in required_controls {
+        let support = descriptor
+            .controls
+            .get(control)
+            .ok_or_else(|| QualificationError::MissingControl(control.clone()))?;
+        if !matches!(
+            support.strength,
+            EnforcementStrength::Native | EnforcementStrength::HostEnforced
+        ) || support.mechanism.trim().is_empty()
+            || support.mechanism.len() > 256
+        {
+            return Err(QualificationError::InsufficientControl(control.clone()));
+        }
+        descriptor.evidence(&support.evidence, now)?;
+    }
+    Ok(())
+}
+
+pub fn qualify_dispatch(
+    dispatch: &Dispatch,
+    descriptor: &RuntimeDescriptor,
+    required_capabilities: &BTreeSet<Capability>,
+    now: Timestamp,
+) -> Result<(), QualificationError> {
+    let contract = dispatch.contract();
+    contract
+        .validate_at(now)
+        .map_err(|_| QualificationError::InvalidContract)?;
+    if contract.host_id() != &descriptor.host_id {
+        return Err(QualificationError::IneligibleHost);
+    }
+    let controls = contract.enforcement().keys().cloned().collect();
+    let mut capabilities = required_capabilities.clone();
+    capabilities.insert(Capability::ContextLimits);
+    let limits = descriptor
+        .context_limits
+        .as_ref()
+        .ok_or(QualificationError::ContextLimitExceeded)?;
+    let context = &contract.binding().context;
+    if context.reserved_output_tokens > limits.max_output_tokens
+        || context
+            .max_input_tokens
+            .checked_add(context.reserved_output_tokens)
+            .is_none_or(|total| total > limits.context_window_tokens)
+    {
+        return Err(QualificationError::ContextLimitExceeded);
+    }
+    if !contract.binding().required_tools.is_empty() {
+        capabilities.insert(Capability::Tools);
+    }
+    if !contract.binding().required_skills.is_empty() {
+        capabilities.insert(Capability::Skills);
+    }
+    if !contract
+        .binding()
+        .required_tools
+        .is_subset(&descriptor.tools)
+        || !contract
+            .binding()
+            .required_skills
+            .is_subset(&descriptor.skills)
+    {
+        return Err(QualificationError::MissingResource);
+    }
+    qualify_profile(
+        contract.profile(),
+        descriptor,
+        &capabilities,
+        &controls,
+        now,
+    )
+}

--- a/crates/symbiote-runtime-sdk/src/events.rs
+++ b/crates/symbiote-runtime-sdk/src/events.rs
@@ -1,0 +1,641 @@
+//! Normalized runtime observations. Nothing in this module completes canonical work.
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+use symbiote_domain::{CommandId, DispatchId, HostId, RequestId, RuntimeKind, SessionId};
+
+pub const MAX_EVENT_TEXT_BYTES: usize = 16_384;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct EventText(String);
+impl JsonSchema for EventText {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "EventText".into()
+    }
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({"type":"string","maxLength":16384,"description":"At most 16384 UTF-8 bytes; runtime also enforces this stricter byte limit."})
+    }
+}
+impl EventText {
+    pub fn new(text: impl Into<String>) -> Result<Self, EventError> {
+        let text = text.into();
+        if text.len() > MAX_EVENT_TEXT_BYTES {
+            return Err(EventError::TextTooLarge);
+        }
+        Ok(Self(text))
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+impl TryFrom<String> for EventText {
+    type Error = EventError;
+    fn try_from(text: String) -> Result<Self, Self::Error> {
+        Self::new(text)
+    }
+}
+impl From<EventText> for String {
+    fn from(text: EventText) -> Self {
+        text.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SessionBinding {
+    pub session_id: SessionId,
+    pub dispatch_id: DispatchId,
+    pub host_id: HostId,
+    pub runtime: RuntimeKind,
+}
+
+/// Absence and a measured zero have different wire representations.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum UsageMeasurement {
+    Unknown { reason: UnknownUsageReason },
+    Measured { value: u64 },
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UnknownUsageReason {
+    NotReported,
+    Unsupported,
+    PartialVisibility,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageCoverage {
+    RootOnly,
+    RootAndChildren,
+    AggregateOnly,
+    Unknown,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeUsage {
+    pub input_tokens: UsageMeasurement,
+    pub output_tokens: UsageMeasurement,
+    pub cached_input_tokens: UsageMeasurement,
+    pub billed_micro_units: UsageMeasurement,
+    pub coverage: UsageCoverage,
+}
+impl RuntimeUsage {
+    pub fn validate(&self) -> Result<(), EventError> {
+        if let (
+            UsageMeasurement::Measured { value: input },
+            UsageMeasurement::Measured { value: cached },
+        ) = (&self.input_tokens, &self.cached_input_tokens)
+        {
+            if cached > input {
+                return Err(EventError::InvalidUsage);
+            }
+        }
+        if let (
+            UsageMeasurement::Measured { value: input },
+            UsageMeasurement::Measured { value: output },
+        ) = (&self.input_tokens, &self.output_tokens)
+        {
+            if input.checked_add(*output).is_none() {
+                return Err(EventError::InvalidUsage);
+            }
+        }
+        Ok(())
+    }
+}
+impl<'de> Deserialize<'de> for RuntimeUsage {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            input_tokens: UsageMeasurement,
+            output_tokens: UsageMeasurement,
+            cached_input_tokens: UsageMeasurement,
+            billed_micro_units: UsageMeasurement,
+            coverage: UsageCoverage,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let usage = Self {
+            input_tokens: wire.input_tokens,
+            output_tokens: wire.output_tokens,
+            cached_input_tokens: wire.cached_input_tokens,
+            billed_micro_units: wire.billed_micro_units,
+            coverage: wire.coverage,
+        };
+        usage.validate().map_err(serde::de::Error::custom)?;
+        Ok(usage)
+    }
+}
+
+/// Retain a namespaced reference to separately governed/redacted vendor evidence,
+/// not an unbounded raw payload or a copy of authentication material.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VendorEventReference {
+    pub namespace: EventText,
+    pub id: RequestId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationKind {
+    FilesystemMutation,
+    ShellProcess,
+    Git,
+    Network,
+    McpAccess,
+    SecretAccess,
+    PostEdit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RuntimeEventKind {
+    Ready {},
+    Message {
+        text: EventText,
+    },
+    ToolProposed {
+        tool_call_id: RequestId,
+        name: EventText,
+        arguments: EventText,
+    },
+    ToolStarted {
+        tool_call_id: RequestId,
+    },
+    ToolCompleted {
+        tool_call_id: RequestId,
+        output: EventText,
+    },
+    ToolFailed {
+        tool_call_id: RequestId,
+        error: EventText,
+    },
+    ApprovalRequested {
+        request_id: RequestId,
+        prompt: EventText,
+    },
+    WorkerQuestion {
+        request_id: RequestId,
+        prompt: EventText,
+    },
+    Observation {
+        resource: ObservationKind,
+        detail: EventText,
+    },
+    Diagnostic {
+        message: EventText,
+    },
+    Usage {
+        usage: RuntimeUsage,
+    },
+    CompletionRequested {
+        report: EventText,
+    },
+    Exit {
+        code: Option<i32>,
+    },
+    Disconnected {
+        reason: EventText,
+    },
+    Reconnected {},
+    Crashed {
+        reason: EventText,
+    },
+    CancellationRequested {
+        reason: EventText,
+    },
+    CancelAcknowledged {},
+}
+impl RuntimeEventKind {
+    fn is_mutation_observation(&self) -> bool {
+        matches!(
+            self,
+            Self::ToolProposed { .. }
+                | Self::ToolStarted { .. }
+                | Self::ToolCompleted { .. }
+                | Self::ToolFailed { .. }
+                | Self::Observation { .. }
+        )
+    }
+}
+
+/// The adapter assigns positive contiguous sequence numbers per immutable binding.
+/// This envelope proves structure, not that the sender is an authenticated adapter.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeEvent {
+    id: CommandId,
+    #[schemars(range(min = 1))]
+    sequence: u64,
+    binding: SessionBinding,
+    payload: RuntimeEventKind,
+    vendor: Option<VendorEventReference>,
+}
+impl RuntimeEvent {
+    pub fn new(
+        id: CommandId,
+        sequence: u64,
+        binding: SessionBinding,
+        payload: RuntimeEventKind,
+    ) -> Result<Self, EventError> {
+        if sequence == 0 {
+            return Err(EventError::InvalidSequence);
+        }
+        if let RuntimeEventKind::Usage { usage } = &payload {
+            usage.validate()?;
+        }
+        if matches!(&payload, RuntimeEventKind::ToolProposed { name, .. } if name.as_str().trim().is_empty())
+        {
+            return Err(EventError::EmptyToolName);
+        }
+        Ok(Self {
+            id,
+            sequence,
+            binding,
+            payload,
+            vendor: None,
+        })
+    }
+    pub fn with_vendor_reference(
+        mut self,
+        vendor: VendorEventReference,
+    ) -> Result<Self, EventError> {
+        if vendor.namespace.as_str().trim().is_empty() {
+            return Err(EventError::InvalidVendorReference);
+        }
+        self.vendor = Some(vendor);
+        Ok(self)
+    }
+    pub fn id(&self) -> &CommandId {
+        &self.id
+    }
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+    pub fn binding(&self) -> &SessionBinding {
+        &self.binding
+    }
+    pub fn payload(&self) -> &RuntimeEventKind {
+        &self.payload
+    }
+    pub fn vendor_reference(&self) -> Option<&VendorEventReference> {
+        self.vendor.as_ref()
+    }
+}
+impl<'de> Deserialize<'de> for RuntimeEvent {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            id: CommandId,
+            sequence: u64,
+            binding: SessionBinding,
+            payload: RuntimeEventKind,
+            vendor: Option<VendorEventReference>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let mut event = Self::new(wire.id, wire.sequence, wire.binding, wire.payload)
+            .map_err(serde::de::Error::custom)?;
+        if let Some(vendor) = wire.vendor {
+            event = event
+                .with_vendor_reference(vendor)
+                .map_err(serde::de::Error::custom)?;
+        }
+        Ok(event)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionState {
+    AwaitingReady,
+    Running,
+    Disconnected,
+    Cancelling,
+    Cancelled,
+    Exited,
+    Crashed,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ResidualEffects {
+    Unassessed,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EventReceipt {
+    pub sequence: u64,
+    pub state: SessionState,
+    pub replayed: bool,
+    pub residual_effects: ResidualEffects,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TrackerLimits {
+    pub replay_capacity: usize,
+    pub max_tool_calls: usize,
+    pub max_events: usize,
+}
+impl Default for TrackerLimits {
+    fn default() -> Self {
+        Self {
+            replay_capacity: 128,
+            max_tool_calls: 256,
+            max_events: 4096,
+        }
+    }
+}
+impl TrackerLimits {
+    fn validate(self) -> Result<Self, EventError> {
+        if !(1..=1024).contains(&self.replay_capacity)
+            || !(1..=256).contains(&self.max_tool_calls)
+            || !(1..=65536).contains(&self.max_events)
+            || self.replay_capacity > self.max_events
+        {
+            return Err(EventError::InvalidLimits);
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "error", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EventError {
+    TextTooLarge,
+    InvalidUsage,
+    EmptyToolName,
+    InvalidVendorReference,
+    InvalidSequence,
+    BindingMismatch,
+    IdempotencyConflict,
+    SequenceConflict,
+    SequenceGap { expected: u64, received: u64 },
+    ReplayUnavailable { floor: u64 },
+    InvalidTransition,
+    UnknownTool,
+    ToolAlreadyExists,
+    ToolTransitionRejected,
+    CapacityExceeded,
+    InvalidLimits,
+    ResidualEffectUnknown,
+}
+impl fmt::Display for EventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for EventError {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+enum ToolState {
+    Proposed,
+    Started,
+    Completed,
+    Failed,
+}
+#[derive(Clone, Debug, Serialize)]
+struct RetainedEvent {
+    event: RuntimeEvent,
+    receipt: EventReceipt,
+}
+
+/// Serialize for inspection only; deliberately no Deserialize authority shortcut.
+/// A new tracker must consume its event stream in order. When history has expired,
+/// recovery requires an authoritative adapter/store handoff, not a guessed replay.
+#[derive(Clone, Debug, Serialize)]
+pub struct SessionTracker {
+    binding: SessionBinding,
+    limits: TrackerLimits,
+    state: SessionState,
+    last_sequence: u64,
+    cancellation_requested: bool,
+    before_disconnect: Option<SessionState>,
+    residual_effects: ResidualEffects,
+    history: VecDeque<RetainedEvent>,
+    seen_ids: BTreeSet<CommandId>,
+    tools: BTreeMap<RequestId, ToolState>,
+}
+impl SessionTracker {
+    pub fn new(binding: SessionBinding, limits: TrackerLimits) -> Result<Self, EventError> {
+        Ok(Self {
+            binding,
+            limits: limits.validate()?,
+            state: SessionState::AwaitingReady,
+            last_sequence: 0,
+            cancellation_requested: false,
+            before_disconnect: None,
+            residual_effects: ResidualEffects::Unassessed,
+            history: VecDeque::new(),
+            seen_ids: BTreeSet::new(),
+            tools: BTreeMap::new(),
+        })
+    }
+    pub fn binding(&self) -> &SessionBinding {
+        &self.binding
+    }
+    pub fn state(&self) -> SessionState {
+        self.state
+    }
+    pub fn next_sequence(&self) -> u64 {
+        self.last_sequence + 1
+    }
+    pub fn replay_floor(&self) -> u64 {
+        self.history.front().map_or(1, |entry| entry.event.sequence)
+    }
+    pub fn residual_effects(&self) -> ResidualEffects {
+        self.residual_effects
+    }
+    pub fn retained_event_count(&self) -> usize {
+        self.history.len()
+    }
+    pub fn tracked_tool_count(&self) -> usize {
+        self.tools.len()
+    }
+
+    pub fn apply(&mut self, event: RuntimeEvent) -> Result<EventReceipt, EventError> {
+        if event.binding != self.binding {
+            return Err(EventError::BindingMismatch);
+        }
+        if event.sequence < self.replay_floor() {
+            return Err(EventError::ReplayUnavailable {
+                floor: self.replay_floor(),
+            });
+        }
+        if let Some(previous) = self.history.iter().find(|entry| entry.event.id == event.id) {
+            return if previous.event == event {
+                let mut receipt = previous.receipt.clone();
+                receipt.replayed = true;
+                Ok(receipt)
+            } else {
+                Err(EventError::IdempotencyConflict)
+            };
+        }
+        if self.seen_ids.contains(&event.id) {
+            return Err(EventError::IdempotencyConflict);
+        }
+        if event.sequence <= self.last_sequence {
+            return Err(EventError::SequenceConflict);
+        }
+        if event.sequence != self.next_sequence() {
+            return Err(EventError::SequenceGap {
+                expected: self.next_sequence(),
+                received: event.sequence,
+            });
+        }
+        if self.cancellation_requested && event.payload.is_mutation_observation() {
+            self.residual_effects = ResidualEffects::Unknown;
+            return Err(EventError::ResidualEffectUnknown);
+        }
+        if self.seen_ids.len() >= self.limits.max_events {
+            return Err(EventError::CapacityExceeded);
+        }
+        self.transition(&event.payload)?;
+        self.last_sequence = event.sequence;
+        self.seen_ids.insert(event.id.clone());
+        let receipt = EventReceipt {
+            sequence: event.sequence,
+            state: self.state,
+            replayed: false,
+            residual_effects: self.residual_effects,
+        };
+        if self.history.len() == self.limits.replay_capacity {
+            self.history.pop_front();
+        }
+        self.history.push_back(RetainedEvent {
+            event,
+            receipt: receipt.clone(),
+        });
+        Ok(receipt)
+    }
+
+    fn transition(&mut self, payload: &RuntimeEventKind) -> Result<(), EventError> {
+        use RuntimeEventKind as E;
+        match payload {
+            E::Usage { .. } | E::Diagnostic { .. } => {}
+            E::Ready {} => {
+                if self.state != SessionState::AwaitingReady {
+                    return Err(EventError::InvalidTransition);
+                }
+                self.state = SessionState::Running;
+            }
+            E::Message { .. }
+            | E::ApprovalRequested { .. }
+            | E::WorkerQuestion { .. }
+            | E::Observation { .. }
+            | E::CompletionRequested { .. } => {
+                self.require_running()?;
+            }
+            E::ToolProposed { tool_call_id, .. } => {
+                self.require_running()?;
+                if self.tools.contains_key(tool_call_id) {
+                    return Err(EventError::ToolAlreadyExists);
+                }
+                if self.tools.len() >= self.limits.max_tool_calls {
+                    return Err(EventError::CapacityExceeded);
+                }
+                self.tools.insert(tool_call_id.clone(), ToolState::Proposed);
+            }
+            E::ToolStarted { tool_call_id } => {
+                self.tool_transition(tool_call_id, ToolState::Proposed, ToolState::Started)?;
+            }
+            E::ToolCompleted { tool_call_id, .. } => {
+                self.tool_transition(tool_call_id, ToolState::Started, ToolState::Completed)?;
+            }
+            E::ToolFailed { tool_call_id, .. } => {
+                self.tool_transition(tool_call_id, ToolState::Started, ToolState::Failed)?;
+            }
+            E::Disconnected { .. } => {
+                if !matches!(
+                    self.state,
+                    SessionState::AwaitingReady | SessionState::Running | SessionState::Cancelling
+                ) {
+                    return Err(EventError::InvalidTransition);
+                }
+                self.residual_effects = ResidualEffects::Unknown;
+                self.before_disconnect = Some(self.state);
+                self.state = SessionState::Disconnected;
+            }
+            E::Reconnected {} => {
+                if self.state != SessionState::Disconnected {
+                    return Err(EventError::InvalidTransition);
+                }
+                self.state = if self.cancellation_requested {
+                    SessionState::Cancelling
+                } else {
+                    self.before_disconnect
+                        .unwrap_or(SessionState::AwaitingReady)
+                };
+                self.before_disconnect = None;
+            }
+            E::CancellationRequested { .. } => {
+                if !matches!(
+                    self.state,
+                    SessionState::AwaitingReady
+                        | SessionState::Running
+                        | SessionState::Disconnected
+                ) {
+                    return Err(EventError::InvalidTransition);
+                }
+                self.cancellation_requested = true;
+                self.residual_effects = ResidualEffects::Unknown;
+                if self.state != SessionState::Disconnected {
+                    self.state = SessionState::Cancelling;
+                }
+            }
+            E::CancelAcknowledged {} => {
+                if !self.cancellation_requested {
+                    return Err(EventError::InvalidTransition);
+                }
+                self.state = SessionState::Cancelled;
+            }
+            E::Exit { .. } | E::Crashed { .. } => {
+                if matches!(self.state, SessionState::Exited | SessionState::Crashed) {
+                    return Err(EventError::InvalidTransition);
+                }
+                if matches!(payload, E::Crashed { .. })
+                    || self
+                        .tools
+                        .values()
+                        .any(|state| *state == ToolState::Started)
+                {
+                    self.residual_effects = ResidualEffects::Unknown;
+                }
+                self.state = if self.cancellation_requested {
+                    SessionState::Cancelled
+                } else if matches!(payload, E::Crashed { .. }) {
+                    SessionState::Crashed
+                } else {
+                    SessionState::Exited
+                };
+            }
+        }
+        Ok(())
+    }
+    fn require_running(&self) -> Result<(), EventError> {
+        if self.state == SessionState::Running {
+            Ok(())
+        } else {
+            Err(EventError::InvalidTransition)
+        }
+    }
+    fn tool_transition(
+        &mut self,
+        id: &RequestId,
+        expected: ToolState,
+        next: ToolState,
+    ) -> Result<(), EventError> {
+        self.require_running()?;
+        let state = self.tools.get_mut(id).ok_or(EventError::UnknownTool)?;
+        if *state != expected {
+            return Err(EventError::ToolTransitionRejected);
+        }
+        *state = next;
+        Ok(())
+    }
+}

--- a/crates/symbiote-runtime-sdk/src/lib.rs
+++ b/crates/symbiote-runtime-sdk/src/lib.rs
@@ -1,0 +1,10 @@
+//! Runtime integration boundary. Neither adapters nor providers own canonical completion.
+mod adapter;
+mod capabilities;
+pub mod events;
+pub mod provider;
+
+pub use adapter::*;
+pub use capabilities::*;
+
+pub const SDK_VERSION: u32 = 1;

--- a/crates/symbiote-runtime-sdk/src/provider.rs
+++ b/crates/symbiote-runtime-sdk/src/provider.rs
@@ -1,0 +1,562 @@
+//! Inference contracts only: no agent loop, credentials, network, or Host writes.
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    pin::Pin,
+};
+use symbiote_domain::*;
+
+pub const PROVIDER_CONTRACT_VERSION: u32 = 1;
+pub const MAX_ENVELOPE_BYTES: usize = 256 * 1024;
+pub const MAX_MESSAGES: usize = 128;
+pub const MAX_TOOLS: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderError {
+    UnsupportedVersion,
+    InvalidDescriptor,
+    InvalidEnvelope,
+    EnvelopeTooLarge,
+    ModelMismatch,
+    UnsupportedCapability,
+    ContextLimit,
+    InputLimit,
+    OutputLimit,
+    BindingMismatch,
+    CredentialRequired,
+    UnexpectedCredential,
+    ExpiredEntitlement,
+    UnsupportedAuthenticationBilling,
+    LocalPolicyRequired,
+    InvalidUsage,
+    UnknownTool,
+    DuplicateToolCall,
+    Unavailable,
+}
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for ProviderError {}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+    Ultra,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ModelCapabilities {
+    pub reasoning_efforts: BTreeSet<ReasoningEffort>,
+    pub tools: bool,
+    pub images: bool,
+    pub streaming: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ModelDescriptor {
+    pub schema_version: u32,
+    pub id: ModelId,
+    pub provider_id: ProviderConnectionId,
+    pub context_window_tokens: u64,
+    pub max_output_tokens: u64,
+    pub capabilities: ModelCapabilities,
+}
+impl ModelDescriptor {
+    pub fn validate(&self) -> Result<(), ProviderError> {
+        if self.schema_version != PROVIDER_CONTRACT_VERSION {
+            return Err(ProviderError::UnsupportedVersion);
+        }
+        if self.context_window_tokens == 0
+            || self.max_output_tokens == 0
+            || self.max_output_tokens > self.context_window_tokens
+        {
+            return Err(ProviderError::InvalidDescriptor);
+        }
+        Ok(())
+    }
+}
+
+/// Policy supplied by an authenticated Host after resolving endpoint locality.
+/// Not a wire grant and not proof that an arbitrary URL is actually local.
+#[derive(Clone, Debug, Default)]
+pub struct ProviderPolicy {
+    pub verified_local_endpoints: BTreeMap<ProviderConnectionId, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderBinding {
+    schema_version: u32,
+    runtime_kind: RuntimeKind,
+    runtime_profile_id: RuntimeProfileId,
+    adapter_id: InferenceProviderAdapterId,
+    provider_id: ProviderConnectionId,
+    endpoint_reference: String,
+    model_id: ModelId,
+    credential_reference: Option<CredentialReferenceId>,
+    entitlement_id: BillingEntitlementId,
+    entitlement_expires_at: Timestamp,
+}
+impl ProviderBinding {
+    pub fn runtime_kind(&self) -> RuntimeKind {
+        self.runtime_kind
+    }
+    pub fn adapter_id(&self) -> &InferenceProviderAdapterId {
+        &self.adapter_id
+    }
+    pub fn provider_id(&self) -> &ProviderConnectionId {
+        &self.provider_id
+    }
+    pub fn endpoint_reference(&self) -> &str {
+        &self.endpoint_reference
+    }
+    pub fn model_id(&self) -> &ModelId {
+        &self.model_id
+    }
+    pub fn credential_reference(&self) -> Option<&CredentialReferenceId> {
+        self.credential_reference.as_ref()
+    }
+    pub fn validate_at(&self, now: Timestamp) -> Result<(), ProviderError> {
+        if self.entitlement_expires_at <= now {
+            return Err(ProviderError::ExpiredEntitlement);
+        }
+        Ok(())
+    }
+}
+
+/// All inputs are canonical references, not secret values. Evidence authenticity,
+/// endpoint locality and the actual runtime loop owner are Host responsibilities.
+pub fn validate_binding(
+    profile: &RuntimeProfile,
+    connection: &ProviderConnection,
+    credential: Option<&CredentialReference>,
+    entitlement: &BillingEntitlement,
+    model: &ModelDescriptor,
+    policy: &ProviderPolicy,
+    now: Timestamp,
+) -> Result<ProviderBinding, ProviderError> {
+    model.validate()?;
+    if profile.provider != connection.id
+        || entitlement.provider != connection.id
+        || entitlement.id != profile.billing_entitlement
+        || model.provider_id != connection.id
+        || model.id != profile.model
+        || connection.endpoint_reference.trim().is_empty()
+    {
+        return Err(ProviderError::BindingMismatch);
+    }
+    if entitlement.expires_at <= now {
+        return Err(ProviderError::ExpiredEntitlement);
+    }
+    if profile.runtime == RuntimeKind::NativeSymbiote
+        && (connection.authentication == AuthenticationKind::HarnessManaged
+            || entitlement.kind == BillingKind::HarnessSubscription)
+    {
+        return Err(ProviderError::UnsupportedAuthenticationBilling);
+    }
+    let credential_reference = match (&connection.authentication, &entitlement.kind) {
+        (AuthenticationKind::ApiCredential, BillingKind::MeteredApi) => {
+            let credential = credential.ok_or(ProviderError::CredentialRequired)?;
+            if credential.id != profile.credential || credential.vault_key.trim().is_empty() {
+                return Err(ProviderError::BindingMismatch);
+            }
+            Some(credential.id.clone())
+        }
+        (AuthenticationKind::HarnessManaged, BillingKind::HarnessSubscription)
+            if profile.runtime == RuntimeKind::ExternalHarness =>
+        {
+            if credential.is_some() {
+                return Err(ProviderError::UnexpectedCredential);
+            }
+            None
+        }
+        (AuthenticationKind::LocalUnauthenticated, BillingKind::Local) => {
+            if credential.is_some() {
+                return Err(ProviderError::UnexpectedCredential);
+            }
+            if policy.verified_local_endpoints.get(&connection.id)
+                != Some(&connection.endpoint_reference)
+            {
+                return Err(ProviderError::LocalPolicyRequired);
+            }
+            None
+        }
+        _ => return Err(ProviderError::UnsupportedAuthenticationBilling),
+    };
+    Ok(ProviderBinding {
+        schema_version: PROVIDER_CONTRACT_VERSION,
+        runtime_kind: profile.runtime,
+        runtime_profile_id: profile.id.clone(),
+        adapter_id: connection.adapter.clone(),
+        provider_id: connection.id.clone(),
+        endpoint_reference: connection.endpoint_reference.clone(),
+        model_id: model.id.clone(),
+        credential_reference,
+        entitlement_id: entitlement.id.clone(),
+        entitlement_expires_at: entitlement.expires_at,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum InputPart {
+    Text {
+        text: String,
+    },
+    /// Host-resolved artifact reference, never an arbitrary URL or secret-bearing path.
+    Image {
+        artifact_id: ArtifactId,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InputMessage {
+    pub role: MessageRole,
+    pub content: Vec<InputPart>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderRequest {
+    pub schema_version: u32,
+    pub request_id: RequestId,
+    pub provider_id: ProviderConnectionId,
+    pub model_id: ModelId,
+    pub messages: Vec<InputMessage>,
+    pub tools: Vec<ToolDefinition>,
+    /// Upper-bound estimate supplied by the Context Broker; not provider-reported usage.
+    pub input_token_budget: u64,
+    pub max_output_tokens: u64,
+    pub reasoning: Option<ReasoningEffort>,
+    pub streaming: bool,
+}
+
+fn tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'))
+}
+
+fn validate_json(value: &Value) -> Result<(), ProviderError> {
+    fn visit(value: &Value, depth: usize, remaining: &mut usize) -> Result<(), ProviderError> {
+        if depth > 32 || *remaining == 0 {
+            return Err(ProviderError::InvalidEnvelope);
+        }
+        *remaining -= 1;
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    visit(item, depth + 1, remaining)?;
+                }
+            }
+            Value::Object(items) => {
+                for item in items.values() {
+                    visit(item, depth + 1, remaining)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    visit(value, 0, &mut 4096)
+}
+
+fn bounded<T: Serialize>(value: &T) -> Result<(), ProviderError> {
+    struct Counter(usize);
+    impl std::io::Write for Counter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if bytes.len() > MAX_ENVELOPE_BYTES - self.0 {
+                return Err(std::io::Error::other("provider envelope bound"));
+            }
+            self.0 += bytes.len();
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    serde_json::to_writer(&mut Counter(0), value).map_err(|_| ProviderError::EnvelopeTooLarge)
+}
+
+impl ProviderRequest {
+    pub fn parse(bytes: &[u8], model: &ModelDescriptor) -> Result<Self, ProviderError> {
+        if bytes.len() > MAX_ENVELOPE_BYTES {
+            return Err(ProviderError::EnvelopeTooLarge);
+        }
+        let request: Self =
+            serde_json::from_slice(bytes).map_err(|_| ProviderError::InvalidEnvelope)?;
+        request.validate(model)?;
+        Ok(request)
+    }
+    pub fn validate(&self, model: &ModelDescriptor) -> Result<(), ProviderError> {
+        model.validate()?;
+        if self.schema_version != PROVIDER_CONTRACT_VERSION {
+            return Err(ProviderError::UnsupportedVersion);
+        }
+        if self.provider_id != model.provider_id || self.model_id != model.id {
+            return Err(ProviderError::ModelMismatch);
+        }
+        if self.messages.is_empty()
+            || self.messages.len() > MAX_MESSAGES
+            || self.tools.len() > MAX_TOOLS
+        {
+            return Err(ProviderError::InvalidEnvelope);
+        }
+        if self.input_token_budget == 0
+            || self
+                .input_token_budget
+                .checked_add(self.max_output_tokens)
+                .is_none_or(|sum| sum > model.context_window_tokens)
+        {
+            return Err(ProviderError::ContextLimit);
+        }
+        if self.max_output_tokens == 0 || self.max_output_tokens > model.max_output_tokens {
+            return Err(ProviderError::OutputLimit);
+        }
+        if (self.streaming && !model.capabilities.streaming)
+            || (!self.tools.is_empty() && !model.capabilities.tools)
+            || self
+                .reasoning
+                .as_ref()
+                .is_some_and(|effort| !model.capabilities.reasoning_efforts.contains(effort))
+        {
+            return Err(ProviderError::UnsupportedCapability);
+        }
+        for message in &self.messages {
+            if message.content.is_empty() || message.content.len() > 32 {
+                return Err(ProviderError::InvalidEnvelope);
+            }
+            for part in &message.content {
+                match part {
+                    InputPart::Text { text } if text.is_empty() => {
+                        return Err(ProviderError::InvalidEnvelope);
+                    }
+                    InputPart::Image { .. } if !model.capabilities.images => {
+                        return Err(ProviderError::UnsupportedCapability);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let mut names = BTreeSet::new();
+        for tool in &self.tools {
+            if !tool_name(&tool.name) || !tool.input_schema.is_object() || !names.insert(&tool.name)
+            {
+                return Err(ProviderError::InvalidEnvelope);
+            }
+            validate_json(&tool.input_schema)?;
+        }
+        bounded(self)
+    }
+    pub fn validate_binding(
+        &self,
+        binding: &ProviderBinding,
+        now: Timestamp,
+    ) -> Result<(), ProviderError> {
+        binding.validate_at(now)?;
+        if self.provider_id != binding.provider_id || self.model_id != binding.model_id {
+            return Err(ProviderError::BindingMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageUnknownReason {
+    NotReported,
+    Interrupted,
+    Unsupported,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum TokenUsage {
+    Unknown {
+        reason: UsageUnknownReason,
+    },
+    Known {
+        input_tokens: u64,
+        output_tokens: u64,
+        cached_input_tokens: Option<u64>,
+        reasoning_tokens: Option<u64>,
+    },
+}
+impl TokenUsage {
+    /// Unknown totals remain None, never zero. Reasoning is a subset of output;
+    /// cached tokens are a subset of input, so neither is counted twice.
+    pub fn total(&self) -> Result<Option<u64>, ProviderError> {
+        match self {
+            Self::Unknown { .. } => Ok(None),
+            Self::Known {
+                input_tokens,
+                output_tokens,
+                cached_input_tokens,
+                reasoning_tokens,
+            } => {
+                if cached_input_tokens.is_some_and(|n| n > *input_tokens)
+                    || reasoning_tokens.is_some_and(|n| n > *output_tokens)
+                {
+                    return Err(ProviderError::InvalidUsage);
+                }
+                input_tokens
+                    .checked_add(*output_tokens)
+                    .map(Some)
+                    .ok_or(ProviderError::InvalidUsage)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderToolCall {
+    /// Canonical request correlation, not an authorization token or raw provider ID.
+    pub call_id: RequestId,
+    pub name: String,
+    pub arguments: Value,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    Stop,
+    ToolCalls,
+    Length,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderResponse {
+    pub schema_version: u32,
+    pub request_id: RequestId,
+    pub provider_id: ProviderConnectionId,
+    pub model_id: ModelId,
+    pub text: String,
+    pub tool_calls: Vec<ProviderToolCall>,
+    pub finish_reason: FinishReason,
+    pub usage: TokenUsage,
+}
+impl ProviderResponse {
+    pub fn parse(
+        bytes: &[u8],
+        request: &ProviderRequest,
+        model: &ModelDescriptor,
+    ) -> Result<Self, ProviderError> {
+        if bytes.len() > MAX_ENVELOPE_BYTES {
+            return Err(ProviderError::EnvelopeTooLarge);
+        }
+        let response: Self =
+            serde_json::from_slice(bytes).map_err(|_| ProviderError::InvalidEnvelope)?;
+        response.validate(request, model)?;
+        Ok(response)
+    }
+    pub fn validate(
+        &self,
+        request: &ProviderRequest,
+        model: &ModelDescriptor,
+    ) -> Result<(), ProviderError> {
+        request.validate(model)?;
+        if self.schema_version != PROVIDER_CONTRACT_VERSION {
+            return Err(ProviderError::UnsupportedVersion);
+        }
+        if self.request_id != request.request_id
+            || self.provider_id != request.provider_id
+            || self.model_id != request.model_id
+        {
+            return Err(ProviderError::ModelMismatch);
+        }
+        if self.tool_calls.len() > MAX_TOOLS {
+            return Err(ProviderError::InvalidEnvelope);
+        }
+        if (self.finish_reason == FinishReason::ToolCalls) != !self.tool_calls.is_empty() {
+            return Err(ProviderError::InvalidEnvelope);
+        }
+        if self.finish_reason == FinishReason::Stop && self.text.is_empty() {
+            return Err(ProviderError::InvalidEnvelope);
+        }
+        let mut ids = BTreeSet::new();
+        for call in &self.tool_calls {
+            if !ids.insert(&call.call_id) {
+                return Err(ProviderError::DuplicateToolCall);
+            }
+            if !request.tools.iter().any(|tool| tool.name == call.name) {
+                return Err(ProviderError::UnknownTool);
+            }
+            if !call.arguments.is_object() {
+                return Err(ProviderError::InvalidEnvelope);
+            }
+            validate_json(&call.arguments)?;
+        }
+        if self
+            .usage
+            .total()?
+            .is_some_and(|total| total > model.context_window_tokens)
+        {
+            return Err(ProviderError::ContextLimit);
+        }
+        if let TokenUsage::Known {
+            input_tokens,
+            output_tokens,
+            ..
+        } = self.usage
+        {
+            if input_tokens > request.input_token_budget {
+                return Err(ProviderError::InputLimit);
+            }
+            if output_tokens > request.max_output_tokens {
+                return Err(ProviderError::OutputLimit);
+            }
+        }
+        bounded(self)
+    }
+}
+
+pub type ProviderFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<ProviderResponse, ProviderError>> + Send + 'a>>;
+
+/// A model turn only, distinct from the crate's AgentRuntimeAdapter (loop owner).
+/// Implementations must validate request/model/binding, recheck expiry when used,
+/// and validate the final response. No implementation is supplied in this slice.
+pub trait InferenceProviderAdapter: Send + Sync {
+    fn adapter_id(&self) -> &InferenceProviderAdapterId;
+    fn infer<'a>(
+        &'a self,
+        request: &'a ProviderRequest,
+        binding: &'a ProviderBinding,
+    ) -> ProviderFuture<'a>;
+}

--- a/crates/symbiote-runtime-sdk/tests/adapter.rs
+++ b/crates/symbiote-runtime-sdk/tests/adapter.rs
@@ -1,0 +1,461 @@
+use std::collections::{BTreeMap, BTreeSet};
+use symbiote_domain::*;
+use symbiote_runtime_sdk::*;
+
+fn proof(runtime: RuntimeKind) -> ProbeEvidence {
+    ProbeEvidence {
+        artifact: EvidenceId::new("proof").unwrap(),
+        adapter_id: AgentRuntimeAdapterId::new("adapter").unwrap(),
+        installation: profile(runtime).installation,
+        profile_id: RuntimeProfileId::new("profile").unwrap(),
+        profile_revision: Revision(1),
+        model_id: ModelId::new("model").unwrap(),
+        host_id: HostId::new("host").unwrap(),
+        adapter_version: "1.0".into(),
+        upstream_version: "fixture-1".into(),
+        platform: "linux".into(),
+        observed_at: Timestamp(1),
+        expires_at: Timestamp(1000),
+    }
+}
+fn profile(runtime: RuntimeKind) -> RuntimeProfile {
+    RuntimeProfile {
+        id: RuntimeProfileId::new("profile").unwrap(),
+        revision: Revision(1),
+        runtime,
+        adapter: AgentRuntimeAdapterId::new("adapter").unwrap(),
+        installation: (runtime == RuntimeKind::ExternalHarness)
+            .then(|| InstallationId::new("installation").unwrap()),
+        provider: ProviderConnectionId::new("provider").unwrap(),
+        credential: CredentialReferenceId::new("credential").unwrap(),
+        billing_entitlement: BillingEntitlementId::new("billing").unwrap(),
+        model: ModelId::new("model").unwrap(),
+        eligible_hosts: [HostId::new("host").unwrap()].into(),
+    }
+}
+fn descriptor(runtime: RuntimeKind) -> RuntimeDescriptor {
+    RuntimeDescriptor {
+        sdk_version: SDK_VERSION,
+        adapter_id: AgentRuntimeAdapterId::new("adapter").unwrap(),
+        installation: profile(runtime).installation,
+        profile_id: RuntimeProfileId::new("profile").unwrap(),
+        profile_revision: Revision(1),
+        model_id: ModelId::new("model").unwrap(),
+        adapter_version: "1.0".into(),
+        upstream_version: "fixture-1".into(),
+        runtime,
+        owner: if runtime == RuntimeKind::NativeSymbiote {
+            RuntimeOwner::SymbioteNative {}
+        } else {
+            RuntimeOwner::External {
+                driver: HarnessDriverId::new("fixture-driver").unwrap(),
+            }
+        },
+        transport: if runtime == RuntimeKind::NativeSymbiote {
+            Transport::NativeLoop
+        } else {
+            Transport::StructuredRpc
+        },
+        tier: IntegrationTier::Structured,
+        host_id: HostId::new("host").unwrap(),
+        platform: "linux".into(),
+        capabilities: [
+            Capability::StructuredMessages,
+            Capability::ContextLimits,
+            Capability::Tools,
+        ]
+        .into_iter()
+        .map(|capability| {
+            (
+                capability,
+                Support::Supported {
+                    evidence: Box::new(proof(runtime)),
+                },
+            )
+        })
+        .collect(),
+        controls: [
+            Control::Filesystem,
+            Control::Cancellation,
+            Control::CompletionAuthority,
+        ]
+        .into_iter()
+        .map(|control| {
+            (
+                control,
+                ControlSupport {
+                    strength: EnforcementStrength::HostEnforced,
+                    mechanism: "fixture only".into(),
+                    evidence: proof(runtime),
+                },
+            )
+        })
+        .collect(),
+        tools: ["read_file".into()].into(),
+        skills: BTreeSet::new(),
+        context_limits: Some(RuntimeContextLimits {
+            context_window_tokens: 8192,
+            max_output_tokens: 2048,
+        }),
+    }
+}
+fn dispatch(runtime: RuntimeKind) -> Dispatch {
+    let project = ProjectId::new("project").unwrap();
+    let role_id = RoleId::new("engineer").unwrap();
+    let root = RootId::new("root").unwrap();
+    let task = Task::new(
+        TaskId::new("task").unwrap(),
+        project.clone(),
+        root.clone(),
+        role_id.clone(),
+        ChangeStreamId::new("stream").unwrap(),
+        VersionedTaskContract {
+            id: TaskContractId::new("task-contract").unwrap(),
+            revision: Revision(1),
+        },
+    );
+    let role = Role {
+        id: role_id.clone(),
+        project_id: project.clone(),
+        revision: Revision(1),
+        name: "Engineer".into(),
+        operating_contract: VersionedRoleContract {
+            id: RoleContractId::new("role-contract").unwrap(),
+            revision: Revision(1),
+        },
+    };
+    let profile = profile(runtime);
+    let binding = WorkforceBinding {
+        id: BindingId::new("binding").unwrap(),
+        revision: Revision(1),
+        project_id: project.clone(),
+        role_id,
+        profile_id: profile.id.clone(),
+        profile_revision: profile.revision,
+        protocol: VersionedProtocol {
+            id: ProtocolId::new("protocol").unwrap(),
+            revision: Revision(1),
+        },
+        access: AccessSnapshot {
+            project_id: project,
+            roots: [root].into(),
+            grants: [Permission::ReadRoot, Permission::MutateStream].into(),
+            policy_revision: Revision(1),
+        },
+        required_controls: BTreeSet::new(),
+        context: ContextPolicy {
+            bundle: ContextBundleId::new("context").unwrap(),
+            revision: Revision(1),
+            max_input_tokens: 4096,
+            reserved_output_tokens: 1024,
+        },
+        required_tools: ["read_file".into()].into(),
+        required_skills: BTreeSet::new(),
+        escalation: EscalationPolicy::ReturnToLead,
+    };
+    let host = Host {
+        id: HostId::new("host").unwrap(),
+        revision: Revision(1),
+        device: DeviceId::new("device").unwrap(),
+        fabric: None,
+        supported_runtimes: vec![runtime],
+        controls: [
+            Control::Filesystem,
+            Control::Cancellation,
+            Control::CompletionAuthority,
+        ]
+        .into_iter()
+        .map(|control| {
+            (
+                control,
+                EnforcementClaim {
+                    strength: EnforcementStrength::HostEnforced,
+                    evidence: EvidenceId::new("proof").unwrap(),
+                    verified_at: Timestamp(1),
+                    expires_at: Timestamp(1000),
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>(),
+    };
+    Dispatch::compile(
+        DispatchId::new("dispatch").unwrap(),
+        RuntimeContractId::new("runtime-contract").unwrap(),
+        DispatchInputs {
+            task: &task,
+            role: &role,
+            binding: &binding,
+            profile: &profile,
+            host: &host,
+            now: Timestamp(2),
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn native_external_and_mixed_staffing_preserve_role_task_and_stream_identity() {
+    let native = dispatch(RuntimeKind::NativeSymbiote);
+    let external = dispatch(RuntimeKind::ExternalHarness);
+    for dispatch in [&native, &external] {
+        qualify_dispatch(
+            dispatch,
+            &descriptor(dispatch.contract().profile().runtime),
+            &BTreeSet::new(),
+            Timestamp(3),
+        )
+        .unwrap();
+    }
+    assert_eq!(native.contract().role().id, external.contract().role().id);
+    assert_eq!(native.contract().task_id(), external.contract().task_id());
+    assert_eq!(
+        native.contract().stream_id(),
+        external.contract().stream_id()
+    );
+    assert!(native.contract().profile().installation.is_none());
+}
+
+#[test]
+fn external_full_harness_cannot_claim_native_ownership_or_transport() {
+    let mut descriptor = descriptor(RuntimeKind::ExternalHarness);
+    descriptor.owner = RuntimeOwner::SymbioteNative {};
+    assert_eq!(
+        descriptor.validate(),
+        Err(QualificationError::RuntimeOwnerMismatch)
+    );
+    assert!(
+        serde_json::from_str::<RuntimeOwner>(r#"{"kind":"symbiote_native","driver":"codex"}"#)
+            .is_err()
+    );
+    assert!(
+        serde_json::from_str::<SessionControl>(r#"{"kind":"cancel","approve_all":true}"#).is_err()
+    );
+}
+
+#[test]
+fn evidence_expiry_version_drift_and_observed_controls_reject_qualification() {
+    let dispatch = dispatch(RuntimeKind::ExternalHarness);
+    let mut report = descriptor(RuntimeKind::ExternalHarness);
+    report
+        .controls
+        .get_mut(&Control::Filesystem)
+        .unwrap()
+        .strength = EnforcementStrength::ExternallyObserved;
+    assert_eq!(
+        qualify_dispatch(&dispatch, &report, &BTreeSet::new(), Timestamp(3)),
+        Err(QualificationError::InsufficientControl(Control::Filesystem))
+    );
+    let mut report = descriptor(RuntimeKind::ExternalHarness);
+    report.upstream_version = "changed".into();
+    assert_eq!(
+        qualify_dispatch(&dispatch, &report, &BTreeSet::new(), Timestamp(3)),
+        Err(QualificationError::StaleEvidence)
+    );
+    assert!(
+        qualify_dispatch(
+            &dispatch,
+            &descriptor(RuntimeKind::ExternalHarness),
+            &BTreeSet::new(),
+            Timestamp(1000)
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn proof_cannot_be_substituted_across_adapter_installation_profile_or_model() {
+    for change in 0..4 {
+        let mut profile = profile(RuntimeKind::ExternalHarness);
+        let mut report = descriptor(RuntimeKind::ExternalHarness);
+        match change {
+            0 => {
+                profile.adapter = AgentRuntimeAdapterId::new("other-adapter").unwrap();
+                report.adapter_id = profile.adapter.clone();
+            }
+            1 => {
+                profile.installation = Some(InstallationId::new("other-installation").unwrap());
+                report.installation = profile.installation.clone();
+            }
+            2 => {
+                profile.revision = Revision(2);
+                report.profile_revision = Revision(2);
+            }
+            _ => {
+                profile.model = ModelId::new("other-model").unwrap();
+                report.model_id = profile.model.clone();
+            }
+        }
+        assert_eq!(
+            qualify_profile(
+                &profile,
+                &report,
+                &[Capability::Tools].into(),
+                &[Control::Filesystem].into(),
+                Timestamp(3)
+            ),
+            Err(QualificationError::StaleEvidence)
+        );
+    }
+}
+
+#[test]
+fn tier_never_substitutes_for_capability_and_context_or_tool_requirements() {
+    let dispatch = dispatch(RuntimeKind::ExternalHarness);
+    let mut report = descriptor(RuntimeKind::ExternalHarness);
+    report.tier = IntegrationTier::Certified;
+    report
+        .capabilities
+        .insert(Capability::Tools, Support::Unknown);
+    assert_eq!(
+        qualify_dispatch(&dispatch, &report, &BTreeSet::new(), Timestamp(3)),
+        Err(QualificationError::UnknownCapability(Capability::Tools))
+    );
+    let mut report = descriptor(RuntimeKind::ExternalHarness);
+    report.tools.clear();
+    assert_eq!(
+        qualify_dispatch(&dispatch, &report, &BTreeSet::new(), Timestamp(3)),
+        Err(QualificationError::MissingResource)
+    );
+    let mut report = descriptor(RuntimeKind::ExternalHarness);
+    report
+        .context_limits
+        .as_mut()
+        .unwrap()
+        .context_window_tokens = 2048;
+    assert_eq!(
+        qualify_dispatch(&dispatch, &report, &BTreeSet::new(), Timestamp(3)),
+        Err(QualificationError::ContextLimitExceeded)
+    );
+}
+
+struct Journal {
+    fail: bool,
+    mismatch: bool,
+    writes: usize,
+}
+impl ActivationJournal for Journal {
+    fn persist_authorization(
+        &mut self,
+        dispatch: &Dispatch,
+        descriptor: &RuntimeDescriptor,
+        at: Timestamp,
+    ) -> Result<ActivationReceipt, AdapterError> {
+        self.writes += 1;
+        if self.fail {
+            return Err(AdapterError::AuthorizationNotPersisted);
+        }
+        Ok(ActivationReceipt {
+            command_id: CommandId::new("authorization").unwrap(),
+            revision: Revision(if self.mismatch { 0 } else { 1 }),
+            dispatch: dispatch.clone(),
+            descriptor: descriptor.clone(),
+            authorized_at: at,
+        })
+    }
+}
+struct FixtureAdapter {
+    descriptor: RuntimeDescriptor,
+    launched: bool,
+}
+impl AgentRuntimeAdapter for FixtureAdapter {
+    fn descriptor(&self) -> &RuntimeDescriptor {
+        &self.descriptor
+    }
+    fn launch(&mut self, permit: LaunchPermit, at: Timestamp) -> Result<SessionId, AdapterError> {
+        permit.validate_at(&self.descriptor, at)?;
+        self.launched = true;
+        Ok(SessionId::new("fixture-session").unwrap())
+    }
+}
+
+#[test]
+fn preparation_is_inert_and_authorization_precedes_activation_with_fresh_recheck() {
+    let mut journal = Journal {
+        fail: true,
+        mismatch: false,
+        writes: 0,
+    };
+    let prepared = PreparedLaunch::new(
+        dispatch(RuntimeKind::NativeSymbiote),
+        descriptor(RuntimeKind::NativeSymbiote),
+        BTreeSet::new(),
+        Timestamp(3),
+    )
+    .unwrap();
+    assert_eq!(journal.writes, 0);
+    assert!(matches!(
+        prepared.authorize(&mut journal, Timestamp(4)),
+        Err(AdapterError::AuthorizationNotPersisted)
+    ));
+    assert_eq!(journal.writes, 1);
+    journal.fail = false;
+    journal.mismatch = true;
+    assert!(matches!(
+        PreparedLaunch::new(
+            dispatch(RuntimeKind::NativeSymbiote),
+            descriptor(RuntimeKind::NativeSymbiote),
+            BTreeSet::new(),
+            Timestamp(3)
+        )
+        .unwrap()
+        .authorize(&mut journal, Timestamp(4)),
+        Err(AdapterError::ContractMismatch)
+    ));
+    journal.mismatch = false;
+    let permit = PreparedLaunch::new(
+        dispatch(RuntimeKind::NativeSymbiote),
+        descriptor(RuntimeKind::NativeSymbiote),
+        BTreeSet::new(),
+        Timestamp(3),
+    )
+    .unwrap()
+    .authorize(&mut journal, Timestamp(4))
+    .unwrap();
+    let mut adapter = FixtureAdapter {
+        descriptor: descriptor(RuntimeKind::NativeSymbiote),
+        launched: false,
+    };
+    assert!(adapter.launch(permit, Timestamp(1000)).is_err());
+    assert!(!adapter.launched);
+}
+
+#[test]
+fn structured_and_generic_pty_expose_different_guarantees_for_same_dispatch() {
+    let dispatch = dispatch(RuntimeKind::ExternalHarness);
+    let structured = descriptor(RuntimeKind::ExternalHarness);
+    let mut pty = structured.clone();
+    pty.transport = Transport::Pty;
+    pty.tier = IntegrationTier::TerminalCompatible;
+    pty.capabilities.clear();
+    pty.context_limits = None;
+    pty.controls.clear();
+    pty.tools.clear();
+    assert!(PreparedLaunch::new(dispatch.clone(), pty, BTreeSet::new(), Timestamp(3)).is_err());
+    let mut journal = Journal {
+        fail: false,
+        mismatch: false,
+        writes: 0,
+    };
+    let permit = PreparedLaunch::new(dispatch, structured.clone(), BTreeSet::new(), Timestamp(3))
+        .unwrap()
+        .authorize(&mut journal, Timestamp(4))
+        .unwrap();
+    let mut adapter = FixtureAdapter {
+        descriptor: structured,
+        launched: false,
+    };
+    let session = adapter.launch(permit, Timestamp(5)).unwrap();
+    assert!(adapter.launched);
+    assert_eq!(
+        adapter.poll_events(&session, 0, 10),
+        Err(AdapterError::Unsupported {
+            operation: AdapterOperation::PollEvents
+        })
+    );
+    assert_eq!(
+        adapter.control(&session, SessionControl::Resume {}),
+        Err(AdapterError::Unsupported {
+            operation: AdapterOperation::Resume
+        })
+    );
+}

--- a/crates/symbiote-runtime-sdk/tests/events.rs
+++ b/crates/symbiote-runtime-sdk/tests/events.rs
@@ -1,0 +1,566 @@
+use symbiote_domain::{CommandId, DispatchId, HostId, RequestId, RuntimeKind, SessionId};
+use symbiote_runtime_sdk::events::*;
+
+fn binding() -> SessionBinding {
+    SessionBinding {
+        session_id: SessionId::new("session").unwrap(),
+        dispatch_id: DispatchId::new("dispatch").unwrap(),
+        host_id: HostId::new("host").unwrap(),
+        runtime: RuntimeKind::NativeSymbiote,
+    }
+}
+fn text(value: &str) -> EventText {
+    EventText::new(value).unwrap()
+}
+fn tool() -> RequestId {
+    RequestId::new("tool-1").unwrap()
+}
+fn event(sequence: u64, payload: RuntimeEventKind) -> RuntimeEvent {
+    RuntimeEvent::new(
+        CommandId::new(format!("event-{sequence}")).unwrap(),
+        sequence,
+        binding(),
+        payload,
+    )
+    .unwrap()
+}
+fn tracker() -> SessionTracker {
+    SessionTracker::new(binding(), TrackerLimits::default()).unwrap()
+}
+fn proposed() -> RuntimeEventKind {
+    RuntimeEventKind::ToolProposed {
+        tool_call_id: tool(),
+        name: text("read_file"),
+        arguments: text("bounded redacted arguments"),
+    }
+}
+
+#[test]
+fn tool_lifecycle_report_and_exit_never_create_canonical_completion() {
+    let mut session = tracker();
+    session.apply(event(1, RuntimeEventKind::Ready {})).unwrap();
+    session.apply(event(2, proposed())).unwrap();
+    session
+        .apply(event(
+            3,
+            RuntimeEventKind::ToolStarted {
+                tool_call_id: tool(),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(
+            4,
+            RuntimeEventKind::ToolCompleted {
+                tool_call_id: tool(),
+                output: text("observed output"),
+            },
+        ))
+        .unwrap();
+    let report = session
+        .apply(event(
+            5,
+            RuntimeEventKind::CompletionRequested {
+                report: text("worker says done"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(report.state, SessionState::Running);
+    let exit = session
+        .apply(event(6, RuntimeEventKind::Exit { code: Some(0) }))
+        .unwrap();
+    assert_eq!(exit.state, SessionState::Exited);
+    assert_eq!(session.tracked_tool_count(), 1);
+    assert_eq!(
+        session.apply(event(
+            7,
+            RuntimeEventKind::CompletionRequested {
+                report: text("done again")
+            }
+        )),
+        Err(EventError::InvalidTransition)
+    );
+    let value = serde_json::to_value(session).unwrap();
+    assert_eq!(value["state"], "exited");
+    assert!(!value.as_object().unwrap().contains_key("task"));
+}
+
+#[test]
+fn missing_out_of_order_and_changed_events_cannot_advance() {
+    let mut session = tracker();
+    let ready = event(1, RuntimeEventKind::Ready {});
+    let original = session.apply(ready.clone()).unwrap();
+    let duplicate = session.apply(ready).unwrap();
+    assert_eq!(duplicate.sequence, original.sequence);
+    assert_eq!(duplicate.state, original.state);
+    assert!(duplicate.replayed);
+    assert_eq!(
+        session.apply(event(
+            1,
+            RuntimeEventKind::Message {
+                text: text("changed")
+            }
+        )),
+        Err(EventError::IdempotencyConflict)
+    );
+    assert_eq!(
+        session.apply(event(3, RuntimeEventKind::Message { text: text("gap") })),
+        Err(EventError::SequenceGap {
+            expected: 2,
+            received: 3
+        })
+    );
+    let same_sequence = RuntimeEvent::new(
+        CommandId::new("different-id").unwrap(),
+        1,
+        binding(),
+        RuntimeEventKind::Ready {},
+    )
+    .unwrap();
+    assert_eq!(
+        session.apply(same_sequence),
+        Err(EventError::SequenceConflict)
+    );
+    assert_eq!(session.next_sequence(), 2);
+    assert_eq!(session.retained_event_count(), 1);
+}
+
+#[test]
+fn immutable_binding_rejects_cross_session_dispatch_host_and_runtime() {
+    let mut variants = vec![];
+    let mut other = binding();
+    other.session_id = SessionId::new("other").unwrap();
+    variants.push(other);
+    let mut other = binding();
+    other.dispatch_id = DispatchId::new("other").unwrap();
+    variants.push(other);
+    let mut other = binding();
+    other.host_id = HostId::new("other").unwrap();
+    variants.push(other);
+    let mut other = binding();
+    other.runtime = RuntimeKind::ExternalHarness;
+    variants.push(other);
+    let mut session = tracker();
+    for other in variants {
+        let foreign = RuntimeEvent::new(
+            CommandId::new("foreign").unwrap(),
+            1,
+            other,
+            RuntimeEventKind::Ready {},
+        )
+        .unwrap();
+        assert_eq!(session.apply(foreign), Err(EventError::BindingMismatch));
+    }
+    assert_eq!(session.next_sequence(), 1);
+}
+
+#[test]
+fn cancellation_rejects_late_tool_effects_and_never_reports_clean_success() {
+    let mut session = tracker();
+    session.apply(event(1, RuntimeEventKind::Ready {})).unwrap();
+    session.apply(event(2, proposed())).unwrap();
+    session
+        .apply(event(
+            3,
+            RuntimeEventKind::ToolStarted {
+                tool_call_id: tool(),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(
+            4,
+            RuntimeEventKind::CancellationRequested {
+                reason: text("client cancelled"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(
+        session.apply(event(
+            5,
+            RuntimeEventKind::ToolCompleted {
+                tool_call_id: tool(),
+                output: text("late write")
+            }
+        )),
+        Err(EventError::ResidualEffectUnknown)
+    );
+    assert_eq!(session.next_sequence(), 5);
+    assert_eq!(session.residual_effects(), ResidualEffects::Unknown);
+    // The rejected effect is not silently skipped: the authoritative producer
+    // must reconcile its stream; this fixture explicitly supplies the same next slot.
+    session
+        .apply(event(5, RuntimeEventKind::CancelAcknowledged {}))
+        .unwrap();
+    assert_eq!(session.state(), SessionState::Cancelled);
+    assert_eq!(
+        session.apply(event(
+            6,
+            RuntimeEventKind::Observation {
+                resource: ObservationKind::FilesystemMutation,
+                detail: text("late file event")
+            }
+        )),
+        Err(EventError::ResidualEffectUnknown)
+    );
+    session
+        .apply(event(6, RuntimeEventKind::Exit { code: Some(0) }))
+        .unwrap();
+    assert_eq!(session.state(), SessionState::Cancelled);
+    assert_eq!(session.residual_effects(), ResidualEffects::Unknown);
+}
+
+#[test]
+fn usage_unknown_is_distinct_from_zero_and_hidden_children_stay_visible() {
+    let unknown = UsageMeasurement::Unknown {
+        reason: UnknownUsageReason::NotReported,
+    };
+    let measured = UsageMeasurement::Measured { value: 0 };
+    assert_ne!(
+        serde_json::to_value(&unknown).unwrap(),
+        serde_json::to_value(&measured).unwrap()
+    );
+    let payload = RuntimeEventKind::Usage {
+        usage: RuntimeUsage {
+            input_tokens: measured,
+            output_tokens: unknown.clone(),
+            cached_input_tokens: unknown.clone(),
+            billed_micro_units: unknown,
+            coverage: UsageCoverage::RootOnly,
+        },
+    };
+    let envelope = event(1, payload);
+    assert_eq!(
+        serde_json::from_value::<RuntimeEvent>(serde_json::to_value(&envelope).unwrap()).unwrap(),
+        envelope
+    );
+    let mut missing = serde_json::to_value(&envelope).unwrap();
+    missing["payload"]["usage"]
+        .as_object_mut()
+        .unwrap()
+        .remove("output_tokens");
+    assert!(serde_json::from_value::<RuntimeEvent>(missing).is_err());
+}
+
+#[test]
+fn disconnect_resume_preserves_readiness_and_cancellation_intent() {
+    let mut session = tracker();
+    session
+        .apply(event(
+            1,
+            RuntimeEventKind::Disconnected {
+                reason: text("handshake transport lost"),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(2, RuntimeEventKind::Reconnected {}))
+        .unwrap();
+    assert_eq!(session.state(), SessionState::AwaitingReady);
+    assert_eq!(
+        session.apply(event(3, proposed())),
+        Err(EventError::InvalidTransition)
+    );
+    session.apply(event(3, RuntimeEventKind::Ready {})).unwrap();
+    session
+        .apply(event(
+            4,
+            RuntimeEventKind::Disconnected {
+                reason: text("transport lost"),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(
+            5,
+            RuntimeEventKind::CancellationRequested {
+                reason: text("cancel while disconnected"),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(6, RuntimeEventKind::Reconnected {}))
+        .unwrap();
+    assert_eq!(session.state(), SessionState::Cancelling);
+    assert_eq!(
+        session.apply(event(7, proposed())),
+        Err(EventError::ResidualEffectUnknown)
+    );
+    assert_eq!(session.residual_effects(), ResidualEffects::Unknown);
+}
+
+#[test]
+fn tool_failure_and_unknown_or_reused_tool_ids_are_deterministic() {
+    let mut session = tracker();
+    session.apply(event(1, RuntimeEventKind::Ready {})).unwrap();
+    assert_eq!(
+        session.apply(event(
+            2,
+            RuntimeEventKind::ToolStarted {
+                tool_call_id: tool()
+            }
+        )),
+        Err(EventError::UnknownTool)
+    );
+    session.apply(event(2, proposed())).unwrap();
+    assert_eq!(
+        session.apply(event(
+            3,
+            RuntimeEventKind::ToolCompleted {
+                tool_call_id: tool(),
+                output: text("unstarted")
+            }
+        )),
+        Err(EventError::ToolTransitionRejected)
+    );
+    session
+        .apply(event(
+            3,
+            RuntimeEventKind::ToolStarted {
+                tool_call_id: tool(),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(
+            4,
+            RuntimeEventKind::ToolFailed {
+                tool_call_id: tool(),
+                error: text("bounded error"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(
+        session.apply(event(5, proposed())),
+        Err(EventError::ToolAlreadyExists)
+    );
+    session
+        .apply(event(
+            5,
+            RuntimeEventKind::Crashed {
+                reason: text("runtime died"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(session.state(), SessionState::Crashed);
+    assert_eq!(session.residual_effects(), ResidualEffects::Unknown);
+}
+
+#[test]
+fn replay_window_eviction_cannot_reuse_old_ids_and_total_memory_is_bounded() {
+    let mut session = SessionTracker::new(
+        binding(),
+        TrackerLimits {
+            replay_capacity: 2,
+            max_tool_calls: 1,
+            max_events: 4,
+        },
+    )
+    .unwrap();
+    let ready = event(1, RuntimeEventKind::Ready {});
+    session.apply(ready.clone()).unwrap();
+    session
+        .apply(event(
+            2,
+            RuntimeEventKind::Message {
+                text: text("second"),
+            },
+        ))
+        .unwrap();
+    session
+        .apply(event(
+            3,
+            RuntimeEventKind::Message {
+                text: text("third"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(session.retained_event_count(), 2);
+    assert_eq!(session.replay_floor(), 2);
+    assert_eq!(
+        session.apply(ready),
+        Err(EventError::ReplayUnavailable { floor: 2 })
+    );
+    let reused = RuntimeEvent::new(
+        CommandId::new("event-1").unwrap(),
+        4,
+        binding(),
+        RuntimeEventKind::Message {
+            text: text("reuse"),
+        },
+    )
+    .unwrap();
+    assert_eq!(session.apply(reused), Err(EventError::IdempotencyConflict));
+    session
+        .apply(event(
+            4,
+            RuntimeEventKind::Message {
+                text: text("fourth"),
+            },
+        ))
+        .unwrap();
+    assert_eq!(
+        session.apply(event(
+            5,
+            RuntimeEventKind::Message {
+                text: text("fifth")
+            }
+        )),
+        Err(EventError::CapacityExceeded)
+    );
+    assert_eq!(session.next_sequence(), 5);
+    assert_eq!(session.retained_event_count(), 2);
+}
+
+#[test]
+fn tool_capacity_and_limits_fail_closed() {
+    assert!(
+        SessionTracker::new(
+            binding(),
+            TrackerLimits {
+                replay_capacity: 0,
+                ..TrackerLimits::default()
+            }
+        )
+        .is_err()
+    );
+    let mut session = SessionTracker::new(
+        binding(),
+        TrackerLimits {
+            max_tool_calls: 1,
+            ..TrackerLimits::default()
+        },
+    )
+    .unwrap();
+    session.apply(event(1, RuntimeEventKind::Ready {})).unwrap();
+    session.apply(event(2, proposed())).unwrap();
+    assert_eq!(
+        session.apply(event(
+            3,
+            RuntimeEventKind::ToolProposed {
+                tool_call_id: RequestId::new("other-tool").unwrap(),
+                name: text("read"),
+                arguments: text("")
+            }
+        )),
+        Err(EventError::CapacityExceeded)
+    );
+    assert_eq!(session.tracked_tool_count(), 1);
+    assert_eq!(session.next_sequence(), 3);
+}
+
+#[test]
+fn wire_validation_rejects_zero_sequence_oversized_utf8_and_unknown_fields() {
+    assert!(EventText::new("x".repeat(MAX_EVENT_TEXT_BYTES)).is_ok());
+    assert_eq!(
+        EventText::new("x".repeat(MAX_EVENT_TEXT_BYTES + 1)),
+        Err(EventError::TextTooLarge)
+    );
+    assert_eq!(
+        EventText::new("🦀".repeat(MAX_EVENT_TEXT_BYTES / 4 + 1)),
+        Err(EventError::TextTooLarge)
+    );
+    let original = event(1, RuntimeEventKind::Ready {});
+    let mut zero = serde_json::to_value(&original).unwrap();
+    zero["sequence"] = serde_json::json!(0);
+    assert!(serde_json::from_value::<RuntimeEvent>(zero).is_err());
+    let mut unknown = serde_json::to_value(&original).unwrap();
+    unknown["payload"]["task_completed"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<RuntimeEvent>(unknown).is_err());
+    let mut oversized = serde_json::to_value(event(
+        1,
+        RuntimeEventKind::Message {
+            text: text("small"),
+        },
+    ))
+    .unwrap();
+    oversized["payload"]["text"] = serde_json::json!("x".repeat(MAX_EVENT_TEXT_BYTES + 1));
+    assert!(serde_json::from_value::<RuntimeEvent>(oversized).is_err());
+}
+
+#[test]
+fn event_schema_keeps_namespaced_evidence_separate_and_bounded() {
+    let original = event(1, RuntimeEventKind::Ready {})
+        .with_vendor_reference(VendorEventReference {
+            namespace: text("vendor.runtime"),
+            id: RequestId::new("raw-reference").unwrap(),
+        })
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<RuntimeEvent>(&serde_json::to_string(&original).unwrap()).unwrap(),
+        original
+    );
+    let schema = serde_json::to_value(schemars::schema_for!(RuntimeEvent)).unwrap();
+    assert_eq!(
+        schema["$defs"]["EventText"]["maxLength"],
+        MAX_EVENT_TEXT_BYTES
+    );
+    assert!(original.vendor_reference().is_some());
+}
+
+#[test]
+fn invalid_known_usage_subsets_and_totals_reject_construction_and_wire_without_advancing() {
+    let unknown = UsageMeasurement::Unknown {
+        reason: UnknownUsageReason::NotReported,
+    };
+    let measured = |value| UsageMeasurement::Measured { value };
+    let valid = RuntimeUsage {
+        input_tokens: measured(1),
+        output_tokens: measured(2),
+        cached_input_tokens: measured(1),
+        billed_micro_units: unknown.clone(),
+        coverage: UsageCoverage::RootOnly,
+    };
+    let mut session = tracker();
+    session.apply(event(1, RuntimeEventKind::Ready {})).unwrap();
+    for invalid in [
+        RuntimeUsage {
+            cached_input_tokens: measured(100),
+            ..valid.clone()
+        },
+        RuntimeUsage {
+            input_tokens: measured(u64::MAX),
+            output_tokens: measured(1),
+            ..valid.clone()
+        },
+    ] {
+        assert_eq!(
+            RuntimeEvent::new(
+                CommandId::new("invalid-usage").unwrap(),
+                2,
+                binding(),
+                RuntimeEventKind::Usage {
+                    usage: invalid.clone()
+                }
+            ),
+            Err(EventError::InvalidUsage)
+        );
+        assert!(
+            serde_json::from_value::<RuntimeUsage>(serde_json::to_value(&invalid).unwrap())
+                .is_err()
+        );
+        let mut wire = serde_json::to_value(event(
+            2,
+            RuntimeEventKind::Usage {
+                usage: valid.clone(),
+            },
+        ))
+        .unwrap();
+        wire["payload"]["usage"] = serde_json::to_value(invalid).unwrap();
+        assert!(serde_json::from_value::<RuntimeEvent>(wire).is_err());
+        assert_eq!(session.next_sequence(), 2);
+    }
+    let partial = RuntimeUsage {
+        input_tokens: unknown,
+        cached_input_tokens: measured(100),
+        ..valid
+    };
+    session
+        .apply(event(2, RuntimeEventKind::Usage { usage: partial }))
+        .unwrap();
+    assert_eq!(
+        session.next_sequence(),
+        3,
+        "unknown input is not zero and cannot disprove a cached subset"
+    );
+}

--- a/crates/symbiote-runtime-sdk/tests/provider.rs
+++ b/crates/symbiote-runtime-sdk/tests/provider.rs
@@ -1,0 +1,595 @@
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use symbiote_domain::*;
+use symbiote_runtime_sdk::provider::*;
+
+fn fixtures() -> (
+    RuntimeProfile,
+    ProviderConnection,
+    CredentialReference,
+    BillingEntitlement,
+    ModelDescriptor,
+) {
+    let provider_id = ProviderConnectionId::new("provider").unwrap();
+    let credential_id = CredentialReferenceId::new("credential").unwrap();
+    let entitlement_id = BillingEntitlementId::new("entitlement").unwrap();
+    let model_id = ModelId::new("model").unwrap();
+    (
+        RuntimeProfile {
+            id: RuntimeProfileId::new("profile").unwrap(),
+            revision: Revision(1),
+            runtime: RuntimeKind::NativeSymbiote,
+            adapter: AgentRuntimeAdapterId::new("native-loop").unwrap(),
+            installation: None,
+            provider: provider_id.clone(),
+            credential: credential_id.clone(),
+            billing_entitlement: entitlement_id.clone(),
+            model: model_id.clone(),
+            eligible_hosts: BTreeSet::from([HostId::new("host").unwrap()]),
+        },
+        ProviderConnection {
+            id: provider_id.clone(),
+            adapter: InferenceProviderAdapterId::new("inference").unwrap(),
+            endpoint_reference: "endpoint-main".into(),
+            authentication: AuthenticationKind::ApiCredential,
+        },
+        CredentialReference {
+            id: credential_id,
+            vault_key: "vault-reference-only".into(),
+        },
+        BillingEntitlement {
+            id: entitlement_id,
+            provider: provider_id.clone(),
+            kind: BillingKind::MeteredApi,
+            verification_evidence: EvidenceId::new("entitlement-proof").unwrap(),
+            expires_at: Timestamp(100),
+        },
+        ModelDescriptor {
+            schema_version: 1,
+            id: model_id,
+            provider_id,
+            context_window_tokens: 128,
+            max_output_tokens: 64,
+            capabilities: ModelCapabilities {
+                reasoning_efforts: [ReasoningEffort::Low].into(),
+                tools: true,
+                images: true,
+                streaming: true,
+            },
+        },
+    )
+}
+fn request() -> ProviderRequest {
+    ProviderRequest {
+        schema_version: 1,
+        request_id: RequestId::new("inference-request").unwrap(),
+        provider_id: ProviderConnectionId::new("provider").unwrap(),
+        model_id: ModelId::new("model").unwrap(),
+        messages: vec![InputMessage {
+            role: MessageRole::User,
+            content: vec![InputPart::Text {
+                text: "hello".into(),
+            }],
+        }],
+        tools: vec![],
+        input_token_budget: 10,
+        max_output_tokens: 20,
+        reasoning: None,
+        streaming: false,
+    }
+}
+fn response() -> ProviderResponse {
+    let request = request();
+    ProviderResponse {
+        schema_version: 1,
+        request_id: request.request_id,
+        provider_id: request.provider_id,
+        model_id: request.model_id,
+        text: "hello".into(),
+        tool_calls: vec![],
+        finish_reason: FinishReason::Stop,
+        usage: TokenUsage::Unknown {
+            reason: UsageUnknownReason::NotReported,
+        },
+    }
+}
+
+#[test]
+fn native_api_requires_matching_credential_and_explicit_metered_entitlement() {
+    let (profile, connection, credential, entitlement, model) = fixtures();
+    let binding = validate_binding(
+        &profile,
+        &connection,
+        Some(&credential),
+        &entitlement,
+        &model,
+        &ProviderPolicy::default(),
+        Timestamp(1),
+    )
+    .unwrap();
+    assert_eq!(binding.credential_reference(), Some(&credential.id));
+    assert_eq!(binding.adapter_id(), &connection.adapter);
+    assert!(
+        !serde_json::to_string(&binding)
+            .unwrap()
+            .contains(&credential.vault_key)
+    );
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            None,
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::CredentialRequired
+    );
+    let mut wrong = credential;
+    wrong.id = CredentialReferenceId::new("other").unwrap();
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            Some(&wrong),
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::BindingMismatch
+    );
+}
+
+#[test]
+fn external_harness_subscription_never_accepts_copied_native_credentials() {
+    let (mut profile, mut connection, credential, mut entitlement, model) = fixtures();
+    profile.runtime = RuntimeKind::ExternalHarness;
+    profile.adapter = AgentRuntimeAdapterId::new("external-loop").unwrap();
+    profile.installation = Some(InstallationId::new("external-cli").unwrap());
+    connection.authentication = AuthenticationKind::HarnessManaged;
+    entitlement.kind = BillingKind::HarnessSubscription;
+    let binding = validate_binding(
+        &profile,
+        &connection,
+        None,
+        &entitlement,
+        &model,
+        &ProviderPolicy::default(),
+        Timestamp(1),
+    )
+    .unwrap();
+    assert_eq!(binding.runtime_kind(), RuntimeKind::ExternalHarness);
+    assert_eq!(binding.credential_reference(), None);
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            Some(&credential),
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::UnexpectedCredential
+    );
+    profile.runtime = RuntimeKind::NativeSymbiote;
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            None,
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::UnsupportedAuthenticationBilling
+    );
+}
+
+#[test]
+fn native_local_endpoint_needs_no_cli_or_secret_but_requires_exact_local_policy() {
+    let (profile, mut connection, _, mut entitlement, model) = fixtures();
+    connection.authentication = AuthenticationKind::LocalUnauthenticated;
+    entitlement.kind = BillingKind::Local;
+    assert!(profile.installation.is_none());
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            None,
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::LocalPolicyRequired
+    );
+    let policy = ProviderPolicy {
+        verified_local_endpoints: BTreeMap::from([(
+            connection.id.clone(),
+            connection.endpoint_reference.clone(),
+        )]),
+    };
+    let binding = validate_binding(
+        &profile,
+        &connection,
+        None,
+        &entitlement,
+        &model,
+        &policy,
+        Timestamp(1),
+    )
+    .unwrap();
+    assert_eq!(binding.credential_reference(), None);
+    assert_eq!(binding.endpoint_reference(), "endpoint-main");
+    connection.endpoint_reference = "different-endpoint".into();
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            None,
+            &entitlement,
+            &model,
+            &policy,
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::LocalPolicyRequired
+    );
+}
+
+#[test]
+fn binding_mismatches_expiry_and_billing_fallback_fail_closed() {
+    let (profile, connection, credential, entitlement, model) = fixtures();
+    for at in [Timestamp(100), Timestamp(101)] {
+        assert_eq!(
+            validate_binding(
+                &profile,
+                &connection,
+                Some(&credential),
+                &entitlement,
+                &model,
+                &ProviderPolicy::default(),
+                at
+            )
+            .unwrap_err(),
+            ProviderError::ExpiredEntitlement
+        );
+    }
+    let binding = validate_binding(
+        &profile,
+        &connection,
+        Some(&credential),
+        &entitlement,
+        &model,
+        &ProviderPolicy::default(),
+        Timestamp(99),
+    )
+    .unwrap();
+    assert!(binding.validate_at(Timestamp(100)).is_err());
+    let mut mismatch = entitlement.clone();
+    mismatch.provider = ProviderConnectionId::new("other").unwrap();
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            Some(&credential),
+            &mismatch,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::BindingMismatch
+    );
+    let mut mismatch = entitlement;
+    mismatch.kind = BillingKind::HarnessSubscription;
+    assert_eq!(
+        validate_binding(
+            &profile,
+            &connection,
+            Some(&credential),
+            &mismatch,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .unwrap_err(),
+        ProviderError::UnsupportedAuthenticationBilling
+    );
+}
+
+#[test]
+fn mixed_runtime_profiles_roundtrip_without_changing_role_identity() {
+    let (native, mut connection, _, mut entitlement, model) = fixtures();
+    let mut external = native.clone();
+    external.runtime = RuntimeKind::ExternalHarness;
+    external.id = RuntimeProfileId::new("external-profile").unwrap();
+    external.adapter = AgentRuntimeAdapterId::new("external-loop").unwrap();
+    connection.authentication = AuthenticationKind::HarnessManaged;
+    entitlement.kind = BillingKind::HarnessSubscription;
+    let lead = RoleId::new("lead").unwrap();
+    let worker = RoleId::new("worker").unwrap();
+    for assignments in [
+        vec![
+            (lead.clone(), native.clone()),
+            (worker.clone(), external.clone()),
+        ],
+        vec![
+            (lead.clone(), external.clone()),
+            (worker.clone(), native.clone()),
+        ],
+        vec![
+            (lead.clone(), native.clone()),
+            (worker.clone(), native.clone()),
+        ],
+    ] {
+        let decoded: Vec<(RoleId, RuntimeProfile)> =
+            serde_json::from_str(&serde_json::to_string(&assignments).unwrap()).unwrap();
+        assert_eq!(assignments, decoded);
+    }
+    assert!(
+        validate_binding(
+            &external,
+            &connection,
+            None,
+            &entitlement,
+            &model,
+            &ProviderPolicy::default(),
+            Timestamp(1)
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn ultra_requires_explicit_model_advertisement() {
+    let (_, _, _, _, mut model) = fixtures();
+    let mut req = request();
+    req.reasoning = Some(ReasoningEffort::Ultra);
+    assert_eq!(
+        req.validate(&model),
+        Err(ProviderError::UnsupportedCapability)
+    );
+    model
+        .capabilities
+        .reasoning_efforts
+        .insert(ReasoningEffort::Ultra);
+    assert!(req.validate(&model).is_ok());
+    assert_eq!(
+        serde_json::to_string(&ReasoningEffort::Ultra).unwrap(),
+        "\"ultra\""
+    );
+    req.reasoning = Some(ReasoningEffort::None);
+    assert_eq!(
+        req.validate(&model),
+        Err(ProviderError::UnsupportedCapability)
+    );
+    req.reasoning = None;
+    assert!(req.validate(&model).is_ok());
+}
+
+#[test]
+fn model_context_and_feature_requests_are_explicit() {
+    let (_, _, _, _, mut model) = fixtures();
+    assert!(request().validate(&model).is_ok());
+    let mut req = request();
+    req.input_token_budget = 109;
+    assert_eq!(req.validate(&model), Err(ProviderError::ContextLimit));
+    req.input_token_budget = u64::MAX;
+    assert_eq!(req.validate(&model), Err(ProviderError::ContextLimit));
+    let mut req = request();
+    req.max_output_tokens = 65;
+    assert_eq!(req.validate(&model), Err(ProviderError::OutputLimit));
+    let mut req = request();
+    req.reasoning = Some(ReasoningEffort::High);
+    assert_eq!(
+        req.validate(&model),
+        Err(ProviderError::UnsupportedCapability)
+    );
+    model.capabilities.streaming = false;
+    let mut req = request();
+    req.streaming = true;
+    assert_eq!(
+        req.validate(&model),
+        Err(ProviderError::UnsupportedCapability)
+    );
+    model.capabilities.images = false;
+    let mut req = request();
+    req.messages[0].content = vec![InputPart::Image {
+        artifact_id: ArtifactId::new("image").unwrap(),
+    }];
+    assert_eq!(
+        req.validate(&model),
+        Err(ProviderError::UnsupportedCapability)
+    );
+}
+
+#[test]
+fn unknown_usage_is_never_zero_and_known_subsets_do_not_double_count() {
+    for reason in [
+        UsageUnknownReason::NotReported,
+        UsageUnknownReason::Interrupted,
+        UsageUnknownReason::Unsupported,
+    ] {
+        assert_eq!(TokenUsage::Unknown { reason }.total().unwrap(), None);
+    }
+    assert_eq!(
+        TokenUsage::Known {
+            input_tokens: 10,
+            output_tokens: 20,
+            cached_input_tokens: Some(5),
+            reasoning_tokens: Some(12)
+        }
+        .total()
+        .unwrap(),
+        Some(30)
+    );
+    for usage in [
+        TokenUsage::Known {
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_input_tokens: Some(2),
+            reasoning_tokens: None,
+        },
+        TokenUsage::Known {
+            input_tokens: 1,
+            output_tokens: 1,
+            cached_input_tokens: None,
+            reasoning_tokens: Some(2),
+        },
+        TokenUsage::Known {
+            input_tokens: u64::MAX,
+            output_tokens: 1,
+            cached_input_tokens: None,
+            reasoning_tokens: None,
+        },
+    ] {
+        assert_eq!(usage.total(), Err(ProviderError::InvalidUsage));
+    }
+}
+
+#[test]
+fn tool_calls_require_declared_names_unique_ids_and_object_arguments() {
+    let (_, _, _, _, model) = fixtures();
+    let mut req = request();
+    req.tools.push(ToolDefinition {
+        name: "read_code".into(),
+        description: "Read source".into(),
+        input_schema: json!({"type":"object"}),
+    });
+    let mut output = response();
+    output.finish_reason = FinishReason::ToolCalls;
+    output.tool_calls.push(ProviderToolCall {
+        call_id: RequestId::new("tool-call").unwrap(),
+        name: "read_code".into(),
+        arguments: json!({"path":"example.rs"}),
+    });
+    assert!(output.validate(&req, &model).is_ok());
+    output.tool_calls.push(output.tool_calls[0].clone());
+    assert_eq!(
+        output.validate(&req, &model),
+        Err(ProviderError::DuplicateToolCall)
+    );
+    output.tool_calls.pop();
+    output.tool_calls[0].name = "execute_anything".into();
+    assert_eq!(
+        output.validate(&req, &model),
+        Err(ProviderError::UnknownTool)
+    );
+    output.tool_calls[0].name = "read_code".into();
+    output.tool_calls[0].arguments = json!([]);
+    assert_eq!(
+        output.validate(&req, &model),
+        Err(ProviderError::InvalidEnvelope)
+    );
+}
+
+#[test]
+fn envelopes_are_bounded_strict_and_correlated() {
+    let (_, _, _, _, model) = fixtures();
+    let req = request();
+    assert_eq!(
+        ProviderRequest::parse(&serde_json::to_vec(&req).unwrap(), &model).unwrap(),
+        req
+    );
+    let mut unknown = serde_json::to_value(&req).unwrap();
+    unknown["credential_value"] = json!("must-not-be-here");
+    assert_eq!(
+        ProviderRequest::parse(unknown.to_string().as_bytes(), &model).unwrap_err(),
+        ProviderError::InvalidEnvelope
+    );
+    assert_eq!(
+        ProviderRequest::parse(&vec![b' '; MAX_ENVELOPE_BYTES + 1], &model).unwrap_err(),
+        ProviderError::EnvelopeTooLarge
+    );
+    let mut output = response();
+    output.request_id = RequestId::new("other").unwrap();
+    assert_eq!(
+        output.validate(&req, &model),
+        Err(ProviderError::ModelMismatch)
+    );
+    let mut output = response();
+    output.text = "a".repeat(MAX_ENVELOPE_BYTES);
+    assert_eq!(
+        output.validate(&req, &model),
+        Err(ProviderError::EnvelopeTooLarge)
+    );
+    let mut bad_version = req.clone();
+    bad_version.schema_version = 2;
+    assert_eq!(
+        bad_version.validate(&model),
+        Err(ProviderError::UnsupportedVersion)
+    );
+}
+
+#[test]
+fn known_input_usage_respects_budget_even_when_model_context_has_room() {
+    let (_, _, _, _, model) = fixtures();
+    let req = request();
+    let mut output = response();
+    for input_tokens in [9, 10, 11, 100] {
+        output.usage = TokenUsage::Known {
+            input_tokens,
+            output_tokens: 1,
+            cached_input_tokens: None,
+            reasoning_tokens: None,
+        };
+        let expected = if input_tokens <= req.input_token_budget {
+            Ok(())
+        } else {
+            Err(ProviderError::InputLimit)
+        };
+        assert_eq!(output.validate(&req, &model), expected);
+    }
+    output.usage = TokenUsage::Unknown {
+        reason: UsageUnknownReason::NotReported,
+    };
+    assert!(output.validate(&req, &model).is_ok());
+    assert_eq!(output.usage.total().unwrap(), None);
+}
+
+#[test]
+fn nested_tool_json_and_usage_overruns_are_rejected() {
+    let (_, _, _, _, model) = fixtures();
+    let mut req = request();
+    let mut schema = json!({});
+    for _ in 0..34 {
+        schema = json!({"child":schema});
+    }
+    req.tools.push(ToolDefinition {
+        name: "tool".into(),
+        description: String::new(),
+        input_schema: schema,
+    });
+    assert_eq!(req.validate(&model), Err(ProviderError::InvalidEnvelope));
+    let mut output = response();
+    output.usage = TokenUsage::Known {
+        input_tokens: 10,
+        output_tokens: 21,
+        cached_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        output.validate(&request(), &model),
+        Err(ProviderError::OutputLimit)
+    );
+    output.usage = TokenUsage::Known {
+        input_tokens: 128,
+        output_tokens: 1,
+        cached_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        output.validate(&request(), &model),
+        Err(ProviderError::ContextLimit)
+    );
+}

--- a/docs/contracts/providers.md
+++ b/docs/contracts/providers.md
@@ -1,0 +1,43 @@
+# Inference provider contracts — #464 foundation
+
+`symbiote_runtime_sdk::provider` separates a model-turn adapter from the agent-loop `AgentRuntimeAdapter`. `InferenceProviderAdapter` uses the existing domain `InferenceProviderAdapterId`; runtime adapters use `AgentRuntimeAdapterId`. Neither trait is a control plane. This module performs no network requests, tool execution, credential reads, billing operations or canonical Task completion. It contains no provider implementation and establishes no live model compatibility.
+
+## Identity, versions and capabilities
+
+`ModelDescriptor` references canonical `ModelId` and `ProviderConnectionId`, token context/output limits and explicit reasoning/tool/image/streaming capabilities. Requests name the same identities; responses must preserve them and the request correlation. Capabilities are supplied facts, not guessed from a model name. Unsupported effort/capability requests fail explicitly. The reasoning vocabulary is none/minimal/low/medium/high/x_high/max/ultra; every explicit value requires model advertisement, including none. An omitted effort makes no explicit selection. These names do not assert any provider's wire mapping or support; additional mappings require verified adapter behavior rather than silent substitution.
+
+`PROVIDER_CONTRACT_VERSION = 1` versions these provider envelopes independently from canonical domain schemas, Host RPC and native agent/external harness state. Unknown versions fail. There is no invented migration from a historical provider schema and no automatic rewrite of stored native or external session state.
+
+## Authentication and billing
+
+`validate_binding` requires consistent RuntimeProfile/provider/model/credential/entitlement identities and an unexpired entitlement. An expiry equal to the current time is expired. Resulting `ProviderBinding` is read-only metadata and intentionally cannot be deserialized as authority; it retains the endpoint reference and only a credential *identity*, never its vault key or secret value. Recheck expiry at request execution, not only when loading configuration.
+
+Supported mappings are deliberately explicit:
+
+| Authentication | Billing | Runtime | Credential input |
+| --- | --- | --- | --- |
+| API credential | Metered API | Native or external | Matching credential reference required |
+| Harness managed | Harness subscription | External only | Must be absent |
+| Local unauthenticated | Local | Native or external | Must be absent; trusted local policy required |
+
+Native bindings reject harness-managed authentication and harness subscriptions. External subscription bindings reject passed native credentials, preventing this boundary from silently copying a native credential reference into harness-managed work. Unsupported combinations fail rather than switching billing methods. A symbolic credential ID remains in the existing domain RuntimeProfile even for no-secret mappings; it is not resolved or leased in those cases.
+
+`ProviderPolicy` is a non-wire Host input mapping verified-local provider IDs to exact endpoint references. Changing an endpoint invalidates that local-policy match. Endpoint locality, entitlement verification evidence authenticity, credential ownership/access and the actual runtime loop owner remain Host responsibilities; a typed ID or a localhost-looking string does not prove them. An all-native local binding needs neither a secret nor an installed third-party CLI. This is a configuration fixture, not startup/process proof.
+
+## Bounded model-turn envelopes
+
+`ProviderRequest` accepts at most 128 messages, 32 parts per message and 64 uniquely named tools. Images reference Host-resolved artifact IDs, not arbitrary remote URLs. Model tool schemas remain declarations and do not grant permission. JSON schema/arguments are bounded to depth 32 and 4,096 nodes; each complete serialized envelope is capped at 256 KiB. Parsing checks byte size first and rejects unknown fields. Programmatic validation counts serialization bytes without creating a second unbounded output buffer.
+
+The request's input-token budget is a Context Broker upper-bound estimate, distinct from measured usage. Input budget plus reserved maximum output must fit the declared context window using checked arithmetic. Maximum output must be positive and fit the model's output limit. This module does not implement tokenization or prove that an estimator is accurate.
+
+`ProviderResponse` contains text, correlated tool-call envelopes, finish reason and explicit `TokenUsage`. Tool-call IDs must be unique, tool names must have been declared, and arguments must be JSON objects. The tool engine must still validate arguments against the tool's actual schema and enforce Host permissions before execution. A provider tool call is a request, never an authorized effect. Cancelled/truncated responses cannot carry actionable tool-call lists under this initial completed-envelope contract.
+
+Usage is `Known` or `Unknown` with a reason (`not_reported`, `interrupted`, `unsupported`). Unknown is never zero. Known cached tokens are a subset of input and reasoning tokens are a subset of output, so totals do not double-count them. Overflow, invalid subsets, context overruns and reported input/output beyond their respective request budgets fail explicitly. Known input above `input_token_budget` returns `InputLimit` even when the model context still has room; equality is allowed. No monetary cost is guessed and no entitlement accounting is performed.
+
+The async trait returns a completed response envelope. A streaming-capability request may be implemented by consuming a provider stream into that bounded result; incremental stream transport, cancellation wiring and partial-response recovery are not implemented here and remain pending. Adapter implementations must validate descriptors/requests/bindings/responses and match their own adapter ID before use. No fake adapter is counted as provider integration evidence.
+
+## Verification and pending scope
+
+Tests cover mixed native/external identity round trips, native rejection of subscription/harness mappings, required API references, external no-copy behavior, exact local policy with no CLI/secret, changed endpoint rejection, entitlement expiry, request/model limits, unsupported capabilities, tool-call validation, strict/oversized envelopes, deep JSON, usage subsets/overflow/unknowns and response correlation. They do not authenticate an account or call a model.
+
+Pending #464 acceptance: actual native runtime integration, verified provider adapters/endpoints, credential-store leasing and ownership enforcement, endpoint/model evidence freshness, full provider authentication/billing compatibility, adapter validation enforcement at live invocation, stream/cancellation/recovery tests, mixed real-runtime executions and denied direct-Host-state writes. Security/privacy applies to every live credential/endpoint/tool boundary. Accessibility is not applicable to this headless contract module; UI reporting remains client work. Contract checks are portable, but actual platform/provider behavior is untested. No state migration, billing change or production rollout occurs in this module.

--- a/docs/contracts/runtime-events.md
+++ b/docs/contracts/runtime-events.md
@@ -1,0 +1,48 @@
+# Normalized runtime events and bounded session observation
+
+Owner: [#184](https://github.com/RepairYourTech/SymbioteIDE/issues/184). `symbiote_runtime_sdk::events` implements a provider-neutral observation boundary and deterministic in-memory session tracker. It uses domain Session, Dispatch and Host identities and `RuntimeKind`; it imports no canonical Task mutator. A worker completion request remains an observation, and a zero exit code produces only an `Exited` session state. No event or tracker state means canonical work is complete.
+
+## Wire contract
+
+`SessionBinding` fixes the Session ID, Dispatch ID, Host ID and native/external runtime kind. `RuntimeEvent::new` binds a validated domain `CommandId`, positive per-session sequence and normalized payload to that immutable ownership tuple. Tool calls, approval requests, questions and optional vendor references use validated domain `RequestId` values. The tracker rejects any ownership mismatch, even on a duplicate event. Event fields have no setters; deserialization validates the positive sequence and bounded text before constructing the envelope.
+
+The normalized payload variants cover ready, message, tool proposed/started/completed/failed, approval request, worker question, filesystem/process/Git/network/MCP/secret-access/post-edit observation, diagnostic, usage, completion request, exit, disconnect, reconnect, crash, cancellation request and cancellation acknowledgment. Observations do not themselves enforce filesystem, tool or credential restrictions. Structured adapters must emit only events they can actually observe; a generic terminal adapter must not fabricate structured tool lifecycles from guessed semantics.
+
+`EventText` bounds each message, argument, result, error and diagnostic to 16,384 UTF-8 **bytes**. The generated JSON Schema advertises a maximum character length, with a description of the stricter runtime byte check. Unicode and JSON escaping mean the transport must impose its own frame-byte limit before deserializing; this type does not bound allocation while an unbounded transport is decoding a string. There are no unbounded vectors or raw vendor payloads in an event. `VendorEventReference` retains a bounded, nonempty namespace and typed reference to separately governed vendor evidence. Callers must redact message/tool content and manage raw evidence access; this module does not claim automatic secret detection or redaction.
+
+Usage has explicit `Measured { value }` and `Unknown { reason }` representations for input/output/cache tokens and billed micro-units. Missing fields do not default to zero. Coverage separately identifies root-only, root-and-children, aggregate-only or unknown reporting. These values are reported observations, not verified costs, token accounting, entitlement decisions or complete child visibility. Currency/unit interpretation and quota/rate-limit interfaces remain outside this bounded event implementation.
+
+Known cached input cannot exceed known input, and a known input/output sum must fit `u64`. The same validator runs for direct event construction and wire deserialization. Unknown values remain unknown; a measured cached value is not rejected merely because total input is unreported.
+
+## Lifecycle and replay
+
+Create a `SessionTracker` from a binding and `TrackerLimits`, then call `apply(event)`. Its `EventReceipt` contains the original event sequence, resulting session state, replay marker and residual-effect assessment. A retained exact duplicate returns its original result with `replayed=true`; changed content under the same ID conflicts. A reused sequence conflicts. A missing sequence reports the expected/received gap without advancing the cursor. Event receipts are not durable commits or external-effect acknowledgments.
+
+The initial state awaits a ready event. A reconnect restores pre-disconnect readiness rather than inventing a completed handshake. Disconnect and crash make residual effects unknown. Tool events follow proposed → started → completed/failed; unknown, reused or invalidly ordered tool IDs are rejected. Approval/question events remain requests for another subsystem to resolve. A completion report leaves the session running. Exit/crash end runtime observation without touching Task or Capability state; trailing usage and diagnostics can still be retained.
+
+Cancellation intent survives disconnect/reconnect. After cancellation is requested, new tool or mutation observations are rejected with `ResidualEffectUnknown`, leave the sequence unadvanced and keep the residual-effect assessment unknown. Acknowledgment and exit do not certify cleanup or undo earlier effects. Rejected events cannot be silently skipped to close a sequence gap: the producer/Host must reconcile its authoritative stream or terminate observation visibly. `Unassessed` is the default residual-effect value, never a claim that no effects occurred.
+
+## Resource and recovery limits
+
+Defaults retain 128 replay entries, at most 256 distinct tool calls and at most 4,096 event identities. Configured hard maxima are 1,024 retained entries, 256 tool identities and 65,536 event identities. Completed tool IDs remain counted so they cannot silently be reused. A bounded deque evicts old payloads, while the bounded identity set prevents an old event ID being recycled at a newer sequence. Exhausting a limit fails closed; it never silently drops an event and reports success.
+
+`replay_floor()` exposes the oldest retained sequence. Events below it return `ReplayUnavailable`; expired history is not guessed or treated as a successful duplicate. A session reaching an identity/resource bound needs an authoritative continuation/checkpoint strategy owned by later integration work. Runtime cancellation/control must remain available independently of telemetry capacity; the tracker is not the mechanism that kills a process or sends cancellation to a harness.
+
+The tracker implements `Serialize` for inspection but deliberately does **not** implement `Deserialize`. An arbitrary serialized snapshot cannot restore trusted history or ownership. Durable replay/checkpoint integration, authenticity and cross-process recovery are not supplied here. Accepted envelopes can be serialized/deserialized, then applied in order to a fresh tracker within its limits.
+
+## Verification and pending acceptance
+
+Run `cargo test -p symbiote-runtime-sdk --test events` and `cargo clippy -p symbiote-runtime-sdk --test events -- -D warnings`. Twelve event tests cover:
+
+- The complete observed tool lifecycle, advisory completion report and false-green exit-zero boundary.
+- Exact duplicates, changed IDs/content, reused sequences and gaps without cursor advancement.
+- Cross-Session/Dispatch/Host/runtime rejection.
+- Cancellation, residual mutation reports and cleanup uncertainty.
+- Unknown versus measured-zero usage and explicit child visibility.
+- Invalid measured token subsets and overflowing totals rejected at construction/deserialization without tracker advancement.
+- Disconnect/reconnect before readiness and while cancellation is pending.
+- Unknown, failed, reused and out-of-order tools.
+- Replay-floor eviction, identity reuse detection and bounded-capacity failure.
+- UTF-8 byte bounds, invalid wire fields and schema/reference round trips.
+
+These are SDK contract tests, not native-agent, Codex, PTY, process cleanup or production adapter evidence. #184 remains open for real adapter integration, full lifecycle methods and capability conformance, qualified tool enforcement, authenticated/redacted raw-event handling, continuation/checkpoint persistence, rate-limit/quota reporting, advanced child lineage/cost coverage and platform-specific compatibility dossiers. No canonical Task mutation or actual runtime execution is enabled by this module.

--- a/docs/contracts/runtime-sdk.md
+++ b/docs/contracts/runtime-sdk.md
@@ -1,0 +1,19 @@
+# Runtime SDK foundations — #184 / #464
+
+`symbiote-runtime-sdk` separates `AgentRuntimeAdapter` (agent/session loop) from `InferenceProviderAdapter` (model requests). It consumes canonical Dispatch, Role, Runtime Profile and enforcement records. No adapter method completes a canonical Task.
+
+Qualification distinguishes native ownership from external full harnesses, transport from integration tier, granular capabilities from enforcement strength, and observed facts from unknown/unsupported features. Native profiles need no external installation. An embedded external harness cannot validate as native ownership. A tier label never supplies a missing capability or proves certification.
+
+Qualification checks adapter/installation/profile revision/model, Host eligibility, version/platform proof bindings and expiry, mandatory compiled controls, named tools/skills and context bounds. Observed or emulated controls cannot satisfy preventive enforcement. The Host must authenticate referenced proof artifacts; SDK metadata cannot prove its own truth.
+
+`PreparedLaunch` is data-only. Authorization rechecks freshness, calls a trusted `ActivationJournal` to persist the exact Dispatch and descriptor, and checks the receipt before producing a nonserializable `LaunchPermit`. Adapters must revalidate the permit immediately before activation. Rust visibility is not a sandbox against code in the trusted process. The callback is an SDK interface, not the SQLite adapter's production activation transaction. Durable fencing/outbox recovery and actual supervision remain downstream obligations. The metadata daemon exposes no launch operation in this batch.
+
+[Runtime events](runtime-events.md) supply bounded immutable identity, gap/replay handling, tool lifecycle and cancellation uncertainty. Worker completion and exit code zero never grant canonical completion. [Provider contracts](providers.md) separate native API and harness authentication/billing and require explicit model capability support. Unknown usage remains unknown; local unauthenticated endpoints require exact Host-approved policy.
+
+```sh
+cargo test -p symbiote-runtime-sdk --locked
+cargo clippy -p symbiote-runtime-sdk --all-targets --locked -- -D warnings
+cargo run -p symbiote-runtime-sdk --example runtime_schema --locked
+```
+
+Reference adapters/journal in tests are in-memory conformance fixtures. They prove qualification/ordering, not real PTY execution, durable activation or OpenAI/Codex integration. The generic PTY fixture lacks required controls and is rejected; the structured fixture receives a permit only with matching fixture evidence. Real transports, installation/authentication/probe lifecycles, profile reconciliation, upstream dossiers, process boundaries, native model/tool loop, Codex App Server and cross-runtime end-to-end proof remain open under #184/#464 and integration owners. Unsupported behavior must never be replaced with simulated success.

--- a/docs/engineering-handoff.md
+++ b/docs/engineering-handoff.md
@@ -1,5 +1,13 @@
 # Engineering handoff
 
+## Runtime SDK foundation — 2026-09-08 UTC
+
+Change Stream `issue-184-runtime-sdk` starts from merged #475 at `c1b7f2f6d7adcbe7c50377d1ff9e990b11019ebe`. Owners #184/#464 consume the reviewed #181/#36 contracts. `symbiote-runtime-sdk` separates agent-loop adapters from inference providers, qualifies immutable dispatches against current identity-bound capability/control evidence, and defines bounded session events and native/external auth/billing checks.
+
+Independent review covers adapter capability/activation logic separately from provider/event logic. New failure fixtures cover proof substitution, stale controls, context bounds, native/external ownership, absent CLI/local endpoint metadata, false completion, replay gaps, cancellation uncertainty and impossible/over-budget usage. Conformance fixtures are not real runtimes; the Host has no SDK activation endpoint or implementation of its ActivationJournal callback yet.
+
+Next: implement dependency-ready runtime profile/configuration and trust/enforcement foundations, then actual adapter transport and dispatch integration under the canonical queue. #184/#464 remain open for real reference transports, compatibility dossiers, process isolation and full native/Codex operation. See `docs/contracts/runtime-sdk.md`, `runtime-events.md` and `providers.md`. Overall first usable release remains incomplete; do not mark the persistent build goal achieved.
+
 ## Durable metadata Host — 2026-09-08 UTC
 
 Current Change Stream: `issue-43-durable-host`, isolated from merged #474 at `42eda51a7e4955cb5f44aa85833e8a313a6ae3a7`. Owners #43/#181/#180 consume the reviewed #36/#176 foundational contracts. New Rust workspace crates implement SQLite current-state/journal transactions, typed transport-neutral requests, and an actual Linux daemon/CLI using private same-UID IPC. The GUI has no canonical state ownership. No agent subprocess or model billing is enabled.


### PR DESCRIPTION
Adds `symbiote-runtime-sdk` for the shared native/external execution boundary under #184/#464. Agent-loop adapters and inference providers have distinct interfaces. Dispatch qualification preserves mandatory controls and checks identity-bound capability evidence, tool/skill availability, context limits and expiry before a trusted journal can issue a launch permit.

Normalized session events provide bounded replay, immutable session/dispatch/Host binding, tool lifecycle and cancellation uncertainty. Completion signals never complete canonical Tasks. Provider contracts enforce model support, credential/entitlement consistency, local endpoint policy and explicit unknown usage; harness-managed credentials cannot silently become native API credentials.

Validation: 31 SDK tests; full workspace tests; strict all-target Clippy; formatting; generated runtime/event/provider schemas. Separate reviewers found and verified proof-substitution and usage-accounting fixes; unsupported event polling now reports its own operation. CI must pass at the current head before integration.

This is the foundational SDK, not live agent execution. Reference fixtures are in-memory; no actual PTY/OpenAI/Codex integration or production ActivationJournal callback is claimed. Real adapters, profile reconciliation, authenticated enforcement, durable launch fencing and runtime integration remain in the canonical queue. #184/#464 remain open.
