### PR TITLE
feat(runtime): add bounded local JSONL process transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-runtime-transport"
+version = "0.1.0"
+dependencies = [
+ "nix",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "symbiote-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk"]
+members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Start the local service using the [Host run instructions](docs/contracts/host.md
 
 The [runtime SDK](docs/contracts/runtime-sdk.md) now defines capability-qualified agent adapters, separate inference providers and bounded session events. These contracts are prerequisites for live native/Codex integration; they do not enable agent execution in the Host yet.
 
+The [local runtime transport](docs/contracts/runtime-transport.md) adds bounded subprocess JSONL I/O and explicit JSON-RPC response correlation. Its deterministic harness fixtures exercise process failures; real runtime packs and sandbox enforcement remain pending.
+
 ```sh
 cargo test --workspace --locked
 cargo clippy --workspace --all-targets --locked -- -D warnings

--- a/crates/symbiote-runtime-transport/Cargo.toml
+++ b/crates/symbiote-runtime-transport/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "symbiote-runtime-transport"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+nix = { version = "=0.30.1", features = ["fs", "process", "signal"] }
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/symbiote-runtime-transport/examples/jsonl_probe.rs
+++ b/crates/symbiote-runtime-transport/examples/jsonl_probe.rs
@@ -1,0 +1,29 @@
+//! Local deterministic plumbing demonstration. No agent, network or credentials.
+use serde_json::json;
+use std::{collections::BTreeMap, time::Duration};
+use symbiote_runtime_transport::{JsonlTransport, SpawnSpec, TransportLimits};
+
+fn main() {
+    let spec = SpawnSpec {
+        executable: "/bin/cat".into(),
+        args: vec![],
+        cwd: std::env::current_dir().expect("working directory"),
+        env: BTreeMap::new(),
+    };
+    let mut transport =
+        JsonlTransport::spawn(spec, TransportLimits::default()).expect("start local echo fixture");
+    let payload = json!({"fixture":"symbiote-jsonl", "sequence":1});
+    transport
+        .send(&payload, Duration::from_secs(2))
+        .expect("send frame");
+    let received = transport
+        .recv(Duration::from_secs(2))
+        .expect("receive frame");
+    assert_eq!(received, payload, "echoed frame differs");
+    transport
+        .cancel(Duration::from_secs(2))
+        .expect("reap echo fixture");
+    println!(
+        "Verified one structured round trip and fixture cancellation. No agent task was executed."
+    );
+}

--- a/crates/symbiote-runtime-transport/src/lib.rs
+++ b/crates/symbiote-runtime-transport/src/lib.rs
@@ -1,0 +1,674 @@
+//! Bounded Unix JSONL pipes. Environment isolation is not a security sandbox.
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
+use nix::sys::signal::{Signal, killpg};
+use nix::unistd::Pid;
+use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde_json::Value;
+use std::collections::{BTreeMap, VecDeque};
+use std::ffi::OsString;
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::os::fd::AsFd;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Receiver, SyncSender, TryRecvError},
+};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+pub mod rpc;
+
+pub struct SpawnSpec {
+    pub executable: PathBuf,
+    pub args: Vec<OsString>,
+    pub cwd: PathBuf,
+    pub env: BTreeMap<OsString, OsString>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TransportLimits {
+    pub max_frame_bytes: usize,
+    pub frame_queue_capacity: usize,
+    pub diagnostic_queue_capacity: usize,
+    pub max_diagnostic_bytes: usize,
+}
+impl Default for TransportLimits {
+    fn default() -> Self {
+        Self {
+            max_frame_bytes: 65_536,
+            frame_queue_capacity: 32,
+            diagnostic_queue_capacity: 32,
+            max_diagnostic_bytes: 4096,
+        }
+    }
+}
+impl TransportLimits {
+    fn validate(self) -> Result<Self> {
+        if !(1..=1_048_576).contains(&self.max_frame_bytes)
+            || !(1..=256).contains(&self.frame_queue_capacity)
+            || !(1..=256).contains(&self.diagnostic_queue_capacity)
+            || !(1..=65_536).contains(&self.max_diagnostic_bytes)
+        {
+            return Err(TransportError::InvalidLimits);
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProcessExit {
+    pub code: Option<i32>,
+    pub signal: Option<i32>,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GroupSignalStatus {
+    Sent,
+    Absent,
+    LeaderAlreadyReaped,
+    Failed,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DescendantCleanup {
+    Unknown,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CancelReport {
+    pub exit: ProcessExit,
+    pub group_signal: GroupSignalStatus,
+    pub descendant_cleanup: DescendantCleanup,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransportError {
+    InvalidLimits,
+    InvalidExecutable,
+    InvalidWorkingDirectory,
+    Io {
+        operation: &'static str,
+        kind: io::ErrorKind,
+    },
+    MalformedFrame,
+    FrameTooLarge,
+    FrameQueueOverflow,
+    UnterminatedFrame,
+    PartialFrameWrite,
+    DeadlineExceeded,
+    ProcessExited(ProcessExit),
+    StdoutClosed,
+    Closed,
+}
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for TransportError {}
+pub type Result<T> = std::result::Result<T, TransportError>;
+fn io_error(operation: &'static str, error: io::Error) -> TransportError {
+    TransportError::Io {
+        operation,
+        kind: error.kind(),
+    }
+}
+
+#[derive(Clone)]
+pub struct Diagnostic {
+    pub text: String,
+    pub truncated: bool,
+}
+impl fmt::Debug for Diagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Diagnostic")
+            .field("bytes", &self.text.len())
+            .field("truncated", &self.truncated)
+            .finish_non_exhaustive()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct DiagnosticBatch {
+    pub entries: Vec<Diagnostic>,
+    pub dropped: u64,
+}
+#[derive(Default)]
+struct DiagnosticBuffer {
+    entries: VecDeque<Diagnostic>,
+    dropped: u64,
+}
+type Fault = Arc<Mutex<Option<TransportError>>>;
+fn fail(fault: &Fault, error: TransportError) {
+    let mut current = fault.lock().unwrap_or_else(|poison| poison.into_inner());
+    if current.is_none() {
+        *current = Some(error);
+    }
+}
+
+pub struct JsonlTransport {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    frames: Receiver<Value>,
+    fault: Fault,
+    diagnostics: Arc<Mutex<DiagnosticBuffer>>,
+    stop: Arc<AtomicBool>,
+    stdout_eof: Arc<AtomicBool>,
+    stderr_finished: Arc<AtomicBool>,
+    readers: Vec<JoinHandle<()>>,
+    limits: TransportLimits,
+    exit: Option<ProcessExit>,
+    closed: bool,
+    group_signal: Option<GroupSignalStatus>,
+}
+
+impl JsonlTransport {
+    pub fn spawn(spec: SpawnSpec, limits: TransportLimits) -> Result<Self> {
+        let limits = limits.validate()?;
+        if !spec.executable.is_absolute() || !spec.executable.is_file() {
+            return Err(TransportError::InvalidExecutable);
+        }
+        if !spec.cwd.is_absolute() || !spec.cwd.is_dir() {
+            return Err(TransportError::InvalidWorkingDirectory);
+        }
+        let mut child = Command::new(spec.executable)
+            .args(spec.args)
+            .current_dir(spec.cwd)
+            .env_clear()
+            .envs(spec.env)
+            .process_group(0)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| io_error("spawn", e))?;
+        let pipes = (child.stdin.take(), child.stdout.take(), child.stderr.take());
+        let (Some(stdin), Some(stdout), Some(stderr)) = pipes else {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TransportError::Closed);
+        };
+        if nonblocking(&stdin)
+            .and_then(|_| nonblocking(&stdout))
+            .and_then(|_| nonblocking(&stderr))
+            .is_err()
+        {
+            let _ = killpg(Pid::from_raw(child.id() as i32), Signal::SIGKILL);
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(TransportError::Io {
+                operation: "configure nonblocking pipes",
+                kind: io::ErrorKind::Other,
+            });
+        }
+        let (sender, frames) = mpsc::sync_channel(limits.frame_queue_capacity);
+        let fault = Arc::new(Mutex::new(None));
+        let stop = Arc::new(AtomicBool::new(false));
+        let stdout_eof = Arc::new(AtomicBool::new(false));
+        let diagnostics = Arc::new(Mutex::new(DiagnosticBuffer::default()));
+        let stderr_finished = Arc::new(AtomicBool::new(false));
+        let err_finished = stderr_finished.clone();
+        let out_stop = stop.clone();
+        let out_fault = fault.clone();
+        let out_eof = stdout_eof.clone();
+        let err_stop = stop.clone();
+        let err_fault = fault.clone();
+        let err_buffer = diagnostics.clone();
+        let mut transport = Self {
+            child,
+            stdin: Some(stdin),
+            frames,
+            fault,
+            diagnostics,
+            stop,
+            stdout_eof,
+            stderr_finished,
+            readers: vec![],
+            limits,
+            exit: None,
+            closed: false,
+            group_signal: None,
+        };
+        let out = thread::Builder::new()
+            .name("jsonl-stdout".into())
+            .spawn(move || {
+                read_stdout(
+                    stdout,
+                    sender,
+                    out_stop,
+                    out_fault,
+                    out_eof,
+                    limits.max_frame_bytes,
+                )
+            })
+            .map_err(|e| io_error("spawn stdout reader", e))?;
+        transport.readers.push(out);
+        let err = thread::Builder::new()
+            .name("jsonl-stderr".into())
+            .spawn(move || {
+                read_stderr(stderr, err_stop, err_fault, err_buffer, limits);
+                err_finished.store(true, Ordering::Release);
+            })
+            .map_err(|e| io_error("spawn stderr reader", e))?;
+        transport.readers.push(err);
+        Ok(transport)
+    }
+    pub fn child_id(&self) -> u32 {
+        self.child.id()
+    }
+    pub fn failure(&self) -> Option<TransportError> {
+        self.fault
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone()
+    }
+    pub fn diagnostics_finished(&self) -> bool {
+        self.stderr_finished.load(Ordering::Acquire)
+    }
+    pub fn send(&mut self, value: &Value, timeout: Duration) -> Result<()> {
+        self.check_open()?;
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or(TransportError::DeadlineExceeded)?;
+        let mut writer = BoundedFrame {
+            bytes: Vec::new(),
+            limit: self.limits.max_frame_bytes,
+            deadline,
+            error: None,
+        };
+        if serde_json::to_writer(&mut writer, value).is_err() {
+            return Err(writer.error.unwrap_or(TransportError::MalformedFrame));
+        }
+        let mut frame = writer.bytes;
+        frame.push(b'\n');
+        let mut offset = 0;
+        while offset < frame.len() {
+            self.check_open()?;
+            if Instant::now() >= deadline {
+                if offset > 0 {
+                    fail(&self.fault, TransportError::PartialFrameWrite);
+                    return Err(TransportError::PartialFrameWrite);
+                }
+                return Err(TransportError::DeadlineExceeded);
+            }
+            match self
+                .stdin
+                .as_mut()
+                .ok_or(TransportError::Closed)?
+                .write(&frame[offset..])
+            {
+                Ok(0) => {
+                    fail(&self.fault, TransportError::Closed);
+                    return Err(TransportError::Closed);
+                }
+                Ok(written) => offset += written,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(2))
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => {
+                    let error = io_error("write stdin", error);
+                    fail(&self.fault, error.clone());
+                    return Err(error);
+                }
+            }
+        }
+        Ok(())
+    }
+    pub fn recv(&mut self, timeout: Duration) -> Result<Value> {
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or(TransportError::DeadlineExceeded)?;
+        loop {
+            self.check_open()?;
+            match self.frames.try_recv() {
+                Ok(frame) => return Ok(frame),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => {}
+            }
+            if self.stdout_eof.load(Ordering::Acquire) {
+                return match self.try_wait()? {
+                    Some(exit) => Err(TransportError::ProcessExited(exit)),
+                    None => Err(TransportError::StdoutClosed),
+                };
+            }
+            if Instant::now() >= deadline {
+                return Err(TransportError::DeadlineExceeded);
+            }
+            thread::sleep(Duration::from_millis(2));
+        }
+    }
+    /// Reaps the directly owned child. After reaping, cancellation cannot safely
+    /// signal its historical group ID; descendant cleanup stays explicitly unknown.
+    pub fn try_wait(&mut self) -> Result<Option<ProcessExit>> {
+        if self.exit.is_none() {
+            if let Some(status) = self
+                .child
+                .try_wait()
+                .map_err(|e| io_error("poll child", e))?
+            {
+                self.exit = Some(ProcessExit {
+                    code: status.code(),
+                    signal: status.signal(),
+                });
+            }
+        }
+        Ok(self.exit.clone())
+    }
+    pub fn diagnostics(&mut self) -> DiagnosticBatch {
+        let mut buffer = self
+            .diagnostics
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        DiagnosticBatch {
+            entries: buffer.entries.drain(..).collect(),
+            dropped: std::mem::take(&mut buffer.dropped),
+        }
+    }
+    /// Hard cancellation, not a promise that escaped descendants were terminated.
+    /// The unreaped owned Child pins PID reuse while its initial group is signalled.
+    pub fn cancel(&mut self, timeout: Duration) -> Result<CancelReport> {
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or(TransportError::DeadlineExceeded)?;
+        self.closed = true;
+        self.stop.store(true, Ordering::Release);
+        self.stdin.take();
+        if self.exit.is_none() {
+            let pid =
+                Pid::from_raw(i32::try_from(self.child.id()).map_err(|_| TransportError::Closed)?);
+            let outcome = match killpg(pid, Signal::SIGKILL) {
+                Ok(()) => GroupSignalStatus::Sent,
+                Err(nix::errno::Errno::ESRCH) => GroupSignalStatus::Absent,
+                Err(_) => GroupSignalStatus::Failed,
+            };
+            self.group_signal.get_or_insert(outcome);
+            // Also target the directly owned child if it moved out of its group.
+            let _ = self.child.kill();
+        } else {
+            self.group_signal
+                .get_or_insert(GroupSignalStatus::LeaderAlreadyReaped);
+        }
+        while let Some(reader) = self.readers.last() {
+            if reader.is_finished() {
+                if let Some(reader) = self.readers.pop() {
+                    let _ = reader.join();
+                }
+            } else if Instant::now() >= deadline {
+                return Err(TransportError::DeadlineExceeded);
+            } else {
+                thread::sleep(Duration::from_millis(2));
+            }
+        }
+        loop {
+            if let Some(exit) = self.try_wait()? {
+                return Ok(CancelReport {
+                    exit,
+                    group_signal: self
+                        .group_signal
+                        .clone()
+                        .unwrap_or(GroupSignalStatus::LeaderAlreadyReaped),
+                    descendant_cleanup: DescendantCleanup::Unknown,
+                });
+            }
+            if Instant::now() >= deadline {
+                return Err(TransportError::DeadlineExceeded);
+            }
+            thread::sleep(Duration::from_millis(2));
+        }
+    }
+    fn check_open(&self) -> Result<()> {
+        if self.closed {
+            return Err(TransportError::Closed);
+        }
+        if let Some(error) = self
+            .fault
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .clone()
+        {
+            return Err(error);
+        }
+        Ok(())
+    }
+}
+impl Drop for JsonlTransport {
+    fn drop(&mut self) {
+        let _ = self.cancel(Duration::from_millis(500));
+    }
+}
+
+struct BoundedFrame {
+    bytes: Vec<u8>,
+    limit: usize,
+    deadline: Instant,
+    error: Option<TransportError>,
+}
+impl Write for BoundedFrame {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if Instant::now() >= self.deadline {
+            self.error = Some(TransportError::DeadlineExceeded);
+            return Err(io::Error::other("serialization deadline"));
+        }
+        if bytes.len() > self.limit.saturating_sub(self.bytes.len()) {
+            self.error = Some(TransportError::FrameTooLarge);
+            return Err(io::Error::other("frame limit"));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn nonblocking(fd: &impl AsFd) -> nix::Result<()> {
+    let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL)?);
+    fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK))?;
+    Ok(())
+}
+fn read_stdout(
+    mut pipe: impl Read,
+    sender: SyncSender<Value>,
+    stop: Arc<AtomicBool>,
+    fault: Fault,
+    eof: Arc<AtomicBool>,
+    limit: usize,
+) {
+    let mut frame = Vec::with_capacity(limit.min(4096));
+    let mut bytes = [0; 4096];
+    while !stop.load(Ordering::Acquire) {
+        match pipe.read(&mut bytes) {
+            Ok(0) => {
+                if !frame.is_empty() {
+                    fail(&fault, TransportError::UnterminatedFrame);
+                }
+                eof.store(true, Ordering::Release);
+                return;
+            }
+            Ok(count) => {
+                for byte in &bytes[..count] {
+                    if *byte == b'\n' {
+                        if frame.last() == Some(&b'\r') {
+                            frame.pop();
+                        }
+                        let value = match serde_json::from_slice::<StrictValue>(&frame) {
+                            Ok(value) => value.0,
+                            Err(_) => {
+                                fail(&fault, TransportError::MalformedFrame);
+                                return;
+                            }
+                        };
+                        if sender.try_send(value).is_err() {
+                            fail(&fault, TransportError::FrameQueueOverflow);
+                            return;
+                        }
+                        frame.clear();
+                    } else if frame.len() == limit {
+                        fail(&fault, TransportError::FrameTooLarge);
+                        return;
+                    } else {
+                        frame.push(*byte);
+                    }
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(2))
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => {
+                fail(&fault, io_error("read stdout", error));
+                return;
+            }
+        }
+    }
+}
+fn read_stderr(
+    mut pipe: impl Read,
+    stop: Arc<AtomicBool>,
+    fault: Fault,
+    buffer: Arc<Mutex<DiagnosticBuffer>>,
+    limits: TransportLimits,
+) {
+    let mut line = Vec::with_capacity(limits.max_diagnostic_bytes.min(4096));
+    let mut truncated = false;
+    let mut bytes = [0; 4096];
+    while !stop.load(Ordering::Acquire) {
+        match pipe.read(&mut bytes) {
+            Ok(0) => {
+                if !line.is_empty() || truncated {
+                    push_diagnostic(
+                        &buffer,
+                        &line,
+                        truncated,
+                        limits.diagnostic_queue_capacity,
+                        limits.max_diagnostic_bytes,
+                    );
+                }
+                return;
+            }
+            Ok(count) => {
+                for byte in &bytes[..count] {
+                    if *byte == b'\n' {
+                        push_diagnostic(
+                            &buffer,
+                            &line,
+                            truncated,
+                            limits.diagnostic_queue_capacity,
+                            limits.max_diagnostic_bytes,
+                        );
+                        line.clear();
+                        truncated = false;
+                    } else if line.len() < limits.max_diagnostic_bytes {
+                        line.push(*byte);
+                    } else {
+                        truncated = true;
+                    }
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(2))
+            }
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => {
+                fail(&fault, io_error("read stderr", error));
+                return;
+            }
+        }
+    }
+}
+fn push_diagnostic(
+    buffer: &Mutex<DiagnosticBuffer>,
+    bytes: &[u8],
+    truncated: bool,
+    capacity: usize,
+    byte_limit: usize,
+) {
+    let mut buffer = buffer.lock().unwrap_or_else(|poison| poison.into_inner());
+    if buffer.entries.len() == capacity {
+        buffer.entries.pop_front();
+        buffer.dropped = buffer.dropped.saturating_add(1);
+    }
+    let mut text = String::from_utf8_lossy(bytes).into_owned();
+    let expanded = text.len() > byte_limit;
+    if expanded {
+        let mut boundary = byte_limit;
+        while !text.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        text.truncate(boundary);
+    }
+    buffer.entries.push_back(Diagnostic {
+        text,
+        truncated: truncated || expanded,
+    });
+}
+
+/// serde_json::Value normally collapses duplicate object keys. Preserve protocol
+/// meaning by rejecting them at every nesting level before JSON-RPC sees a Value.
+struct StrictValue(Value);
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        struct StrictVisitor;
+        impl<'de> Visitor<'de> for StrictVisitor {
+            type Value = StrictValue;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("JSON with unique object fields")
+            }
+            fn visit_bool<E: serde::de::Error>(
+                self,
+                v: bool,
+            ) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::Bool(v)))
+            }
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::Number(v.into())))
+            }
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::Number(v.into())))
+            }
+            fn visit_f64<E: serde::de::Error>(self, v: f64) -> std::result::Result<Self::Value, E> {
+                serde_json::Number::from_f64(v)
+                    .map(|n| StrictValue(Value::Number(n)))
+                    .ok_or_else(|| E::custom("invalid JSON number"))
+            }
+            fn visit_str<E: serde::de::Error>(
+                self,
+                v: &str,
+            ) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::String(v.into())))
+            }
+            fn visit_string<E: serde::de::Error>(
+                self,
+                v: String,
+            ) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::String(v)))
+            }
+            fn visit_unit<E: serde::de::Error>(self) -> std::result::Result<Self::Value, E> {
+                Ok(StrictValue(Value::Null))
+            }
+            fn visit_seq<A: SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> std::result::Result<Self::Value, A::Error> {
+                let mut values = Vec::new();
+                while let Some(value) = seq.next_element::<StrictValue>()? {
+                    values.push(value.0);
+                }
+                Ok(StrictValue(Value::Array(values)))
+            }
+            fn visit_map<A: MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> std::result::Result<Self::Value, A::Error> {
+                let mut values = serde_json::Map::new();
+                while let Some(key) = map.next_key::<String>()? {
+                    if values.contains_key(&key) {
+                        return Err(serde::de::Error::custom("duplicate JSON field"));
+                    }
+                    values.insert(key, map.next_value::<StrictValue>()?.0);
+                }
+                Ok(StrictValue(Value::Object(values)))
+            }
+        }
+        deserializer.deserialize_any(StrictVisitor)
+    }
+}

--- a/crates/symbiote-runtime-transport/src/rpc.rs
+++ b/crates/symbiote-runtime-transport/src/rpc.rs
@@ -1,0 +1,250 @@
+//! Explicit JSON-RPC 2.0 correlation. This is not a harness compatibility claim.
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpcError {
+    InvalidLimits,
+    InvalidEnvelope,
+    InvalidMethod,
+    InvalidParams,
+    PendingLimit,
+    IdExhausted,
+    UnknownResponse,
+    UnsupportedPeerRequest,
+}
+
+/// Payloads can contain private source, prompts, and upstream error data.
+/// Deliberately no Debug implementation: never use them as default diagnostics.
+pub enum Incoming {
+    Notification {
+        method: String,
+        params: Option<Value>,
+    },
+    Response {
+        id: String,
+        outcome: Result<Value, Value>,
+    },
+}
+
+/// One connection generation. IDs never repeat within this object. A prepared
+/// request remains pending even if a write is interrupted: delivery is unknown.
+/// Do not automatically replay effectful requests after reconnect.
+pub struct RpcSession {
+    next_id: u64,
+    pending: BTreeSet<String>,
+    max_pending: usize,
+}
+
+impl RpcSession {
+    pub fn new(max_pending: usize) -> Result<Self, RpcError> {
+        if !(1..=4096).contains(&max_pending) {
+            return Err(RpcError::InvalidLimits);
+        }
+        Ok(Self {
+            next_id: 1,
+            pending: BTreeSet::new(),
+            max_pending,
+        })
+    }
+
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub fn request(&mut self, method: &str, params: Option<Value>) -> Result<Value, RpcError> {
+        validate_call(method, params.as_ref())?;
+        if self.pending.len() >= self.max_pending {
+            return Err(RpcError::PendingLimit);
+        }
+        let next = self.next_id.checked_add(1).ok_or(RpcError::IdExhausted)?;
+        let id = self.next_id.to_string();
+        let mut frame = Self::notification(method, params)?;
+        frame
+            .as_object_mut()
+            .expect("constructed object")
+            .insert("id".into(), json!(id));
+        self.pending.insert(id);
+        self.next_id = next;
+        Ok(frame)
+    }
+
+    pub fn notification(method: &str, params: Option<Value>) -> Result<Value, RpcError> {
+        validate_call(method, params.as_ref())?;
+        let mut frame = json!({"jsonrpc":"2.0", "method":method});
+        if let Some(params) = params {
+            frame
+                .as_object_mut()
+                .expect("constructed object")
+                .insert("params".into(), params);
+        }
+        Ok(frame)
+    }
+
+    /// A profile must select this exact dialect. Versionless app servers need
+    /// their own explicitly tested decoder; there is no permissive auto-detect.
+    /// Invalid responses leave pending requests intact. Duplicates are rejected
+    /// as unknown once the first valid response has consumed the ID.
+    pub fn receive(&mut self, frame: Value) -> Result<Incoming, RpcError> {
+        let object = frame.as_object().ok_or(RpcError::InvalidEnvelope)?;
+        if object.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+            return Err(RpcError::InvalidEnvelope);
+        }
+        if let Some(method) = object.get("method") {
+            if object
+                .keys()
+                .any(|key| !["jsonrpc", "method", "params", "id"].contains(&key.as_str()))
+            {
+                return Err(RpcError::InvalidEnvelope);
+            }
+            let method = method.as_str().ok_or(RpcError::InvalidMethod)?;
+            validate_call(method, object.get("params"))?;
+            if object.contains_key("id") {
+                return Err(RpcError::UnsupportedPeerRequest);
+            }
+            return Ok(Incoming::Notification {
+                method: method.to_owned(),
+                params: object.get("params").cloned(),
+            });
+        }
+        if object
+            .keys()
+            .any(|key| !["jsonrpc", "id", "result", "error"].contains(&key.as_str()))
+            || object.contains_key("result") == object.contains_key("error")
+        {
+            return Err(RpcError::InvalidEnvelope);
+        }
+        let id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or(RpcError::InvalidEnvelope)?;
+        let outcome = if let Some(error) = object.get("error") {
+            let fields = error.as_object().ok_or(RpcError::InvalidEnvelope)?;
+            if fields.get("code").and_then(Value::as_i64).is_none()
+                || fields.get("message").and_then(Value::as_str).is_none()
+                || fields
+                    .keys()
+                    .any(|key| !["code", "message", "data"].contains(&key.as_str()))
+            {
+                return Err(RpcError::InvalidEnvelope);
+            }
+            Err(error.clone())
+        } else {
+            Ok(object["result"].clone())
+        };
+        if !self.pending.remove(id) {
+            return Err(RpcError::UnknownResponse);
+        }
+        Ok(Incoming::Response {
+            id: id.to_owned(),
+            outcome,
+        })
+    }
+
+    /// Consume the generation on disconnect. These requests have unknown
+    /// delivery/effect disposition, not permission to retry them.
+    pub fn into_unresolved(self) -> Vec<String> {
+        self.pending.into_iter().collect()
+    }
+}
+
+fn validate_call(method: &str, params: Option<&Value>) -> Result<(), RpcError> {
+    if method.is_empty()
+        || method.len() > 256
+        || method.starts_with("rpc.")
+        || method.chars().any(char::is_control)
+    {
+        return Err(RpcError::InvalidMethod);
+    }
+    if params.is_some_and(|value| !value.is_object() && !value.is_array()) {
+        return Err(RpcError::InvalidParams);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reordered_responses_correlate_once_and_null_is_a_result() {
+        let mut rpc = RpcSession::new(2).unwrap();
+        let first = rpc.request("first", None).unwrap();
+        let second = rpc.request("second", Some(json!([]))).unwrap();
+        let response = json!({"jsonrpc":"2.0","id":second["id"],"result":null});
+        assert!(matches!(
+            rpc.receive(response.clone()),
+            Ok(Incoming::Response {
+                outcome: Ok(Value::Null),
+                ..
+            })
+        ));
+        assert!(matches!(
+            rpc.receive(response),
+            Err(RpcError::UnknownResponse)
+        ));
+        assert_eq!(rpc.into_unresolved(), vec![first["id"].as_str().unwrap()]);
+    }
+
+    #[test]
+    fn malformed_response_never_consumes_pending_id() {
+        let mut rpc = RpcSession::new(1).unwrap();
+        let request = rpc.request("work", None).unwrap();
+        for response in [
+            json!({"jsonrpc":"2.0","id":request["id"],"result":1,"error":null}),
+            json!({"jsonrpc":"2.0","id":request["id"],"error":{"code":"bad","message":"bad"}}),
+            json!({"id":request["id"],"result":1}),
+            json!({"jsonrpc":"2.0","id":request["id"],"result":1,"extension":true}),
+        ] {
+            assert!(matches!(
+                rpc.receive(response),
+                Err(RpcError::InvalidEnvelope)
+            ));
+            assert_eq!(rpc.pending_count(), 1);
+        }
+        assert!(matches!(
+            rpc.receive(
+                json!({"jsonrpc":"2.0","id":request["id"],"error":{"code":-1,"message":"failure"}})
+            ),
+            Ok(Incoming::Response {
+                outcome: Err(_),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn notifications_are_unconfirmed_and_peer_requests_are_explicitly_unsupported() {
+        let mut rpc = RpcSession::new(1).unwrap();
+        assert!(matches!(
+            rpc.receive(json!({"jsonrpc":"2.0","method":"event","params":{}})),
+            Ok(Incoming::Notification { .. })
+        ));
+        assert_eq!(rpc.pending_count(), 0);
+        assert!(matches!(
+            rpc.receive(json!({"jsonrpc":"2.0","method":"approve","id":1})),
+            Err(RpcError::UnsupportedPeerRequest)
+        ));
+        assert!(matches!(
+            rpc.receive(json!([])),
+            Err(RpcError::InvalidEnvelope)
+        ));
+    }
+
+    #[test]
+    fn admission_limits_fail_without_advancing_identity() {
+        assert!(matches!(RpcSession::new(0), Err(RpcError::InvalidLimits)));
+        let mut rpc = RpcSession::new(1).unwrap();
+        assert_eq!(
+            rpc.request("rpc.reserved", None),
+            Err(RpcError::InvalidMethod)
+        );
+        assert_eq!(
+            rpc.request("work", Some(Value::Null)),
+            Err(RpcError::InvalidParams)
+        );
+        assert_eq!(rpc.request("work", None).unwrap()["id"], "1");
+        assert_eq!(rpc.request("work", None), Err(RpcError::PendingLimit));
+        assert_eq!(rpc.pending_count(), 1);
+    }
+}

--- a/crates/symbiote-runtime-transport/tests/process.rs
+++ b/crates/symbiote-runtime-transport/tests/process.rs
@@ -1,0 +1,280 @@
+use serde_json::json;
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fs,
+    path::PathBuf,
+    thread,
+    time::{Duration, Instant},
+};
+use symbiote_runtime_transport::*;
+
+fn spawn(script: &str, limits: TransportLimits) -> JsonlTransport {
+    JsonlTransport::spawn(
+        SpawnSpec {
+            executable: PathBuf::from("/bin/sh"),
+            args: vec![OsString::from("-c"), OsString::from(script)],
+            cwd: std::env::temp_dir(),
+            env: BTreeMap::new(),
+        },
+        limits,
+    )
+    .unwrap()
+}
+const SECOND: Duration = Duration::from_secs(2);
+fn wait_until(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + SECOND;
+    while !condition() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(2));
+    }
+}
+
+#[test]
+fn actual_echo_has_explicit_environment_and_cwd_and_separate_stderr() {
+    let script = "printf '{\"home_empty\":%s,\"allowed\":\"%s\",\"cwd\":\"%s\"}\n' \"$(test -z \"$HOME\" && echo true || echo false)\" \"$ALLOWED\" \"$PWD\"; printf 'diagnostic only\n' >&2; exec 2>&-; while IFS= read -r line; do printf '%s\n' \"$line\"; done";
+    let mut transport = JsonlTransport::spawn(
+        SpawnSpec {
+            executable: PathBuf::from("/bin/sh"),
+            args: vec!["-c".into(), script.into()],
+            cwd: std::env::temp_dir(),
+            env: BTreeMap::from([("ALLOWED".into(), "explicit".into())]),
+        },
+        TransportLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        transport.recv(SECOND).unwrap(),
+        json!({"home_empty":true,"allowed":"explicit","cwd":std::env::temp_dir().canonicalize().unwrap()})
+    );
+    let request = json!({"method":"echo","params":{"value":"hello"}});
+    transport.send(&request, SECOND).unwrap();
+    assert_eq!(transport.recv(SECOND).unwrap(), request);
+    wait_until(|| transport.diagnostics_finished());
+    let diagnostics = transport.diagnostics();
+    assert_eq!(diagnostics.entries[0].text, "diagnostic only");
+    assert!(!format!("{diagnostics:?}").contains("diagnostic only"));
+    transport.cancel(SECOND).unwrap();
+}
+
+#[test]
+fn malformed_duplicate_nested_duplicate_and_partial_frames_fail_without_desync() {
+    for (script, expected) in [
+        ("printf 'not-json\n{}\n'", TransportError::MalformedFrame),
+        (
+            "printf '{\"id\":1,\"id\":2}\n'",
+            TransportError::MalformedFrame,
+        ),
+        (
+            "printf '{\"result\":{\"x\":1,\"x\":2}}\n'",
+            TransportError::MalformedFrame,
+        ),
+        (
+            "printf '{\"unterminated\":true}'",
+            TransportError::UnterminatedFrame,
+        ),
+    ] {
+        let mut transport = spawn(script, TransportLimits::default());
+        assert_eq!(transport.recv(SECOND), Err(expected.clone()));
+        assert_eq!(transport.recv(SECOND), Err(expected));
+    }
+}
+
+#[test]
+fn oversized_input_and_output_are_explicit_and_queues_are_bounded() {
+    let limits = TransportLimits {
+        max_frame_bytes: 16,
+        ..TransportLimits::default()
+    };
+    let mut transport = spawn("/bin/sleep 10", limits);
+    assert_eq!(
+        transport.send(&json!({"large":"x".repeat(1000)}), SECOND),
+        Err(TransportError::FrameTooLarge)
+    );
+    transport.cancel(SECOND).unwrap();
+    let mut oversized = spawn(
+        "printf '{\"value\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}\n'",
+        limits,
+    );
+    assert_eq!(oversized.recv(SECOND), Err(TransportError::FrameTooLarge));
+    let mut flooded = spawn(
+        "i=0; while [ $i -lt 10 ]; do printf '{}\n'; i=$((i+1)); done",
+        TransportLimits {
+            frame_queue_capacity: 1,
+            ..TransportLimits::default()
+        },
+    );
+    wait_until(|| flooded.failure().is_some());
+    assert_eq!(
+        flooded.recv(SECOND),
+        Err(TransportError::FrameQueueOverflow)
+    );
+}
+
+#[test]
+fn receive_deadline_is_nonfatal_and_stdin_backpressure_cannot_hang() {
+    let mut delayed = spawn(
+        "/bin/sleep 0.1; printf '{}\n'; /bin/sleep 1",
+        TransportLimits::default(),
+    );
+    assert_eq!(
+        delayed.recv(Duration::from_millis(5)),
+        Err(TransportError::DeadlineExceeded)
+    );
+    assert_eq!(delayed.recv(SECOND).unwrap(), json!({}));
+    let mut blocked = spawn(
+        "/bin/sleep 10",
+        TransportLimits {
+            max_frame_bytes: 1_048_576,
+            ..TransportLimits::default()
+        },
+    );
+    let start = Instant::now();
+    let result = blocked.send(&json!("x".repeat(524288)), Duration::from_secs(1));
+    assert_eq!(result, Err(TransportError::PartialFrameWrite));
+    assert!(start.elapsed() < Duration::from_secs(2));
+    assert_eq!(
+        blocked.send(&json!({}), SECOND),
+        Err(TransportError::PartialFrameWrite)
+    );
+    blocked.cancel(SECOND).unwrap();
+}
+
+#[test]
+fn diagnostics_have_bounded_lines_and_loss_is_visible() {
+    let mut transport = spawn(
+        "printf 'longdiagnostic\na\nb\nc\n' >&2; exec 2>&-; /bin/sleep 1",
+        TransportLimits {
+            max_diagnostic_bytes: 4,
+            diagnostic_queue_capacity: 4,
+            ..TransportLimits::default()
+        },
+    );
+    wait_until(|| transport.diagnostics_finished());
+    let first = transport.diagnostics();
+    assert_eq!(first.entries.len(), 4);
+    assert!(first.entries[0].truncated);
+    assert_eq!(first.entries[0].text, "long");
+    let mut overflow = spawn(
+        "printf 'a\nb\nc\n' >&2; exec 2>&-; /bin/sleep 1",
+        TransportLimits {
+            diagnostic_queue_capacity: 1,
+            ..TransportLimits::default()
+        },
+    );
+    wait_until(|| overflow.diagnostics_finished());
+    let second = overflow.diagnostics();
+    assert_eq!(second.entries.len(), 1);
+    assert_eq!(second.dropped, 2);
+    let mut invalid = spawn(
+        "printf '\\377\\377\\377\\377\\n' >&2",
+        TransportLimits {
+            max_diagnostic_bytes: 4,
+            ..TransportLimits::default()
+        },
+    );
+    wait_until(|| invalid.diagnostics_finished());
+    let third = invalid.diagnostics();
+    assert!(third.entries[0].text.len() <= 4);
+    assert!(third.entries[0].truncated);
+}
+
+fn live(pid: u32) -> bool {
+    fs::read_to_string(format!("/proc/{pid}/stat"))
+        .ok()
+        .and_then(|stat| {
+            stat.rsplit_once(')')
+                .map(|(_, tail)| tail.trim_start().starts_with('Z'))
+        })
+        .is_some_and(|zombie| !zombie)
+}
+fn group_members(group: u32) -> Vec<u32> {
+    fs::read_dir("/proc")
+        .unwrap()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            let stat = fs::read_to_string(entry.path().join("stat")).ok()?;
+            let (_, tail) = stat.rsplit_once(')')?;
+            let fields: Vec<_> = tail.split_whitespace().collect();
+            (fields.get(2)?.parse::<u32>().ok()? == group && live(pid)).then_some(pid)
+        })
+        .collect()
+}
+#[test]
+fn cancellation_and_drop_terminate_owned_unescaped_process_groups() {
+    for explicit in [true, false] {
+        let mut transport = spawn(
+            "/bin/sh -c '/bin/sleep 10 & wait' & printf '{}\n'; wait",
+            TransportLimits::default(),
+        );
+        transport.recv(SECOND).unwrap();
+        let group = transport.child_id();
+        let deadline = Instant::now() + SECOND;
+        let members = loop {
+            let members = group_members(group);
+            if members.len() >= 3 {
+                break members;
+            }
+            assert!(Instant::now() < deadline);
+            thread::sleep(Duration::from_millis(5));
+        };
+        if explicit {
+            let report = transport.cancel(SECOND).unwrap();
+            assert!(report.exit.signal.is_some());
+            assert_eq!(report.group_signal, GroupSignalStatus::Sent);
+            assert_eq!(report.descendant_cleanup, DescendantCleanup::Unknown);
+        }
+        drop(transport);
+        let deadline = Instant::now() + SECOND;
+        while members.iter().copied().any(live) {
+            assert!(Instant::now() < deadline);
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+}
+
+#[test]
+fn child_exit_and_closed_transport_are_distinct_from_frames() {
+    let mut transport = spawn("printf '{}\n'; exit 7", TransportLimits::default());
+    assert_eq!(transport.recv(SECOND).unwrap(), json!({}));
+    let deadline = Instant::now() + SECOND;
+    while transport.try_wait().unwrap().is_none() {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert_eq!(
+        transport.recv(SECOND),
+        Err(TransportError::ProcessExited(ProcessExit {
+            code: Some(7),
+            signal: None
+        }))
+    );
+    let report = transport.cancel(SECOND).unwrap();
+    assert_eq!(report.group_signal, GroupSignalStatus::LeaderAlreadyReaped);
+    assert_eq!(report.descendant_cleanup, DescendantCleanup::Unknown);
+    assert_eq!(transport.recv(SECOND), Err(TransportError::Closed));
+}
+
+#[test]
+fn already_reaped_leader_reports_unknown_while_unescaped_child_survives() {
+    let mut transport = spawn(
+        "/bin/sleep 3 >/dev/null 2>&1 & printf '{}\n'; exit 0",
+        TransportLimits::default(),
+    );
+    transport.recv(SECOND).unwrap();
+    let group = transport.child_id();
+    wait_until(|| transport.try_wait().unwrap().is_some());
+    let survivors = group_members(group);
+    assert!(!survivors.is_empty());
+    let report = transport.cancel(SECOND).unwrap();
+    assert_eq!(report.group_signal, GroupSignalStatus::LeaderAlreadyReaped);
+    assert_eq!(report.descendant_cleanup, DescendantCleanup::Unknown);
+    assert!(survivors.iter().copied().any(live));
+    // The fixed child exits by itself. No stale group/PID is signalled by cleanup.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while survivors.iter().copied().any(live) {
+        assert!(Instant::now() < deadline);
+        thread::sleep(Duration::from_millis(5));
+    }
+}

--- a/crates/symbiote-runtime-transport/tests/rpc_process.rs
+++ b/crates/symbiote-runtime-transport/tests/rpc_process.rs
@@ -1,0 +1,59 @@
+use serde_json::json;
+use std::{collections::BTreeMap, time::Duration};
+use symbiote_runtime_transport::{
+    JsonlTransport, SpawnSpec, TransportLimits,
+    rpc::{Incoming, RpcError, RpcSession},
+};
+
+#[test]
+fn actual_process_reorders_replies_without_repeating_completion() {
+    let code = r#"
+import json, sys
+first = json.loads(sys.stdin.readline())
+second = json.loads(sys.stdin.readline())
+print(json.dumps({'jsonrpc':'2.0','method':'progress','params':{'step':1}}), flush=True)
+for request in [second, first, second]:
+    print(json.dumps({'jsonrpc':'2.0','id':request['id'],'result':request['method']}), flush=True)
+"#;
+    let mut transport = JsonlTransport::spawn(
+        SpawnSpec {
+            executable: "/usr/bin/python3".into(),
+            args: vec!["-I".into(), "-u".into(), "-c".into(), code.into()],
+            cwd: std::env::current_dir().unwrap(),
+            env: BTreeMap::new(),
+        },
+        TransportLimits::default(),
+    )
+    .unwrap();
+    let mut rpc = RpcSession::new(2).unwrap();
+    let mut ids = Vec::new();
+    for method in ["first", "second"] {
+        let request = rpc.request(method, None).unwrap();
+        ids.push(request["id"].as_str().unwrap().to_owned());
+        transport.send(&request, Duration::from_secs(2)).unwrap();
+    }
+    let event = transport.recv(Duration::from_secs(2)).unwrap();
+    assert!(matches!(
+        rpc.receive(event),
+        Ok(Incoming::Notification { .. })
+    ));
+    for (expected, expected_id) in ["second", "first"].into_iter().zip(ids.into_iter().rev()) {
+        let response = transport.recv(Duration::from_secs(2)).unwrap();
+        match rpc.receive(response).unwrap() {
+            Incoming::Response {
+                id,
+                outcome: Ok(result),
+            } => {
+                assert_eq!(id, expected_id);
+                assert_eq!(result, json!(expected));
+            }
+            _ => panic!("expected correlated response"),
+        }
+    }
+    let duplicate = transport.recv(Duration::from_secs(2)).unwrap();
+    assert!(matches!(
+        rpc.receive(duplicate),
+        Err(RpcError::UnknownResponse)
+    ));
+    assert!(rpc.into_unresolved().is_empty());
+}

--- a/docs/contracts/runtime-transport.md
+++ b/docs/contracts/runtime-transport.md
@@ -1,0 +1,31 @@
+# Local structured transport
+
+Owner: [#185](https://github.com/RepairYourTech/SymbioteIDE/issues/185), consuming the foundational Host lifecycle and runtime SDK contracts from #180/#184. This is a local subprocess substrate. It is not a complete harness pack, sandbox, or production agent activation path.
+
+`symbiote-runtime-transport` provides newline-delimited JSON process I/O with explicit executable, arguments, working directory and environment. The parent environment is not implicitly inherited. Callers must supply an authorized launch configuration; the library does not turn a file path or executable presence into trust or permission. Never put credentials in command-line arguments.
+
+Stdout carries structured frames; stderr is a separate diagnostic channel. Both must remain bounded even for a stalled consumer or hostile child. Transport decoding does not make an upstream tool request authorized, a worker completion request successful, or a reported usage/capability fact verified. The canonical Host remains responsible for those decisions.
+
+`TransportLimits` defaults to 64 KiB per frame, 32 queued frames, 32 diagnostics and 4096 bytes per diagnostic. Invalid JSON, duplicate object keys (including nested keys), unterminated frames, oversized stdout and a full frame queue produce a sticky failure. A partial stdin write also faults the connection so later frames cannot append to an incomplete message. A receive timeout is nonfatal. Stderr retains a bounded recent window, exposes truncation and dropped-entry counts, and redacts text from `Debug`; explicitly reading its text requires the caller's privacy policy. Final decoded diagnostic text remains subject to the byte limit even when invalid UTF-8 requires replacement characters.
+
+The Unix implementation starts a new process group and uses nonblocking pipes. `cancel` returns a `CancelReport` separating root exit from the group signal status. Descendant cleanup remains `Unknown`: a worker can escape a group, and once `try_wait` has reaped the leader, safely signalling that original numeric group is no longer possible because its ID may be reused. The library skips that unsafe signal and reports `LeaderAlreadyReaped`. `Drop` attempts bounded cleanup but cannot certify it. This is why the Host does not yet activate untrusted workers through this library. Tests prove cancellation of the controlled, unescaped fixture group while its leader is still owned; they do not prove complete containment. Linux is the tested platform; macOS and Windows evidence is pending.
+
+## RPC correlation
+
+`rpc::RpcSession` is an opt-in, strict subset of [JSON-RPC 2.0](https://www.jsonrpc.org/specification). It creates monotonically increasing string request IDs, bounds the number of outstanding requests and correlates responses independently of arrival order. A response consumes an ID only after envelope validation. Unknown or duplicate response IDs fail. Notifications have no response guarantee.
+
+This subset requires the explicit `jsonrpc: "2.0"` version field, object/array parameters, string response IDs, a single response result or error, and no unknown envelope fields. Batch messages and peer-initiated requests are explicitly unsupported. It does not claim compatibility with versionless app-server envelopes, Codex, or ACP. Those need independently tested pack-specific codecs and capability negotiation; no permissive dialect guessing occurs.
+
+A request is tracked before the caller writes it. An interrupted write leaves its delivery and effects unknown. Consuming a disconnected `RpcSession` returns unresolved IDs for the owning adapter to reconcile; notifications are not tracked. This is not durable replay or permission to retry. The owner must retire the old connection before creating a new generation. Raw response/notification payloads may include source and prompts and deliberately do not implement `Debug`. RPC correlation accepts already decoded `Value` objects; raw frame size, nesting and duplicate-key admission belong to the transport decoder.
+
+## Verification and remaining acceptance
+
+Run `cargo test -p symbiote-runtime-transport` for the deterministic local fixture suite and `cargo test --workspace --locked` for integration with the existing contracts. These tests do not perform inference, consume Codex authentication, or require credentials.
+
+`cargo run -p symbiote-runtime-transport --example jsonl_probe` performs a real subprocess round trip through `/bin/cat` and cancels/reaps that fixture. Its output reports transport proof only; it is not the first-release coding task demonstration.
+
+Independent review reproduced two boundary failures and drove fixes: UTF-8 replacement could expand a diagnostic beyond its configured limit, and a root exit alone could obscure surviving descendants after leader reaping. Regression fixtures cover the decoded byte bound and explicit cancellation uncertainty. Separate RPC review tightened the real-process reordered-response fixture to assert both returned IDs and results.
+
+The transport does not yet implement the SDK `AgentRuntimeAdapter` or the Host activation journal. Complete process-tree containment, Host-crash cleanup, durable reconnect/effect reconciliation, heartbeats, remote Hosts, in-process SDKs, ACP, structured CLI conventions, PTY fallback, real Codex/native integrations and cross-platform evidence remain pending under #185 and their canonical dependencies. No issue closure or release readiness is implied. #218 owns preventive sandbox enforcement before untrusted worker activation.
+
+There is no persistent schema or data migration. Rollback removes this additive library from consumers; never automatically replay unresolved requests when changing versions. Accessibility is not applicable to this headless library; the production client retains its accessibility obligations. Performance evidence here concerns bounded buffers and deadlines, not the whole-process resource budgets required by #38.

--- a/docs/engineering-handoff.md
+++ b/docs/engineering-handoff.md
@@ -1,5 +1,13 @@
 # Engineering handoff
 
+## Local structured runtime transport — 2026-09-08 UTC
+
+Change Stream `issue-185-transport` starts from merged #476 at `d7b1391b0e03e861a168e915c0602be681e3b83d`. Owner #185 consumes the #180/#184 foundational contracts. This batch adds a process-backed local JSONL substrate and separate strict JSON-RPC 2.0 response correlation. It does not expose a Host worker activation endpoint or certify Codex/ACP compatibility.
+
+Independent review separates process supervision/framing from RPC correlation. See `docs/contracts/runtime-transport.md` for the actual guarantees, fixture commands and remaining acceptance. Broad #185 remains open for the other substrates, real packs, complete containment and recovery. The full native/Codex first release and persistent build goal remain incomplete.
+
+Next dependency-ready work: #214 versioned agent environment/resource desired-state contracts before #187 native configuration projection; #189 request/objective/capability/plan hierarchy can consume existing #36/#43/#181 foundations independently. Activation still requires the #174 → #191 → #218 trust/threat/enforcement chain. A successful process fixture supplies no sandbox or credential authority.
+
 ## Runtime SDK foundation — 2026-09-08 UTC
 
 Change Stream `issue-184-runtime-sdk` starts from merged #475 at `c1b7f2f6d7adcbe7c50377d1ff9e990b11019ebe`. Owners #184/#464 consume the reviewed #181/#36 contracts. `symbiote-runtime-sdk` separates agent-loop adapters from inference providers, qualifies immutable dispatches against current identity-bound capability/control evidence, and defines bounded session events and native/external auth/billing checks.


### PR DESCRIPTION
Add a local process-backed JSONL transport so runtime packs can share bounded pipes, deadlines, stderr separation and explicit failure handling. A separate strict JSON-RPC 2.0 codec tracks pending requests without silently replaying interrupted work; an actual-process fixture verifies reordered and duplicate responses.

Cancellation reports the root exit and group-signal status separately, with descendant cleanup explicitly unknown. Independent review reproduced and fixed UTF-8 diagnostic expansion and ambiguous cleanup reporting. This is a foundational slice of #185, not a real Codex/ACP adapter or an enabled Host worker path. Complete containment, durable recovery, other substrates and real native/Codex execution remain pending.

Validation: workspace tests, strict all-target Clippy, formatting, actual subprocess regression fixtures and the runnable `jsonl_probe` example. CI checks the containing head on Rust 1.85 and stable. Separate reviewers own RPC/example documentation and process/framing correctness; review findings are integrated before merge.

No data migration or credential/billing changes. See `docs/contracts/runtime-transport.md` for guarantees, reproduction and remaining acceptance. Relates to #185; does not close it.
