### PR TITLE
feat(config): reconcile and publish inactive profile generations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,10 +46,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fallible-iterator"
@@ -59,6 +103,32 @@ name = "find-msvc-tools"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -248,6 +318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +378,18 @@ dependencies = [
  "symbiote-domain",
  "symbiote-protocol",
  "symbiote-store",
+]
+
+[[package]]
+name = "symbiote-projection"
+version = "0.1.0"
+dependencies = [
+ "nix",
+ "serde",
+ "serde_json",
+ "sha2",
+ "symbiote-config",
+ "toml_edit",
 ]
 
 [[package]]
@@ -350,6 +443,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +483,21 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport"]
+members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The [local runtime transport](docs/contracts/runtime-transport.md) adds bounded 
 
 [Agent environments](docs/contracts/agent-environment.md) describe portable resource intent and resolve Role/profile settings before native configuration is projected. Host permission and credential gates remain separate from read-only configuration resolution.
 
+[Configuration projection](docs/contracts/projection.md) now reconciles managed TOML keys and publishes verifiable inactive profile generations while preserving existing profiles. Actual harness activation and reload verification remain pending.
+
 ```sh
 cargo test --workspace --locked
 cargo clippy --workspace --all-targets --locked -- -D warnings

--- a/crates/symbiote-projection/Cargo.toml
+++ b/crates/symbiote-projection/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "symbiote-projection"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+symbiote-config = { path = "../symbiote-config" }
+serde.workspace = true
+serde_json.workspace = true
+toml_edit = "=0.22.27"
+nix = { version = "=0.30.1", features = ["fs", "dir", "user"] }
+sha2 = "=0.10.9"
+
+[lints]
+workspace = true

--- a/crates/symbiote-projection/examples/projection_demo.rs
+++ b/crates/symbiote-projection/examples/projection_demo.rs
@@ -1,0 +1,29 @@
+//! A deterministic inactive profile publication; no real harness configuration.
+use std::{collections::BTreeMap, path::Path};
+use symbiote_projection::{generation, toml::*};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        return Err("usage: projection_demo PRIVATE_ROOT NEW_GENERATION".into());
+    }
+    let base = "enabled = false\nuser_setting = 1\n";
+    let actual = "# user comment\nenabled = false # retain\nuser_setting = 2\n";
+    let plan = plan(
+        base,
+        actual,
+        &[ManagedChange {
+            path: vec!["enabled".into()],
+            before: Some(PrimitiveValue::Boolean(false)),
+            desired: Some(PrimitiveValue::Boolean(true)),
+            ownership: ManagedOwnership::SymbioteManaged,
+        }],
+    )?;
+    let files = BTreeMap::from([("config.toml".into(), plan.candidate.into_bytes())]);
+    let receipt = generation::publish(Path::new(&args[0]), &args[1], &files)?;
+    assert_eq!(generation::verify(Path::new(&args[0]), &args[1])?, receipt);
+    println!(
+        "Verified an inactive fixture generation with one TOML file. User comments and unmanaged edits are preserved. No runtime was activated."
+    );
+    Ok(())
+}

--- a/crates/symbiote-projection/src/generation.rs
+++ b/crates/symbiote-projection/src/generation.rs
@@ -1,0 +1,323 @@
+//! Immutable generation publication. Hashes detect drift, not malicious same-user rewriting.
+//! No activation, in-place replacement, cleanup or runtime launch is performed here.
+use nix::{
+    dir::Dir,
+    fcntl::{OFlag, open, openat},
+    sys::stat::{Mode, SFlag, fstat, mkdirat},
+    unistd::geteuid,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    fs::File,
+    io::{Read, Write},
+    os::fd::AsFd,
+    path::{Component, Path, PathBuf},
+};
+
+const MAX_FILE: usize = 1_048_576;
+const MAX_TOTAL: usize = 4 * MAX_FILE;
+const MAX_FILES: usize = 16;
+const MAX_MANIFEST: usize = 16_384;
+const MANIFEST: &str = ".manifest.json";
+const READY: &str = ".ready";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenerationError {
+    InvalidInput,
+    UnsafePath,
+    AlreadyExists,
+    Incomplete,
+    IntegrityMismatch,
+    BoundsExceeded,
+    Io,
+}
+impl fmt::Display for GenerationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "projection generation rejected: {self:?}")
+    }
+}
+impl std::error::Error for GenerationError {}
+pub type Result<T> = std::result::Result<T, GenerationError>;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct FileReceipt {
+    pub bytes: u64,
+    pub sha256: String,
+}
+impl fmt::Debug for FileReceipt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileReceipt")
+            .field("bytes", &self.bytes)
+            .finish_non_exhaustive()
+    }
+}
+#[derive(Clone, PartialEq, Eq)]
+pub struct Receipt {
+    pub generation: String,
+    pub files: BTreeMap<String, FileReceipt>,
+}
+impl fmt::Debug for Receipt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Receipt")
+            .field("file_count", &self.files.len())
+            .finish_non_exhaustive()
+    }
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    version: u32,
+    generation: String,
+    files: Vec<Record>,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    name: String,
+    bytes: u64,
+    sha256: String,
+}
+
+fn name_valid(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 128
+        && name.as_bytes()[0].is_ascii_alphanumeric()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+}
+fn hash(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+fn directory_flags() -> OFlag {
+    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+}
+
+fn check_private(fd: &impl AsFd, directory: bool) -> Result<()> {
+    let stat = fstat(fd).map_err(|_| GenerationError::Io)?;
+    let kind = if directory {
+        SFlag::S_IFDIR
+    } else {
+        SFlag::S_IFREG
+    };
+    let mode = if directory { 0o700 } else { 0o600 };
+    if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != kind
+        || stat.st_uid != geteuid().as_raw()
+        || stat.st_mode & 0o7777 != mode
+        || (!directory && stat.st_nlink != 1)
+    {
+        return Err(GenerationError::UnsafePath);
+    }
+    Ok(())
+}
+
+// Resolve each component against a pinned directory fd; no canonicalize/check/open race.
+fn root_directory(path: &Path) -> Result<File> {
+    let path: PathBuf = if path.is_absolute() {
+        path.into()
+    } else {
+        std::env::current_dir()
+            .map_err(|_| GenerationError::Io)?
+            .join(path)
+    };
+    let mut fd = open(Path::new("/"), directory_flags(), Mode::empty())
+        .map_err(|_| GenerationError::UnsafePath)?;
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(name) => {
+                fd = openat(&fd, name, directory_flags(), Mode::empty())
+                    .map_err(|_| GenerationError::UnsafePath)?;
+            }
+            _ => return Err(GenerationError::UnsafePath),
+        }
+    }
+    check_private(&fd, true)?;
+    Ok(File::from(fd))
+}
+fn generation_directory(root: &File, generation: &str) -> Result<File> {
+    let fd = openat(root, generation, directory_flags(), Mode::empty())
+        .map_err(|_| GenerationError::UnsafePath)?;
+    check_private(&fd, true)?;
+    Ok(File::from(fd))
+}
+fn write_new(directory: &File, name: &str, bytes: &[u8]) -> Result<()> {
+    let fd = openat(
+        directory,
+        name,
+        OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::S_IRUSR | Mode::S_IWUSR,
+    )
+    .map_err(|_| GenerationError::Io)?;
+    check_private(&fd, false)?;
+    let mut file = File::from(fd);
+    file.write_all(bytes).map_err(|_| GenerationError::Io)?;
+    file.sync_all().map_err(|_| GenerationError::Io)
+}
+fn read_file(directory: &File, name: &str, limit: usize) -> Result<Vec<u8>> {
+    let fd = openat(
+        directory,
+        name,
+        OFlag::O_RDONLY | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|_| GenerationError::IntegrityMismatch)?;
+    check_private(&fd, false)?;
+    let stat = fstat(&fd).map_err(|_| GenerationError::Io)?;
+    if stat.st_size < 0 || stat.st_size as u64 > limit as u64 {
+        return Err(GenerationError::BoundsExceeded);
+    }
+    let mut bytes = Vec::new();
+    File::from(fd)
+        .take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| GenerationError::Io)?;
+    if bytes.len() > limit {
+        return Err(GenerationError::BoundsExceeded);
+    }
+    Ok(bytes)
+}
+
+/// Publishes a fresh generation; even identical retries never overwrite an existing directory.
+/// Errors preserve the directory for inspection. After readiness creation an
+/// error may leave a verifiable generation with uncertain durability; reconcile
+/// using `verify` without assuming either rollback or successful publication.
+pub fn publish(
+    root: &Path,
+    generation: &str,
+    files: &BTreeMap<String, Vec<u8>>,
+) -> Result<Receipt> {
+    if !name_valid(generation) || files.keys().any(|name| !name_valid(name)) {
+        return Err(GenerationError::InvalidInput);
+    }
+    if files.len() > MAX_FILES
+        || files.values().any(|bytes| bytes.len() > MAX_FILE)
+        || files.values().map(Vec::len).sum::<usize>() > MAX_TOTAL
+    {
+        return Err(GenerationError::BoundsExceeded);
+    }
+    let root = root_directory(root)?;
+    mkdirat(&root, generation, Mode::S_IRWXU).map_err(|error| {
+        if error == nix::errno::Errno::EEXIST {
+            GenerationError::AlreadyExists
+        } else {
+            GenerationError::Io
+        }
+    })?;
+    let directory = generation_directory(&root, generation)?;
+    let mut records = Vec::new();
+    let mut receipts = BTreeMap::new();
+    for (name, bytes) in files {
+        write_new(&directory, name, bytes)?;
+        let sha256 = hash(bytes);
+        records.push(Record {
+            name: name.clone(),
+            bytes: bytes.len() as u64,
+            sha256: sha256.clone(),
+        });
+        receipts.insert(
+            name.clone(),
+            FileReceipt {
+                bytes: bytes.len() as u64,
+                sha256,
+            },
+        );
+    }
+    directory.sync_all().map_err(|_| GenerationError::Io)?;
+    let manifest = serde_json::to_vec(&Manifest {
+        version: 1,
+        generation: generation.into(),
+        files: records,
+    })
+    .map_err(|_| GenerationError::Io)?;
+    if manifest.len() > MAX_MANIFEST {
+        return Err(GenerationError::BoundsExceeded);
+    }
+    write_new(&directory, MANIFEST, &manifest)?;
+    directory.sync_all().map_err(|_| GenerationError::Io)?;
+    write_new(&directory, READY, hash(&manifest).as_bytes())?;
+    directory.sync_all().map_err(|_| GenerationError::Io)?;
+    root.sync_all().map_err(|_| GenerationError::Io)?;
+    Ok(Receipt {
+        generation: generation.into(),
+        files: receipts,
+    })
+}
+
+/// Verifies readiness, private permissions, exact entry set, lengths and content hashes.
+/// A successful observation is not a lock against later writes by the same OS user.
+pub fn verify(root: &Path, generation: &str) -> Result<Receipt> {
+    if !name_valid(generation) {
+        return Err(GenerationError::InvalidInput);
+    }
+    let root = root_directory(root)?;
+    let directory = generation_directory(&root, generation)?;
+    let mut entries = Dir::openat(&directory, ".", directory_flags(), Mode::empty())
+        .map_err(|_| GenerationError::Io)?;
+    let mut names = BTreeSet::new();
+    for entry in entries.iter() {
+        let entry = entry.map_err(|_| GenerationError::Io)?;
+        let name = entry
+            .file_name()
+            .to_str()
+            .map_err(|_| GenerationError::IntegrityMismatch)?;
+        if matches!(name, "." | "..") {
+            continue;
+        }
+        names.insert(name.to_owned());
+        if names.len() > MAX_FILES + 2 {
+            return Err(GenerationError::BoundsExceeded);
+        }
+    }
+    if !names.contains(READY) || !names.contains(MANIFEST) {
+        return Err(GenerationError::Incomplete);
+    }
+    let manifest_bytes = read_file(&directory, MANIFEST, MAX_MANIFEST)?;
+    if read_file(&directory, READY, 64)? != hash(&manifest_bytes).as_bytes() {
+        return Err(GenerationError::IntegrityMismatch);
+    }
+    let manifest: Manifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|_| GenerationError::IntegrityMismatch)?;
+    if manifest.version != 1
+        || manifest.generation != generation
+        || manifest.files.len() > MAX_FILES
+    {
+        return Err(GenerationError::IntegrityMismatch);
+    }
+    let mut expected = BTreeSet::from([MANIFEST.to_owned(), READY.to_owned()]);
+    let mut total = 0_u64;
+    let mut files = BTreeMap::new();
+    for record in manifest.files {
+        if !name_valid(&record.name) || !expected.insert(record.name.clone()) {
+            return Err(GenerationError::IntegrityMismatch);
+        }
+        if record.bytes > MAX_FILE as u64 {
+            return Err(GenerationError::BoundsExceeded);
+        }
+        total += record.bytes;
+        if total > MAX_TOTAL as u64 {
+            return Err(GenerationError::BoundsExceeded);
+        }
+        let bytes = read_file(&directory, &record.name, MAX_FILE)?;
+        if bytes.len() as u64 != record.bytes || hash(&bytes) != record.sha256 {
+            return Err(GenerationError::IntegrityMismatch);
+        }
+        files.insert(
+            record.name,
+            FileReceipt {
+                bytes: record.bytes,
+                sha256: record.sha256,
+            },
+        );
+    }
+    if expected != names {
+        return Err(GenerationError::IntegrityMismatch);
+    }
+    Ok(Receipt {
+        generation: generation.into(),
+        files,
+    })
+}

--- a/crates/symbiote-projection/src/lib.rs
+++ b/crates/symbiote-projection/src/lib.rs
@@ -1,0 +1,125 @@
+//! Pure desired-state preparation followed by optional inactive profile publication.
+//! This crate does not authorize resource activation or discover native config paths.
+pub mod generation;
+pub mod toml;
+
+use std::collections::{BTreeMap, BTreeSet};
+use symbiote_config::environment::{EffectiveEnvironment, EnvironmentResource, Requirement};
+use toml::ManagedChange;
+
+/// A pack's explicit native-file mapping. Metadata alone is not a compatibility proof.
+pub struct TomlDeclaration {
+    pub resource: EnvironmentResource,
+    pub filename: String,
+    pub changes: Vec<ManagedChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreparationError {
+    BlockedEnvironment,
+    IneligibleResource,
+    MissingInput,
+    MissingMapping,
+    LimitExceeded,
+    Reconciliation(toml::ProjectionError),
+}
+
+pub struct PreparedFiles {
+    files: BTreeMap<String, Vec<u8>>,
+}
+impl PreparedFiles {
+    /// Private configuration content: do not log or serialize without consent.
+    pub fn files(&self) -> &BTreeMap<String, Vec<u8>> {
+        &self.files
+    }
+}
+
+/// Combine explicit pack mappings with eligible environment intent. Inputs are
+/// private, non-credential configuration supplied by the owning pack. No native
+/// paths are inferred, and no file is read or written by this function.
+pub fn prepare_toml(
+    environment: &EffectiveEnvironment,
+    baselines: &BTreeMap<String, String>,
+    current: &BTreeMap<String, String>,
+    declarations: &[TomlDeclaration],
+) -> Result<PreparedFiles, PreparationError> {
+    if !environment.blockers.is_empty() {
+        return Err(PreparationError::BlockedEnvironment);
+    }
+    if declarations.len() > 128 {
+        return Err(PreparationError::LimitExceeded);
+    }
+    let mut grouped: BTreeMap<String, Vec<ManagedChange>> = BTreeMap::new();
+    let mut mapped = BTreeSet::new();
+    let mut change_count = 0usize;
+    let mut value_bytes = 0usize;
+    for declaration in declarations {
+        if !environment
+            .resources
+            .get(&declaration.resource.id)
+            .is_some_and(|resource| {
+                resource.is_eligible() && resource.resource == declaration.resource
+            })
+        {
+            return Err(PreparationError::IneligibleResource);
+        }
+        if declaration.changes.len() > 128 || declaration.filename.len() > 128 {
+            return Err(PreparationError::LimitExceeded);
+        }
+        if declaration.changes.is_empty() {
+            return Err(PreparationError::MissingMapping);
+        }
+        change_count += declaration.changes.len();
+        if change_count > 1024 {
+            return Err(PreparationError::LimitExceeded);
+        }
+        for change in &declaration.changes {
+            if change.path.len() > 16 || change.path.iter().any(|part| part.len() > 128) {
+                return Err(PreparationError::LimitExceeded);
+            }
+            for value in [&change.before, &change.desired] {
+                if let Some(toml::PrimitiveValue::String(value)) = value {
+                    value_bytes = value_bytes
+                        .checked_add(value.len())
+                        .ok_or(PreparationError::LimitExceeded)?;
+                    if value_bytes > 1_048_576 {
+                        return Err(PreparationError::LimitExceeded);
+                    }
+                }
+            }
+        }
+        mapped.insert(&declaration.resource.id);
+        grouped
+            .entry(declaration.filename.clone())
+            .or_default()
+            .extend(declaration.changes.clone());
+    }
+    if environment.resources.iter().any(|(id, resource)| {
+        resource.resource.requirement == Requirement::Required && !mapped.contains(id)
+    }) {
+        return Err(PreparationError::MissingMapping);
+    }
+    if grouped.len() > 16 {
+        return Err(PreparationError::LimitExceeded);
+    }
+    let mut files = BTreeMap::new();
+    let mut total = 0usize;
+    for (filename, changes) in grouped {
+        let baseline = baselines
+            .get(&filename)
+            .ok_or(PreparationError::MissingInput)?;
+        let actual = current
+            .get(&filename)
+            .ok_or(PreparationError::MissingInput)?;
+        let plan =
+            toml::plan(baseline, actual, &changes).map_err(PreparationError::Reconciliation)?;
+        total = total
+            .checked_add(plan.candidate.len())
+            .ok_or(PreparationError::LimitExceeded)?;
+        if total > 4 * 1_048_576 {
+            return Err(PreparationError::LimitExceeded);
+        }
+        files.insert(filename, plan.candidate.into_bytes());
+    }
+    Ok(PreparedFiles { files })
+}

--- a/crates/symbiote-projection/src/toml.rs
+++ b/crates/symbiote-projection/src/toml.rs
@@ -1,0 +1,243 @@
+//! Pure reconciliation of explicitly owned primitive TOML keys.
+use std::fmt;
+use std::fmt::Write;
+use toml_edit::{DocumentMut, Item, Table, Value};
+
+const MAX_BYTES: usize = 1_048_576;
+
+struct BoundedOutput(String);
+impl fmt::Write for BoundedOutput {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        if value.len() > MAX_BYTES.saturating_sub(self.0.len()) {
+            return Err(fmt::Error);
+        }
+        self.0.push_str(value);
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum PrimitiveValue {
+    String(String),
+    Boolean(bool),
+    Integer(i64),
+}
+impl fmt::Debug for PrimitiveValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PrimitiveValue([redacted])")
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedOwnership {
+    SymbioteManaged,
+    Unmanaged,
+}
+#[derive(Clone, PartialEq, Eq)]
+pub struct ManagedChange {
+    pub path: Vec<String>,
+    pub before: Option<PrimitiveValue>,
+    pub desired: Option<PrimitiveValue>,
+    pub ownership: ManagedOwnership,
+}
+impl fmt::Debug for ManagedChange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ManagedChange([redacted])")
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectionError {
+    LimitExceeded,
+    MalformedToml,
+    InvalidPath,
+    OverlappingPaths,
+    UnmanagedKey,
+    BaselineMismatch,
+    ConcurrentEdit,
+    UnsupportedValue,
+    UnsupportedCommentedDeletion,
+}
+impl fmt::Display for ProjectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TOML reconciliation refused")
+    }
+}
+impl std::error::Error for ProjectionError {}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SemanticDiff {
+    pub path: Vec<String>,
+    pub before: Option<PrimitiveValue>,
+    pub after: Option<PrimitiveValue>,
+}
+impl fmt::Debug for SemanticDiff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SemanticDiff([redacted])")
+    }
+}
+#[derive(Clone, PartialEq, Eq)]
+pub struct TomlPlan {
+    pub candidate: String,
+    pub diffs: Vec<SemanticDiff>,
+}
+impl fmt::Debug for TomlPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TomlPlan")
+            .field("candidate", &"[redacted]")
+            .field("diff_count", &self.diffs.len())
+            .finish()
+    }
+}
+
+fn read(table: &Table, path: &[String]) -> Result<Option<PrimitiveValue>, ProjectionError> {
+    let Some(item) = table.get(&path[0]) else {
+        return Ok(None);
+    };
+    if path.len() > 1 {
+        return read(
+            item.as_table().ok_or(ProjectionError::UnsupportedValue)?,
+            &path[1..],
+        );
+    }
+    match item.as_value() {
+        Some(Value::String(value)) => Ok(Some(PrimitiveValue::String(value.value().clone()))),
+        Some(Value::Boolean(value)) => Ok(Some(PrimitiveValue::Boolean(*value.value()))),
+        Some(Value::Integer(value)) => Ok(Some(PrimitiveValue::Integer(*value.value()))),
+        _ => Err(ProjectionError::UnsupportedValue),
+    }
+}
+fn value(primitive: &PrimitiveValue) -> Value {
+    match primitive {
+        PrimitiveValue::String(v) => Value::from(v.as_str()),
+        PrimitiveValue::Boolean(v) => Value::from(*v),
+        PrimitiveValue::Integer(v) => Value::from(*v),
+    }
+}
+
+fn edit(
+    table: &mut Table,
+    path: &[String],
+    desired: &Option<PrimitiveValue>,
+) -> Result<(), ProjectionError> {
+    let key = &path[0];
+    if path.len() > 1 {
+        if !table.contains_key(key) {
+            let mut child = Table::new();
+            child.set_implicit(true);
+            table.insert(key, Item::Table(child));
+        }
+        return edit(
+            table
+                .get_mut(key)
+                .and_then(Item::as_table_mut)
+                .ok_or(ProjectionError::UnsupportedValue)?,
+            &path[1..],
+            desired,
+        );
+    }
+    match desired {
+        Some(primitive) => {
+            let mut replacement = value(primitive);
+            if let Some(previous) = table.get(key).and_then(Item::as_value) {
+                *replacement.decor_mut() = previous.decor().clone();
+            }
+            if let Some(existing) = table.get_mut(key) {
+                *existing = Item::Value(replacement);
+            } else {
+                table.insert(key, Item::Value(replacement));
+            }
+        }
+        None => {
+            // Deletion cannot silently discard either key-prefix or value-suffix comments.
+            if let Some((formatted_key, item)) = table.get_key_value(key) {
+                let has_comment = |raw: Option<&toml_edit::RawString>| {
+                    raw.and_then(toml_edit::RawString::as_str)
+                        .is_some_and(|s| s.contains('#'))
+                };
+                if has_comment(formatted_key.leaf_decor().prefix())
+                    || has_comment(formatted_key.leaf_decor().suffix())
+                    || item.as_value().is_some_and(|v| {
+                        has_comment(v.decor().prefix()) || has_comment(v.decor().suffix())
+                    })
+                {
+                    return Err(ProjectionError::UnsupportedCommentedDeletion);
+                }
+            }
+            table.remove(key);
+        }
+    }
+    Ok(())
+}
+
+/// Caller supplies ownership from its trusted managed-key ledger. This function
+/// never discovers/adopts existing ownership, reads files, or executes TOML content.
+pub fn plan(
+    base: &str,
+    current: &str,
+    changes: &[ManagedChange],
+) -> Result<TomlPlan, ProjectionError> {
+    if base.len() > MAX_BYTES || current.len() > MAX_BYTES || changes.len() > 1024 {
+        return Err(ProjectionError::LimitExceeded);
+    }
+    let base = base
+        .parse::<DocumentMut>()
+        .map_err(|_| ProjectionError::MalformedToml)?;
+    let mut candidate = current
+        .parse::<DocumentMut>()
+        .map_err(|_| ProjectionError::MalformedToml)?;
+    let mut ordered: Vec<_> = changes.iter().collect();
+    ordered.sort_by(|a, b| a.path.cmp(&b.path));
+    let mut aggregate_values = 0_usize;
+    for change in &ordered {
+        if change.path.is_empty()
+            || change.path.len() > 16
+            || change
+                .path
+                .iter()
+                .any(|p| p.is_empty() || p.len() > 128 || p.chars().any(char::is_control))
+        {
+            return Err(ProjectionError::InvalidPath);
+        }
+        if change.ownership != ManagedOwnership::SymbioteManaged {
+            return Err(ProjectionError::UnmanagedKey);
+        }
+        for value in [&change.before, &change.desired] {
+            if let Some(PrimitiveValue::String(value)) = value {
+                aggregate_values = aggregate_values
+                    .checked_add(value.len())
+                    .ok_or(ProjectionError::LimitExceeded)?;
+                if aggregate_values > MAX_BYTES {
+                    return Err(ProjectionError::LimitExceeded);
+                }
+            }
+        }
+    }
+    for pair in ordered.windows(2) {
+        if pair[1].path.starts_with(&pair[0].path) {
+            return Err(ProjectionError::OverlappingPaths);
+        }
+    }
+    let mut diffs = Vec::new();
+    for change in ordered {
+        let baseline = read(base.as_table(), &change.path)?;
+        if baseline != change.before {
+            return Err(ProjectionError::BaselineMismatch);
+        }
+        let actual = read(candidate.as_table(), &change.path)?;
+        if actual == change.desired {
+            continue;
+        }
+        if actual != baseline {
+            return Err(ProjectionError::ConcurrentEdit);
+        }
+        edit(candidate.as_table_mut(), &change.path, &change.desired)?;
+        diffs.push(SemanticDiff {
+            path: change.path.clone(),
+            before: actual,
+            after: change.desired.clone(),
+        });
+    }
+    let mut output = BoundedOutput(String::new());
+    write!(&mut output, "{candidate}").map_err(|_| ProjectionError::LimitExceeded)?;
+    let candidate = output.0;
+    Ok(TomlPlan { candidate, diffs })
+}

--- a/crates/symbiote-projection/tests/generation.rs
+++ b/crates/symbiote-projection/tests/generation.rs
@@ -1,0 +1,269 @@
+#![cfg(target_os = "linux")]
+use std::{
+    collections::BTreeMap,
+    fs::{self, DirBuilder},
+    os::unix::fs::{DirBuilderExt, PermissionsExt, symlink},
+    path::PathBuf,
+    sync::{
+        Arc, Barrier,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use symbiote_projection::generation::{GenerationError, publish, verify};
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct PrivateRoot(PathBuf);
+impl PrivateRoot {
+    fn new() -> Self {
+        loop {
+            let path = std::env::temp_dir().join(format!(
+                "symbiote-generation-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            match DirBuilder::new().mode(0o700).create(&path) {
+                Ok(()) => return Self(path),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => panic!("private test directory creation failed: {error}"),
+            }
+        }
+    }
+}
+impl Drop for PrivateRoot {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+fn files() -> BTreeMap<String, Vec<u8>> {
+    BTreeMap::from([
+        ("config.toml".into(), b"model = 'fixture'\n".to_vec()),
+        ("AGENTS.md".into(), b"Test instructions".to_vec()),
+    ])
+}
+
+#[test]
+fn published_generation_verifies_and_has_private_permissions() {
+    let root = PrivateRoot::new();
+    let receipt = publish(&root.0, "generation-1", &files()).unwrap();
+    assert_eq!(receipt, verify(&root.0, "generation-1").unwrap());
+    assert_eq!(receipt.files["config.toml"].bytes, 18);
+    assert!(!format!("{receipt:?}").contains("generation-1"));
+    assert!(!format!("{receipt:?}").contains("config.toml"));
+    assert_eq!(
+        fs::metadata(root.0.join("generation-1"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777,
+        0o700
+    );
+    for name in ["config.toml", "AGENTS.md", ".manifest.json", ".ready"] {
+        assert_eq!(
+            fs::metadata(root.0.join("generation-1").join(name))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o7777,
+            0o600
+        );
+    }
+    assert_eq!(
+        publish(&root.0, "generation-1", &files()),
+        Err(GenerationError::AlreadyExists)
+    );
+    assert_eq!(receipt, verify(&root.0, "generation-1").unwrap());
+}
+
+#[test]
+fn concurrent_publish_has_one_winner_and_never_mixes_files() {
+    let root = PrivateRoot::new();
+    let barrier = Arc::new(Barrier::new(2));
+    let handles: Vec<_> = (0..2)
+        .map(|n| {
+            let path = root.0.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                let files = BTreeMap::from([("config.toml".into(), vec![n; 1000])]);
+                barrier.wait();
+                publish(&path, "race", &files)
+            })
+        })
+        .collect();
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    assert_eq!(results.iter().filter(|r| r.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|r| **r == Err(GenerationError::AlreadyExists))
+            .count(),
+        1
+    );
+    assert_eq!(
+        verify(&root.0, "race").unwrap(),
+        results.into_iter().find_map(Result::ok).unwrap()
+    );
+}
+
+#[test]
+fn partial_publications_remain_incomplete_and_are_preserved() {
+    let root = PrivateRoot::new();
+    publish(&root.0, "partial", &files()).unwrap();
+    fs::remove_file(root.0.join("partial/.ready")).unwrap();
+    assert_eq!(verify(&root.0, "partial"), Err(GenerationError::Incomplete));
+    assert_eq!(
+        publish(&root.0, "partial", &files()),
+        Err(GenerationError::AlreadyExists)
+    );
+    assert!(root.0.join("partial/config.toml").exists());
+    DirBuilder::new()
+        .mode(0o700)
+        .create(root.0.join("empty"))
+        .unwrap();
+    assert_eq!(verify(&root.0, "empty"), Err(GenerationError::Incomplete));
+}
+
+#[test]
+fn content_manifest_marker_and_entry_set_tampering_is_rejected() {
+    let root = PrivateRoot::new();
+    for generation in [
+        "content",
+        "manifest",
+        "marker",
+        "extra",
+        "missing",
+        "directory",
+    ] {
+        publish(&root.0, generation, &files()).unwrap();
+    }
+    fs::write(root.0.join("content/config.toml"), b"model = 'changed'\n").unwrap();
+    fs::write(root.0.join("manifest/.manifest.json"), b"{}").unwrap();
+    fs::write(root.0.join("marker/.ready"), b"0".repeat(64)).unwrap();
+    fs::write(root.0.join("extra/user-owned.txt"), b"preserve me").unwrap();
+    fs::remove_file(root.0.join("missing/config.toml")).unwrap();
+    fs::remove_file(root.0.join("directory/config.toml")).unwrap();
+    DirBuilder::new()
+        .mode(0o700)
+        .create(root.0.join("directory/config.toml"))
+        .unwrap();
+    for generation in [
+        "content",
+        "manifest",
+        "marker",
+        "extra",
+        "missing",
+        "directory",
+    ] {
+        assert!(verify(&root.0, generation).is_err());
+    }
+    assert_eq!(
+        fs::read(root.0.join("extra/user-owned.txt")).unwrap(),
+        b"preserve me"
+    );
+}
+
+#[test]
+fn unsafe_paths_symlinks_hardlinks_and_permissions_are_rejected() {
+    let root = PrivateRoot::new();
+    for name in [
+        "",
+        "..",
+        "../escape",
+        "a/b",
+        ".ready",
+        "/absolute",
+        "bad\0name",
+    ] {
+        assert_eq!(
+            publish(&root.0, name, &files()),
+            Err(GenerationError::InvalidInput)
+        );
+        assert_eq!(
+            publish(
+                &root.0,
+                "invalid-file",
+                &BTreeMap::from([(name.into(), vec![])])
+            ),
+            Err(GenerationError::InvalidInput)
+        );
+    }
+    assert!(!root.0.join("invalid-file").exists());
+    let alias = root.0.join("alias");
+    symlink(&root.0, &alias).unwrap();
+    assert_eq!(
+        publish(&alias, "new", &files()),
+        Err(GenerationError::UnsafePath)
+    );
+    assert_eq!(
+        publish(&alias.join("child"), "new", &files()),
+        Err(GenerationError::UnsafePath)
+    );
+    publish(&root.0, "linked", &files()).unwrap();
+    fs::remove_file(root.0.join("linked/config.toml")).unwrap();
+    symlink("AGENTS.md", root.0.join("linked/config.toml")).unwrap();
+    assert!(verify(&root.0, "linked").is_err());
+    publish(&root.0, "hardlink", &files()).unwrap();
+    fs::hard_link(
+        root.0.join("hardlink/config.toml"),
+        root.0.join("second-link"),
+    )
+    .unwrap();
+    assert_eq!(
+        verify(&root.0, "hardlink"),
+        Err(GenerationError::UnsafePath)
+    );
+    publish(&root.0, "permissions", &files()).unwrap();
+    fs::set_permissions(
+        root.0.join("permissions/config.toml"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    assert_eq!(
+        verify(&root.0, "permissions"),
+        Err(GenerationError::UnsafePath)
+    );
+    fs::set_permissions(&root.0, fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(
+        publish(&root.0, "public-root", &files()),
+        Err(GenerationError::UnsafePath)
+    );
+}
+
+#[test]
+fn limits_are_rejected_before_creating_a_generation() {
+    let root = PrivateRoot::new();
+    let too_many = (0..17).map(|n| (format!("f{n}"), vec![])).collect();
+    let too_large = BTreeMap::from([("config.toml".into(), vec![0; 1_048_577])]);
+    let too_total = (0..5)
+        .map(|n| (format!("f{n}"), vec![0; 1_048_576]))
+        .collect();
+    for files in [too_many, too_large, too_total] {
+        assert_eq!(
+            publish(&root.0, "oversized", &files),
+            Err(GenerationError::BoundsExceeded)
+        );
+    }
+    assert!(!root.0.join("oversized").exists());
+}
+
+#[test]
+fn unsupported_fifo_does_not_block_and_generation_symlink_is_never_followed() {
+    let root = PrivateRoot::new();
+    publish(&root.0, "fifo", &files()).unwrap();
+    fs::remove_file(root.0.join("fifo/config.toml")).unwrap();
+    nix::unistd::mkfifo(
+        &root.0.join("fifo/config.toml"),
+        nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+    )
+    .unwrap();
+    assert_eq!(verify(&root.0, "fifo"), Err(GenerationError::UnsafePath));
+    symlink("fifo", root.0.join("generation-alias")).unwrap();
+    assert_eq!(
+        verify(&root.0, "generation-alias"),
+        Err(GenerationError::UnsafePath)
+    );
+    assert_eq!(
+        publish(&root.0, "generation-alias", &files()),
+        Err(GenerationError::AlreadyExists)
+    );
+    assert!(root.0.join("generation-alias").is_symlink());
+}

--- a/crates/symbiote-projection/tests/preparation.rs
+++ b/crates/symbiote-projection/tests/preparation.rs
@@ -1,0 +1,159 @@
+use std::collections::BTreeMap;
+use symbiote_config::{ProjectManifest, environment::*};
+use symbiote_projection::{toml::*, *};
+
+fn environment() -> EffectiveEnvironment {
+    let manifest = ProjectManifest::parse(include_str!(
+        "../../symbiote-config/fixtures/environment/project.json"
+    ))
+    .unwrap();
+    let mut document = manifest.agent_environments["development"].clone();
+    let target = ResolutionTarget::parse(include_str!(
+        "../../symbiote-config/fixtures/environment/target.json"
+    ))
+    .unwrap();
+    document.layers[0].resources[0].trust = Trust::Approved;
+    let resource = document.layers[0].resources[0].clone();
+    document
+        .resolve(
+            &target,
+            &ResolutionFacts {
+                target: target.clone(),
+                mode: document.mode,
+                mode_supported: true,
+                resources: vec![ResourceFact {
+                    resource: resource.clone(),
+                    supported: true,
+                    feasible: true,
+                }],
+                approved_core_policies: document.core_policies.clone(),
+                approved_extensions: Default::default(),
+                grants: resource.required_grants,
+                parent_grants: None,
+            },
+        )
+        .unwrap()
+}
+fn declaration(environment: &EffectiveEnvironment) -> TomlDeclaration {
+    TomlDeclaration {
+        resource: environment
+            .resources
+            .values()
+            .next()
+            .unwrap()
+            .resource
+            .clone(),
+        filename: "config.toml".into(),
+        changes: vec![ManagedChange {
+            path: vec!["enabled".into()],
+            before: Some(PrimitiveValue::Boolean(false)),
+            desired: Some(PrimitiveValue::Boolean(true)),
+            ownership: ManagedOwnership::SymbioteManaged,
+        }],
+    }
+}
+fn input(text: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([("config.toml".into(), text.into())])
+}
+
+#[test]
+fn resolved_environment_prepares_comments_and_unmanaged_current_edits() {
+    let environment = environment();
+    let prepared = prepare_toml(
+        &environment,
+        &input("enabled = false\nuser = 1\n"),
+        &input("# human header\nenabled = false # keep\nuser = 2\n"),
+        &[declaration(&environment)],
+    )
+    .unwrap();
+    let output = std::str::from_utf8(&prepared.files()["config.toml"]).unwrap();
+    assert!(output.contains("# human header"));
+    assert!(output.contains("enabled = true # keep"));
+    assert!(output.contains("user = 2"));
+}
+
+#[test]
+fn missing_or_stale_resource_mapping_never_silently_passes() {
+    let environment = environment();
+    let inputs = input("enabled = false\n");
+    assert!(matches!(
+        prepare_toml(&environment, &inputs, &inputs, &[]),
+        Err(PreparationError::MissingMapping)
+    ));
+    let mut stale = declaration(&environment);
+    stale.resource.version_ref = ResourceRef::new("stale-version").unwrap();
+    assert!(matches!(
+        prepare_toml(&environment, &inputs, &inputs, &[stale]),
+        Err(PreparationError::IneligibleResource)
+    ));
+    let mut empty = declaration(&environment);
+    empty.changes.clear();
+    assert!(matches!(
+        prepare_toml(&environment, &inputs, &inputs, &[empty]),
+        Err(PreparationError::MissingMapping)
+    ));
+}
+
+#[test]
+fn global_blockers_and_concurrent_managed_changes_refuse_preparation() {
+    let mut environment = environment();
+    let mapping = declaration(&environment);
+    let inputs = input("enabled = false\n");
+    environment.blockers.push(EnvironmentBlocker {
+        resource: None,
+        reason: BlockReason::UnsupportedMode,
+    });
+    assert!(matches!(
+        prepare_toml(&environment, &inputs, &inputs, &[mapping]),
+        Err(PreparationError::BlockedEnvironment)
+    ));
+    environment.blockers.clear();
+    assert!(matches!(
+        prepare_toml(
+            &environment,
+            &inputs,
+            &input("enabled = 3\n"),
+            &[declaration(&environment)]
+        ),
+        Err(PreparationError::Reconciliation(
+            ProjectionError::ConcurrentEdit
+        ))
+    ));
+}
+
+#[test]
+fn generation_publication_is_inactive_and_never_overwrites_an_existing_profile() {
+    use std::{
+        fs,
+        os::unix::fs::PermissionsExt,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    let root = std::env::temp_dir().join(format!(
+        "symbiote-preparation-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir(&root).unwrap();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o700)).unwrap();
+    let environment = environment();
+    let inputs = input("enabled = false # retain\n");
+    let prepared =
+        prepare_toml(&environment, &inputs, &inputs, &[declaration(&environment)]).unwrap();
+    let receipt = generation::publish(&root, "generation-one", prepared.files()).unwrap();
+    assert_eq!(
+        generation::verify(&root, "generation-one").unwrap(),
+        receipt
+    );
+    let file = root.join("generation-one/config.toml");
+    fs::write(&file, "# concurrent human edit\n").unwrap();
+    assert!(generation::publish(&root, "generation-one", prepared.files()).is_err());
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "# concurrent human edit\n"
+    );
+    assert!(generation::verify(&root, "generation-one").is_err());
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/symbiote-projection/tests/toml.rs
+++ b/crates/symbiote-projection/tests/toml.rs
@@ -1,0 +1,190 @@
+use symbiote_projection::toml::*;
+fn change(
+    path: &[&str],
+    before: Option<PrimitiveValue>,
+    desired: Option<PrimitiveValue>,
+) -> ManagedChange {
+    ManagedChange {
+        path: path.iter().map(|s| (*s).into()).collect(),
+        before,
+        desired,
+        ownership: ManagedOwnership::SymbioteManaged,
+    }
+}
+fn string(v: &str) -> Option<PrimitiveValue> {
+    Some(PrimitiveValue::String(v.into()))
+}
+
+#[test]
+fn preserves_unknown_content_and_comments_during_managed_replacement() {
+    let base = "# user preface\nunknown = 'unchanged' # private\n[agent]\n# model choice\nmodel = 'old' # keep this\n";
+    let current = base.replace("'unchanged'", "'human edit'");
+    let result = plan(
+        base,
+        &current,
+        &[change(&["agent", "model"], string("old"), string("new"))],
+    )
+    .unwrap();
+    assert!(
+        result
+            .candidate
+            .contains("unknown = 'human edit' # private")
+    );
+    assert!(result.candidate.contains("# user preface"));
+    assert!(result.candidate.contains("# model choice"));
+    assert!(result.candidate.contains("# keep this"));
+    assert_eq!(result.diffs.len(), 1);
+    assert_eq!(result.diffs[0].before, string("old"));
+    assert_eq!(result.diffs[0].after, string("new"));
+    let second = plan(
+        base,
+        &result.candidate,
+        &[change(&["agent", "model"], string("old"), string("new"))],
+    )
+    .unwrap();
+    assert_eq!(second.candidate, result.candidate);
+    assert!(second.diffs.is_empty());
+}
+
+#[test]
+fn insert_delete_nested_primitives_and_deterministic_order() {
+    let base = "[existing]\nremove = 1\nkeep = true\n";
+    let mut changes = vec![
+        change(
+            &["new", "enabled"],
+            None,
+            Some(PrimitiveValue::Boolean(true)),
+        ),
+        change(
+            &["existing", "remove"],
+            Some(PrimitiveValue::Integer(1)),
+            None,
+        ),
+    ];
+    let result = plan(base, base, &changes).unwrap();
+    assert!(!result.candidate.contains("remove"));
+    assert!(result.candidate.contains("keep = true"));
+    assert!(result.candidate.contains("enabled = true"));
+    changes.reverse();
+    assert_eq!(result, plan(base, base, &changes).unwrap());
+    assert_eq!(result.diffs.len(), 2);
+}
+
+#[test]
+fn refuses_concurrent_managed_edits_and_false_baselines() {
+    assert_eq!(
+        plan(
+            "key='base'",
+            "key='human'",
+            &[change(&["key"], string("base"), string("desired"))]
+        ),
+        Err(ProjectionError::ConcurrentEdit)
+    );
+    assert_eq!(
+        plan(
+            "key='base'",
+            "key='base'",
+            &[change(&["key"], string("false"), string("desired"))]
+        ),
+        Err(ProjectionError::BaselineMismatch)
+    );
+    assert_eq!(
+        plan(
+            "",
+            "key='human'",
+            &[change(&["key"], None, string("desired"))]
+        ),
+        Err(ProjectionError::ConcurrentEdit)
+    );
+}
+
+#[test]
+fn refuses_unsupported_tables_arrays_and_nonprimitive_values() {
+    for input in [
+        "key=[1,2]",
+        "[key]\nchild=1",
+        "key={child=1}",
+        "key=1.5",
+        "key=2020-01-01",
+    ] {
+        assert_eq!(
+            plan(input, input, &[change(&["key"], None, string("desired"))]),
+            Err(ProjectionError::UnsupportedValue)
+        );
+    }
+    assert_eq!(
+        plan(
+            "key=[]",
+            "key=[]",
+            &[change(&["key", "child"], None, string("desired"))]
+        ),
+        Err(ProjectionError::UnsupportedValue)
+    );
+}
+
+#[test]
+fn refuses_duplicates_malformed_overlap_unmanaged_and_comments_deletion() {
+    for input in ["key=1\nkey=2", "key=["] {
+        assert_eq!(plan(input, input, &[]), Err(ProjectionError::MalformedToml));
+    }
+    let mut edit = change(&["key"], None, string("new"));
+    edit.ownership = ManagedOwnership::Unmanaged;
+    assert_eq!(plan("", "", &[edit]), Err(ProjectionError::UnmanagedKey));
+    assert_eq!(
+        plan(
+            "",
+            "",
+            &[
+                change(&["a"], None, string("new")),
+                change(&["a", "b"], None, string("new"))
+            ]
+        ),
+        Err(ProjectionError::OverlappingPaths)
+    );
+    for input in ["key=1 # keep", "# keep\nkey=1"] {
+        assert_eq!(
+            plan(
+                input,
+                input,
+                &[change(&["key"], Some(PrimitiveValue::Integer(1)), None)]
+            ),
+            Err(ProjectionError::UnsupportedCommentedDeletion)
+        );
+    }
+}
+
+#[test]
+fn errors_and_debug_never_contain_values_or_paths() {
+    let edit = change(&["sensitive-key"], None, string("private-token"));
+    let result = plan("", "", std::slice::from_ref(&edit)).unwrap();
+    for debug in [
+        format!("{edit:?}"),
+        format!("{result:?}"),
+        format!("{:?}", result.diffs),
+        format!("{:?}", edit.desired),
+    ] {
+        assert!(!debug.contains("private-token"));
+        assert!(!debug.contains("sensitive-key"));
+    }
+    assert_eq!(
+        plan(&" ".repeat(1_048_577), "", &[]),
+        Err(ProjectionError::LimitExceeded)
+    );
+}
+
+#[test]
+fn aggregate_values_and_escaped_rendering_are_bounded() {
+    let changes: Vec<_> = (0..17)
+        .map(|i| change(&[&format!("key{i}")], None, string(&"x".repeat(65_536))))
+        .collect();
+    assert_eq!(plan("", "", &changes), Err(ProjectionError::LimitExceeded));
+    // Each NUL expands to a six-byte TOML escape, but raw input remains under the budget.
+    assert_eq!(
+        plan(
+            "",
+            "",
+            &[change(&["key"], None, string(&"\0".repeat(200_000)))]
+        ),
+        Err(ProjectionError::LimitExceeded)
+    );
+}

--- a/docs/contracts/projection.md
+++ b/docs/contracts/projection.md
@@ -1,0 +1,35 @@
+# Inactive configuration projection
+
+Owner: [#187](https://github.com/RepairYourTech/SymbioteIDE/issues/187), consuming #184/#179/#214 foundations. `symbiote-projection` prepares explicit TOML mappings from resolved environment intent and publishes a new inactive profile generation. It does not discover native homes, import credentials, activate resources, reload a harness or change canonical task state.
+
+## Preparation and ownership
+
+`prepare_toml` requires an environment with no global blockers and exact eligible resource declarations for each pack mapping. A mapping for an older resource version or different payload is rejected even if its ID matches. Every required resource must have a nonempty mapping; missing formats cannot silently disappear. Pack declarations remain trusted adapter inputs whose real semantics require a compatibility dossier. These data checks are not Host authorization.
+
+The TOML reconciler accepts explicitly managed primitive string, Boolean and integer leaf keys, with expected baseline and desired values. Baseline and current text are separate. Current managed values must equal the baseline or already equal the desired value; other edits conflict. Unknown keys and unrelated human edits remain unchanged. Replacements preserve key/value comments. A deletion that would discard a comment is refused. Duplicate/overlapping paths, malformed TOML, unmanaged keys, arrays, inline tables and other unsupported managed value shapes are refused. Untouched unsupported shapes are preserved as opaque TOML content.
+
+Changes are ordered deterministically. String inputs and formatted output are bounded before unbounded candidate construction, including escaping expansion. Plans and semantic diffs expose private content only through explicit fields; their `Debug` implementations redact it. Callers must never supply credential stores or inline secrets as projection input. No native source file is read automatically.
+
+## Publication and recovery
+
+`generation::publish` requires an existing private directory owned by the current OS user, then creates a new generation without replacing an existing one. Every path component is opened relative to a directory descriptor with no symlink following. Public filenames are single restricted components; files use 0600 and generation directories 0700. The initial implementation allows at most 16 files, 1 MiB per file and 4 MiB total. Nested directory trees are not supported yet.
+
+Each file is synchronized, followed by a bounded manifest and a final readiness marker; directories are synchronized before returning. The marker binds the manifest, which records exact filenames, byte counts and SHA-256 hashes. `verify` checks the exact entry set, permissions, readiness and content, rejecting symlinks, hardlinks, FIFOs, unexpected files and tampering. Verification is a point-in-time observation, not protection against a later write or a malicious actor running as the same OS user. Hashes detect drift; they are not signatures or permission grants.
+
+Errors preserve the generation for inspection. A missing marker remains unusable; an error after marker creation can leave a complete generation with uncertain durability, so reconcile with `verify` rather than assuming nothing was written. Retrying the same generation name never overwrites it. A later human edit is preserved and causes verification failure. There is no automatic cleanup or in-place rollback: existing profiles remain untouched, and a failed inactive candidate is never selected by this library. Future activation must persist the chosen generation, authorize the contract and install Host controls before executable configuration can load.
+
+## Reproduction and remaining acceptance
+
+Run `cargo test -p symbiote-projection --locked` for format, preparation and real-filesystem fixtures. Tests cover concurrent publishers, modified managed keys, unmanaged edits, drift, partial directory states and private path handling. Partial-state fixtures construct incomplete publications; they do not certify arbitrary process-kill or power-loss boundaries.
+
+For a runnable fixture, create a private scratch directory and run:
+
+```sh
+mkdir -m 700 /tmp/symbiote-projection-demo
+cargo run -p symbiote-projection --example projection_demo -- \
+  /tmp/symbiote-projection-demo first-generation
+```
+
+The demo publishes and verifies fixture TOML. It performs no inference and reads no real runtime home. Repeating the generation name refuses replacement.
+
+Real Codex/native/other pack mappings, per-version golden homes and precedence, credential-safe native import, JSON/JSONC/YAML/Markdown/other patchers, directory trees, native uptake, durable activation/rollback, trust enforcement and cross-platform runtime evidence remain pending. #187 remains open. Linux is the tested filesystem platform; there is no UI accessibility surface in this library. No paid inference, credential changes or existing-native-file migration occurs.

--- a/docs/engineering-handoff.md
+++ b/docs/engineering-handoff.md
@@ -1,5 +1,11 @@
 # Engineering handoff
 
+## Inactive profile projection — 2026-09-08 UTC
+
+Change Stream `issue-187-projection` starts from merged #478 at `76ab590`. Owner #187 consumes #184/#179/#214 foundations. `symbiote-projection` reconciles explicit managed TOML primitives, binds pack mappings to exact eligible environment resources and publishes fresh private profile generations with readiness/content verification. Existing generations and native homes are never overwritten.
+
+See `docs/contracts/projection.md` for tests, demo and remaining acceptance. This is inactive profile preparation, not native/Codex compatibility or activation. Next execution prerequisites still include #174/#191/#218 trust/threat/preventive enforcement, worktree/context/dispatch integration and real runtime packs. Broad #187 and the persistent build goal remain incomplete.
+
 ## Agent environment contracts — 2026-09-08 UTC
 
 Change Stream `issue-214-environment` starts from merged #477 at `18fd58c`. Owner #214 consumes the #179/#184 foundations. Versioned desired resource declarations enter the portable Project manifest, with read-only environment resolution and explicit scope, trust, ownership and compatibility boundaries. Native files remain projections; this batch performs no resource installation or worker activation.


### PR DESCRIPTION
Add configuration projection preparation and inactive profile publication. Explicit pack mappings consume exact eligible environment resources; the TOML reconciler preserves unmanaged edits/comments and refuses conflicting managed edits. New private generations are created without replacing existing profiles and verified through readiness, exact entries and content hashes.

Independent review fixed stale resource mapping reuse, aggregate/rendered allocation bounds, and ambiguous publication-error wording. Eighteen tests cover reconciliation, environment preparation and real filesystem behavior, including concurrent publishers, symlinks/hardlinks/FIFOs, incomplete state and tampering. Full workspace tests, strict all-target Clippy, formatting and the runnable `projection_demo` pass locally; CI checks Rust 1.85 and stable at the containing head.

Relates to #187; does not close it. This implements explicit TOML primitive mappings and inactive immutable generations, not real harness compatibility, native reload, worker activation or in-place rollback. Other formats, real pack dossiers, credential-safe import, complete crash/power-loss evidence and activation/enforcement remain pending. No existing native home or credentials are read or modified. See `docs/contracts/projection.md` for exact bounds, recovery and the fixture demo.
