### PR TITLE
feat(sandbox): isolate Linux command execution behind consent gates

### DIFF
--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -10,16 +10,23 @@ permissions:
 
 jobs:
   contracts:
-    runs-on: ubuntu-latest
+    # Noble's default runner rejects isolated loopback setup. Keep that failure
+    # documented; do not disable AppArmor or relax the invocation to pass tests.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         toolchain: ["1.85.0", stable]
     steps:
       - uses: actions/checkout@v4
-      - name: Install Linux sandbox runtime
+      - name: Build pinned Linux sandbox runtime
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes meson ninja-build libcap-dev pkg-config
+          git clone --no-checkout https://github.com/containers/bubblewrap.git "$RUNNER_TEMP/bubblewrap"
+          git -C "$RUNNER_TEMP/bubblewrap" checkout --detach 2a76602a8c71f36c1527cf9fc3417d9149822e0c
+          meson setup "$RUNNER_TEMP/bubblewrap/build" "$RUNNER_TEMP/bubblewrap" -Dman=disabled -Dbash_completion=disabled -Dzsh_completion=disabled
+          meson compile -C "$RUNNER_TEMP/bubblewrap/build" bwrap
+          sudo install -m 0755 "$RUNNER_TEMP/bubblewrap/build/bwrap" /usr/bin/bwrap
           bwrap --version
           bwrap --unshare-all --unshare-user --disable-userns --assert-userns-disabled \
             --die-with-parent --new-session --clearenv --cap-drop ALL \

--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -21,6 +21,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes bubblewrap
           bwrap --version
+          bwrap --unshare-all --unshare-user --disable-userns --assert-userns-disabled \
+            --die-with-parent --new-session --clearenv --cap-drop ALL \
+            --ro-bind /usr /usr --symlink usr/bin /bin --symlink usr/lib /lib \
+            --symlink usr/lib64 /lib64 --proc /proc --dev /dev --tmpfs /tmp \
+            -- /usr/bin/true
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -16,6 +16,11 @@ jobs:
         toolchain: ["1.85.0", stable]
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux sandbox runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap
+          bwrap --version
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-sandbox"
+version = "0.1.0"
+dependencies = [
+ "nix",
+ "serde",
+ "serde_json",
+ "symbiote-domain",
+ "symbiote-runtime-transport",
+ "symbiote-trust",
+]
+
+[[package]]
 name = "symbiote-store"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust"]
+members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The [local runtime transport](docs/contracts/runtime-transport.md) adds bounded 
 
 The Host records [resource consent and revocation](docs/contracts/resource-consent.md) against exact fingerprints and scope. The [trust boundary baseline](docs/security/trust-boundaries.md) keeps OS worker isolation and other release requirements explicit; consent metadata does not activate a resource.
 
+The [Linux sandbox](docs/security/linux-sandbox.md) develops preventive process
+isolation for read-only and worktree-write execution. Real hostile-process tests
+cover its boundary; authenticated worker launch and full runtime integration
+remain separate acceptance gates. Linux test runs require an installed,
+operational `bwrap` and enabled unprivileged namespaces.
+
 ```sh
 cargo test --workspace --locked
 cargo clippy --workspace --all-targets --locked -- -D warnings

--- a/crates/symbiote-sandbox/Cargo.toml
+++ b/crates/symbiote-sandbox/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "symbiote-sandbox"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+symbiote-domain = { path = "../symbiote-domain" }
+symbiote-trust = { path = "../symbiote-trust" }
+symbiote-runtime-transport = { path = "../symbiote-runtime-transport" }
+serde.workspace = true
+serde_json.workspace = true
+nix = { version = "=0.30.1", features = ["fs", "user", "dir"] }
+
+[lints]
+workspace = true

--- a/crates/symbiote-sandbox/examples/sandbox_probe.rs
+++ b/crates/symbiote-sandbox/examples/sandbox_probe.rs
@@ -1,0 +1,78 @@
+//! Fixture consent only: this is not an authenticated Host approval flow.
+//! Usage: sandbox_probe ABS_HELPER ABS_PRIVATE_WORKTREE ABS_PROTECTED_HOST_DIR
+use std::{collections::BTreeSet, path::PathBuf, time::Duration};
+use symbiote_domain::*;
+use symbiote_runtime_transport::TransportLimits;
+use symbiote_sandbox::*;
+use symbiote_trust::*;
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let inputs: Vec<_> = std::env::args_os().skip(1).map(PathBuf::from).collect();
+    if inputs.len() != 3 {
+        return Err("expected helper, private worktree, protected Host directory".into());
+    }
+    let project = ProjectId::new("fixture-project")?;
+    let root = RootId::new("fixture-root")?;
+    let args=vec!["-c".into(),"import json,os\ntry:\n open('/workspace/denied-write','w');denied=False\nexcept OSError:denied=True\nprint(json.dumps({'sandbox':True,'write_denied':denied,'home':os.environ['HOME']}),flush=True)".into()];
+    let snapshot = ResourceSnapshot {
+        project_id: project.clone(),
+        role_id: RoleId::new("fixture-role")?,
+        profile_id: RuntimeProfileId::new("fixture-runtime")?,
+        host_id: HostId::new("fixture-host")?,
+        resource_ref: "sandbox-probe".into(),
+        fingerprint: fingerprint_command(
+            &root,
+            &inputs[1],
+            Profile::ReadOnly,
+            "/usr/bin/python3",
+            &args,
+        )?,
+        access: AccessSnapshot {
+            project_id: project,
+            roots: BTreeSet::from([root.clone()]),
+            grants: BTreeSet::from([Permission::ReadRoot, Permission::ExecuteProcess]),
+            policy_revision: Revision(1),
+        },
+    };
+    let consent = ResourceConsent {
+        id: CommandId::new("fixture-consent")?,
+        snapshot: snapshot.clone(),
+        user_id: UserId::new("fixture-user")?,
+        issued_at: Timestamp(1),
+        expires_at: Timestamp(3),
+        revoked_at: None,
+    };
+    let mut process = launch(LaunchRequest {
+        helper_path: &inputs[0],
+        consent: &consent,
+        snapshot: &snapshot,
+        policy: &snapshot.access,
+        host: &snapshot.host_id,
+        at: Timestamp(2),
+        root_id: &root,
+        worktree: &inputs[1],
+        protected_paths: &inputs[2..],
+        profile: Profile::ReadOnly,
+        program: "/usr/bin/python3",
+        args: &args,
+        limits: TransportLimits::default(),
+    })?;
+    let evidence = process.recv(Duration::from_secs(5))?;
+    if evidence != serde_json::json!({"sandbox":true,"write_denied":true,"home":"/home/agent"}) {
+        return Err("sandbox probe returned unexpected evidence".into());
+    }
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(exit) = process.try_wait()? {
+            if exit.code != Some(0) || exit.signal.is_some() {
+                return Err("sandbox probe failed".into());
+            }
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err("sandbox probe exit deadline exceeded".into());
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    println!("{evidence}");
+    Ok(())
+}

--- a/crates/symbiote-sandbox/src/bin/symbiote-sandbox-launch.rs
+++ b/crates/symbiote-sandbox/src/bin/symbiote-sandbox-launch.rs
@@ -1,0 +1,45 @@
+//! Trusted, single-threaded descriptor boundary before bubblewrap. No untrusted
+//! code executes until every inherited descriptor other than stdio is closed.
+use std::os::unix::{ffi::OsStrExt, process::CommandExt};
+
+fn run() -> Result<(), ()> {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    if args.len() > 256 || args.iter().map(|a| a.as_bytes().len()).sum::<usize>() > 262_144 {
+        return Err(());
+    }
+    let mut descriptors = Vec::new();
+    for entry in std::fs::read_dir("/proc/self/fd").map_err(|_| ())? {
+        let entry = entry.map_err(|_| ())?;
+        let fd = entry
+            .file_name()
+            .to_str()
+            .ok_or(())?
+            .parse::<i32>()
+            .map_err(|_| ())?;
+        if fd > 2 {
+            descriptors.push(fd);
+        }
+        if descriptors.len() > 65_536 {
+            return Err(());
+        }
+    }
+    // read_dir's own descriptor is closed before this loop. This process has
+    // no other threads or signal handlers that allocate descriptors.
+    for fd in descriptors {
+        match nix::unistd::close(fd) {
+            Ok(()) | Err(nix::errno::Errno::EBADF) => {}
+            Err(_) => return Err(()),
+        }
+    }
+    let _error = std::process::Command::new("/usr/bin/bwrap")
+        .args(args)
+        .env_clear()
+        .exec();
+    Err(())
+}
+fn main() {
+    if run().is_err() {
+        eprintln!("sandbox launcher unavailable");
+        std::process::exit(126);
+    }
+}

--- a/crates/symbiote-sandbox/src/lib.rs
+++ b/crates/symbiote-sandbox/src/lib.rs
@@ -1,0 +1,384 @@
+//! Linux bubblewrap 0.12 invocation, against a trusted Arch-style `/usr` base.
+//! This is an internal trusted launcher, not an authenticated Host endpoint.
+//! Path checks do not defeat a malicious same-UID process racing path replacement;
+//! the caller must reserve the worktree and its private parent for this execution.
+//! Consent binds a command descriptor, not executable bytes or dependency closure.
+#![cfg(target_os = "linux")]
+
+use nix::{
+    dir::Dir,
+    fcntl::{OFlag, open, openat},
+    sys::stat::{Mode, SFlag, fstat},
+    unistd::geteuid,
+};
+use serde::Serialize;
+use serde_json::Value;
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fmt,
+    fs::File,
+    os::fd::AsFd,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+use symbiote_domain::{AccessSnapshot, HostId, Permission, RootId, Timestamp};
+use symbiote_runtime_transport::{
+    CancelReport, JsonlTransport, ProcessExit, SpawnSpec, TransportError, TransportLimits,
+};
+use symbiote_trust::{Fingerprint, ResourceConsent, ResourceSnapshot, authorize_load};
+
+pub const INVOCATION_VERSION: &str = "linux-bwrap-0.12-v1";
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Profile {
+    ReadOnly,
+    WorktreeWrite,
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SandboxError {
+    InvalidCommand,
+    UnsafePath,
+    ProtectedOverlap,
+    ConsentDenied,
+    PermissionDenied,
+    UnsupportedEntry,
+    ResourceLimit,
+    Unavailable,
+    Transport(TransportError),
+}
+impl fmt::Display for SandboxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sandbox rejected: {self:?}")
+    }
+}
+impl std::error::Error for SandboxError {}
+pub type Result<T> = std::result::Result<T, SandboxError>;
+
+/// All authority-bearing fields must come from trusted Host state, not client JSON.
+pub struct LaunchRequest<'a> {
+    /// Trusted installed launcher binary. Revalidated as regular, non-writable by others.
+    pub helper_path: &'a Path,
+    pub consent: &'a ResourceConsent,
+    pub snapshot: &'a ResourceSnapshot,
+    pub policy: &'a AccessSnapshot,
+    pub host: &'a HostId,
+    pub at: Timestamp,
+    pub root_id: &'a RootId,
+    pub worktree: &'a Path,
+    /// Complete protected Host directories; nonempty, absolute, existing and symlink-free.
+    pub protected_paths: &'a [PathBuf],
+    pub profile: Profile,
+    /// Only absolute /usr/bin executables are accepted; arguments are never shell-expanded.
+    pub program: &'a str,
+    pub args: &'a [String],
+    pub limits: TransportLimits,
+}
+
+/// The descriptor includes the absolute worktree, Root, command and fixed policy version.
+/// It deliberately does not claim to fingerprint the installed runtime or imported files.
+pub fn fingerprint_command(
+    root: &RootId,
+    worktree: &Path,
+    profile: Profile,
+    program: &str,
+    args: &[String],
+) -> Result<Fingerprint> {
+    validate_command(program, args)?;
+    validate_absolute(worktree)?;
+    let path = worktree.to_str().ok_or(SandboxError::UnsafePath)?;
+    let bytes = serde_json::to_vec(&(INVOCATION_VERSION, root, path, profile, program, args))
+        .map_err(|_| SandboxError::InvalidCommand)?;
+    Ok(Fingerprint::of(&bytes))
+}
+fn validate_command(program: &str, args: &[String]) -> Result<()> {
+    let suffix = program
+        .strip_prefix("/usr/bin/")
+        .ok_or(SandboxError::InvalidCommand)?;
+    if program.len() > 256
+        || suffix.is_empty()
+        || !suffix
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+        || args.len() > 64
+        || args.iter().any(|a| a.len() > 65_536 || a.contains('\0'))
+        || args.iter().map(String::len).sum::<usize>() > 131_072
+    {
+        return Err(SandboxError::InvalidCommand);
+    }
+    Ok(())
+}
+fn validate_absolute(path: &Path) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    if path.as_os_str().as_bytes().len() > 4096
+        || path.components().count() > 128
+        || !path.is_absolute()
+        || path
+            .components()
+            .any(|c| !matches!(c, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(SandboxError::UnsafePath);
+    }
+    Ok(())
+}
+fn flags() -> OFlag {
+    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC
+}
+fn directory(path: &Path) -> Result<File> {
+    validate_absolute(path)?;
+    let mut fd =
+        open(Path::new("/"), flags(), Mode::empty()).map_err(|_| SandboxError::UnsafePath)?;
+    for component in path.components() {
+        if let Component::Normal(name) = component {
+            fd = openat(&fd, name, flags(), Mode::empty()).map_err(|_| SandboxError::UnsafePath)?;
+            let stat = fstat(&fd).map_err(|_| SandboxError::UnsafePath)?;
+            if ![0, geteuid().as_raw()].contains(&stat.st_uid)
+                || (stat.st_mode & 0o022 != 0 && stat.st_mode & 0o1000 == 0)
+            {
+                return Err(SandboxError::UnsafePath);
+            }
+        }
+    }
+    Ok(fd.into())
+}
+fn owned_private(fd: &impl AsFd, exact: bool) -> Result<()> {
+    let stat = fstat(fd).map_err(|_| SandboxError::UnsafePath)?;
+    if stat.st_uid != geteuid().as_raw()
+        || stat.st_mode & 0o022 != 0
+        || (exact && stat.st_mode & 0o7777 != 0o700)
+    {
+        return Err(SandboxError::UnsafePath);
+    }
+    Ok(())
+}
+fn validate_helper(path: &Path) -> Result<()> {
+    validate_absolute(path)?;
+    let parent = directory(path.parent().ok_or(SandboxError::UnsafePath)?)?;
+    let name = path.file_name().ok_or(SandboxError::UnsafePath)?;
+    let fd = openat(
+        &parent,
+        name,
+        OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|_| SandboxError::Unavailable)?;
+    let stat = fstat(&fd).map_err(|_| SandboxError::Unavailable)?;
+    if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != SFlag::S_IFREG
+        || ![0, geteuid().as_raw()].contains(&stat.st_uid)
+        || stat.st_mode & 0o022 != 0
+        || stat.st_mode & 0o111 == 0
+    {
+        return Err(SandboxError::UnsafePath);
+    }
+    Ok(())
+}
+fn overlap(a: &Path, b: &Path) -> bool {
+    a.starts_with(b) || b.starts_with(a)
+}
+
+// A pathname Unix socket inside a bind mount can reach the Host even with an
+// isolated network namespace. Reject sockets/devices/FIFOs and aliased hardlinks.
+fn inspect_tree(fd: &impl AsFd, depth: usize, left: &mut usize) -> Result<()> {
+    if depth > 64 {
+        return Err(SandboxError::ResourceLimit);
+    }
+    let mut entries =
+        Dir::openat(fd, ".", flags(), Mode::empty()).map_err(|_| SandboxError::UnsafePath)?;
+    for entry in entries.iter() {
+        let entry = entry.map_err(|_| SandboxError::UnsafePath)?;
+        let name = entry.file_name();
+        if name.to_bytes() == b"." || name.to_bytes() == b".." {
+            continue;
+        }
+        *left = left.checked_sub(1).ok_or(SandboxError::ResourceLimit)?;
+        // O_PATH avoids opening device nodes and never follows symlinks.
+        let child = openat(
+            fd,
+            name,
+            OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|_| SandboxError::UnsafePath)?;
+        let stat = fstat(&child).map_err(|_| SandboxError::UnsafePath)?;
+        let kind = SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT;
+        if stat.st_uid != geteuid().as_raw() || stat.st_mode & 0o022 != 0 {
+            return Err(SandboxError::UnsafePath);
+        }
+        match kind {
+            SFlag::S_IFDIR => inspect_tree(&child, depth + 1, left)?,
+            SFlag::S_IFREG if stat.st_nlink == 1 => {}
+            // Symlinks can bypass scans of sockets under another visible mount.
+            _ => return Err(SandboxError::UnsupportedEntry),
+        }
+    }
+    Ok(())
+}
+
+pub struct SandboxProcess {
+    transport: JsonlTransport,
+}
+impl SandboxProcess {
+    /// Explicit opt-in to bounded raw child stderr; Debug on this batch is redacted.
+    pub fn diagnostics(&mut self) -> symbiote_runtime_transport::DiagnosticBatch {
+        self.transport.diagnostics()
+    }
+    pub fn send(&mut self, value: &Value, timeout: Duration) -> Result<()> {
+        self.transport
+            .send(value, timeout)
+            .map_err(SandboxError::Transport)
+    }
+    pub fn recv(&mut self, timeout: Duration) -> Result<Value> {
+        self.transport
+            .recv(timeout)
+            .map_err(SandboxError::Transport)
+    }
+    pub fn try_wait(&mut self) -> Result<Option<ProcessExit>> {
+        self.transport.try_wait().map_err(SandboxError::Transport)
+    }
+    /// The underlying report remains conservative: descendant cleanup is Unknown.
+    pub fn cancel(&mut self, timeout: Duration) -> Result<CancelReport> {
+        self.transport
+            .cancel(timeout)
+            .map_err(SandboxError::Transport)
+    }
+}
+
+pub fn launch(request: LaunchRequest<'_>) -> Result<SandboxProcess> {
+    validate_helper(request.helper_path)?;
+    authorize_load(
+        request.consent,
+        request.snapshot,
+        request.policy,
+        request.host,
+        request.at,
+    )
+    .map_err(|_| SandboxError::ConsentDenied)?;
+    if request.snapshot.fingerprint
+        != fingerprint_command(
+            request.root_id,
+            request.worktree,
+            request.profile,
+            request.program,
+            request.args,
+        )?
+    {
+        return Err(SandboxError::ConsentDenied);
+    }
+    let grants = &request.snapshot.access.grants;
+    if !request.snapshot.access.roots.contains(request.root_id)
+        || !grants.contains(&Permission::ReadRoot)
+        || !grants.contains(&Permission::ExecuteProcess)
+        || (request.profile == Profile::WorktreeWrite
+            && !grants.contains(&Permission::MutateStream))
+    {
+        return Err(SandboxError::PermissionDenied);
+    }
+    if request.protected_paths.is_empty() || request.protected_paths.len() > 32 {
+        return Err(SandboxError::UnsafePath);
+    }
+    let worktree = directory(request.worktree)?;
+    owned_private(&worktree, false)?;
+    owned_private(
+        &directory(request.worktree.parent().ok_or(SandboxError::UnsafePath)?)?,
+        true,
+    )?;
+    if overlap(request.worktree, Path::new("/usr")) {
+        return Err(SandboxError::ProtectedOverlap);
+    }
+    for protected in request.protected_paths {
+        directory(protected)?;
+        if overlap(request.worktree, protected) || overlap(Path::new("/usr"), protected) {
+            return Err(SandboxError::ProtectedOverlap);
+        }
+    }
+    inspect_tree(&worktree, 0, &mut 100_000)?;
+    let mut args: Vec<OsString> = [
+        "--unshare-all",
+        "--unshare-user",
+        "--disable-userns",
+        "--assert-userns-disabled",
+        "--die-with-parent",
+        "--new-session",
+        "--clearenv",
+        "--cap-drop",
+        "ALL",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--symlink",
+        "usr/bin",
+        "/bin",
+        "--symlink",
+        "usr/lib",
+        "/lib",
+        "--symlink",
+        "usr/lib64",
+        "/lib64",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+        "--tmpfs",
+        "/home",
+        "--dir",
+        "/home/agent",
+    ]
+    .into_iter()
+    .map(Into::into)
+    .collect();
+    args.push(
+        if request.profile == Profile::ReadOnly {
+            "--ro-bind"
+        } else {
+            "--bind"
+        }
+        .into(),
+    );
+    args.push(request.worktree.as_os_str().into());
+    args.extend(
+        [
+            "/workspace",
+            "--chdir",
+            "/workspace",
+            "--setenv",
+            "HOME",
+            "/home/agent",
+            "--setenv",
+            "PATH",
+            "/usr/bin:/bin",
+            "--setenv",
+            "TMPDIR",
+            "/tmp",
+            "--remount-ro",
+            "/",
+            "--",
+            "/usr/bin/sh",
+            "-c",
+            "printf '%s\\n' '{\"symbiote_sandbox_ready\":1}'; exec \"$@\"",
+            "symbiote",
+        ]
+        .into_iter()
+        .map(OsString::from),
+    );
+    args.push(request.program.into());
+    args.extend(request.args.iter().map(OsString::from));
+    let mut transport = JsonlTransport::spawn(
+        SpawnSpec {
+            executable: request.helper_path.into(),
+            args,
+            cwd: "/".into(),
+            env: BTreeMap::new(),
+        },
+        request.limits,
+    )
+    .map_err(|_| SandboxError::Unavailable)?;
+    let ready = transport
+        .recv(Duration::from_secs(5))
+        .map_err(|_| SandboxError::Unavailable)?;
+    if ready != serde_json::json!({"symbiote_sandbox_ready":1}) {
+        return Err(SandboxError::Unavailable);
+    }
+    Ok(SandboxProcess { transport })
+}

--- a/crates/symbiote-sandbox/src/lib.rs
+++ b/crates/symbiote-sandbox/src/lib.rs
@@ -45,7 +45,77 @@ pub enum SandboxError {
     UnsupportedEntry,
     ResourceLimit,
     Unavailable,
+    SetupFailed(SetupFailure),
     Transport(TransportError),
+}
+/// Bounded setup stderr is available only through explicit inspection.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SetupFailure {
+    cause: Option<TransportError>,
+    diagnostics: Vec<String>,
+    truncated: bool,
+}
+impl SetupFailure {
+    pub fn cause(&self) -> Option<&TransportError> {
+        self.cause.as_ref()
+    }
+    pub fn diagnostics(&self) -> &[String] {
+        &self.diagnostics
+    }
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+}
+impl fmt::Debug for SetupFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SetupFailure")
+            .field("cause", &self.cause)
+            .field("diagnostic_count", &self.diagnostics.len())
+            .field("truncated", &self.truncated)
+            .finish()
+    }
+}
+impl SandboxError {
+    pub fn setup_failure(&self) -> Option<&SetupFailure> {
+        match self {
+            Self::SetupFailed(failure) => Some(failure),
+            _ => None,
+        }
+    }
+}
+
+fn setup_failure(transport: &mut JsonlTransport, cause: Option<TransportError>) -> SandboxError {
+    let deadline = std::time::Instant::now() + Duration::from_millis(200);
+    while !transport.diagnostics_finished() && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    // Acquire completion before draining: a true observation guarantees the
+    // producer's final entry is already published into the diagnostic queue.
+    let finished = transport.diagnostics_finished();
+    let batch = transport.diagnostics();
+    let mut truncated = !finished || batch.dropped > 0 || batch.entries.len() > 8;
+    let diagnostics = batch
+        .entries
+        .into_iter()
+        .take(8)
+        .map(|entry| {
+            let mut text = entry.text;
+            truncated |= entry.truncated || text.len() > 1024;
+            if text.len() > 1024 {
+                let mut boundary = 1024;
+                while !text.is_char_boundary(boundary) {
+                    boundary -= 1;
+                }
+                text.truncate(boundary);
+            }
+            text
+        })
+        .collect();
+    SandboxError::SetupFailed(SetupFailure {
+        cause,
+        diagnostics,
+        truncated,
+    })
 }
 impl fmt::Display for SandboxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -373,12 +443,13 @@ pub fn launch(request: LaunchRequest<'_>) -> Result<SandboxProcess> {
         },
         request.limits,
     )
-    .map_err(|_| SandboxError::Unavailable)?;
-    let ready = transport
-        .recv(Duration::from_secs(5))
-        .map_err(|_| SandboxError::Unavailable)?;
+    .map_err(SandboxError::Transport)?;
+    let ready = match transport.recv(Duration::from_secs(5)) {
+        Ok(ready) => ready,
+        Err(error) => return Err(setup_failure(&mut transport, Some(error))),
+    };
     if ready != serde_json::json!({"symbiote_sandbox_ready":1}) {
-        return Err(SandboxError::Unavailable);
+        return Err(setup_failure(&mut transport, None));
     }
     Ok(SandboxProcess { transport })
 }

--- a/crates/symbiote-sandbox/tests/process.rs
+++ b/crates/symbiote-sandbox/tests/process.rs
@@ -1,0 +1,423 @@
+#![cfg(target_os = "linux")]
+use std::{
+    collections::BTreeSet,
+    fs::{self, DirBuilder},
+    os::unix::{
+        fs::{DirBuilderExt, symlink},
+        net::UnixListener,
+    },
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+use symbiote_domain::*;
+use symbiote_runtime_transport::{DescendantCleanup, TransportLimits};
+use symbiote_sandbox::*;
+use symbiote_trust::*;
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct Fixture {
+    base: PathBuf,
+    worktree: PathBuf,
+    protected: Vec<PathBuf>,
+}
+impl Fixture {
+    fn new() -> Self {
+        let base = loop {
+            let p = std::env::temp_dir().join(format!(
+                "symbiote-sandbox-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            match DirBuilder::new().mode(0o700).create(&p) {
+                Ok(()) => break p,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => panic!("{e}"),
+            }
+        };
+        let worktree = base.join("worktree");
+        let host = base.join("host");
+        for path in [&worktree, &host] {
+            DirBuilder::new().mode(0o700).create(path).unwrap();
+        }
+        Self {
+            base,
+            worktree,
+            protected: vec![host],
+        }
+    }
+    fn consent(&self, profile: Profile, args: &[String]) -> ResourceConsent {
+        let project = ProjectId::new("project").unwrap();
+        let root = RootId::new("root").unwrap();
+        ResourceConsent {
+            id: CommandId::new("consent").unwrap(),
+            user_id: UserId::new("user").unwrap(),
+            issued_at: Timestamp(1),
+            expires_at: Timestamp(100),
+            revoked_at: None,
+            snapshot: ResourceSnapshot {
+                project_id: project.clone(),
+                role_id: RoleId::new("role").unwrap(),
+                profile_id: RuntimeProfileId::new("runtime").unwrap(),
+                host_id: HostId::new("host").unwrap(),
+                resource_ref: "sandbox-command".into(),
+                fingerprint: fingerprint_command(
+                    &root,
+                    &self.worktree,
+                    profile,
+                    "/usr/bin/python3",
+                    args,
+                )
+                .unwrap(),
+                access: AccessSnapshot {
+                    project_id: project,
+                    roots: BTreeSet::from([root]),
+                    grants: BTreeSet::from([
+                        Permission::ReadRoot,
+                        Permission::ExecuteProcess,
+                        Permission::MutateStream,
+                    ]),
+                    policy_revision: Revision(1),
+                },
+            },
+        }
+    }
+    fn request<'a>(
+        &'a self,
+        consent: &'a ResourceConsent,
+        profile: Profile,
+        args: &'a [String],
+    ) -> LaunchRequest<'a> {
+        LaunchRequest {
+            helper_path: std::path::Path::new(env!("CARGO_BIN_EXE_symbiote-sandbox-launch")),
+            consent,
+            snapshot: &consent.snapshot,
+            policy: &consent.snapshot.access,
+            host: &consent.snapshot.host_id,
+            at: Timestamp(10),
+            root_id: consent.snapshot.access.roots.first().unwrap(),
+            worktree: &self.worktree,
+            protected_paths: &self.protected,
+            profile,
+            program: "/usr/bin/python3",
+            args,
+            limits: TransportLimits::default(),
+        }
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.base).unwrap();
+    }
+}
+
+#[test]
+fn actual_hostile_process_cannot_read_host_credentials_socket_or_network() {
+    let fixture = Fixture::new();
+    let credential = fixture.protected[0].join("credential");
+    fs::write(&credential, b"fixture-only-secret").unwrap();
+    let socket = fixture.protected[0].join("control.sock");
+    let _listener = UnixListener::bind(&socket).unwrap();
+    let tcp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    fs::write(fixture.worktree.join("input"), b"readable").unwrap();
+    let script = r#"import json,os,socket,sys,subprocess
+def denied(f):
+ try: f(); return False
+ except OSError: return True
+def tcp():
+ s=socket.socket();s.settimeout(.2);s.connect(('127.0.0.1',int(sys.argv[3])))
+def unix():
+ s=socket.socket(socket.AF_UNIX);s.connect(sys.argv[2])
+result={'credential_denied':denied(lambda:open(sys.argv[1]).read()),'socket_denied':denied(unix),'network_denied':denied(tcp),'write_denied':denied(lambda:open('/workspace/output','w')),'usr_write_denied':denied(lambda:open('/usr/symbiote-test','w')),'input':open('/workspace/input').read(),'home':os.environ.get('HOME'),'env_keys':sorted(os.environ),'nested_userns_denied':subprocess.run(['/usr/bin/unshare','-Ur','/usr/bin/true'],stderr=subprocess.DEVNULL).returncode!=0}
+print(json.dumps(result),flush=True)
+"#;
+    let args = vec![
+        "-c".into(),
+        script.into(),
+        credential.to_str().unwrap().into(),
+        socket.to_str().unwrap().into(),
+        tcp.local_addr().unwrap().port().to_string(),
+    ];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    let mut child = launch(fixture.request(&consent, Profile::ReadOnly, &args)).unwrap();
+    let report = child.recv(Duration::from_secs(5)).unwrap();
+    for key in [
+        "credential_denied",
+        "socket_denied",
+        "network_denied",
+        "write_denied",
+        "usr_write_denied",
+        "nested_userns_denied",
+    ] {
+        assert_eq!(report[key], true, "{key}");
+    }
+    assert_eq!(report["input"], "readable");
+    assert_eq!(report["home"], "/home/agent");
+    let keys = report["env_keys"].as_array().unwrap();
+    assert!(keys.iter().all(|k| matches!(
+        k.as_str(),
+        Some("HOME" | "PATH" | "TMPDIR" | "PWD" | "LC_CTYPE" | "SHLVL" | "_")
+    )));
+    assert!(!fixture.worktree.join("output").exists());
+}
+
+#[test]
+fn writes_are_explicit_and_sets_id_descendant_stops_after_cancellation() {
+    let fixture = Fixture::new();
+    let script = r#"import json,os,time
+pid=os.fork()
+if pid==0:
+ os.setsid()
+ deadline=time.monotonic()+10
+ while time.monotonic()<deadline:
+  with open('/workspace/heartbeat','ab') as f:f.write(b'x')
+  time.sleep(.01)
+ os._exit(0)
+print(json.dumps({'started':True}),flush=True)
+time.sleep(10)
+"#;
+    let args = vec!["-c".into(), script.into()];
+    let consent = fixture.consent(Profile::WorktreeWrite, &args);
+    let mut child = launch(fixture.request(&consent, Profile::WorktreeWrite, &args)).unwrap();
+    assert_eq!(child.recv(Duration::from_secs(5)).unwrap()["started"], true);
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !fs::metadata(fixture.worktree.join("heartbeat")).is_ok_and(|m| m.len() > 0) {
+        assert!(Instant::now() < deadline);
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    let result = child.cancel(Duration::from_secs(3)).unwrap();
+    assert_eq!(result.descendant_cleanup, DescendantCleanup::Unknown);
+    std::thread::sleep(Duration::from_millis(50));
+    let before = fs::metadata(fixture.worktree.join("heartbeat"))
+        .unwrap()
+        .len();
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        fs::metadata(fixture.worktree.join("heartbeat"))
+            .unwrap()
+            .len(),
+        before
+    );
+}
+
+#[test]
+fn socket_hardlink_symlink_and_protected_overlap_refused_before_spawn() {
+    let fixture = Fixture::new();
+    let args = vec!["-c".into(), "print('{}')".into()];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    let socket = fixture.worktree.join("socket");
+    let listener = UnixListener::bind(&socket).unwrap();
+    assert!(matches!(
+        launch(fixture.request(&consent, Profile::ReadOnly, &args)),
+        Err(SandboxError::UnsupportedEntry)
+    ));
+    drop(listener);
+    fs::remove_file(socket).unwrap();
+    let secret = fixture.protected[0].join("secret");
+    fs::write(&secret, b"fixture").unwrap();
+    let alias = fixture.worktree.join("alias");
+    fs::hard_link(&secret, &alias).unwrap();
+    assert!(matches!(
+        launch(fixture.request(&consent, Profile::ReadOnly, &args)),
+        Err(SandboxError::UnsupportedEntry)
+    ));
+    fs::remove_file(&alias).unwrap();
+    symlink(&secret, &alias).unwrap();
+    assert!(launch(fixture.request(&consent, Profile::ReadOnly, &args)).is_err());
+    fs::remove_file(alias).unwrap();
+    let protected = vec![fixture.base.clone()];
+    let mut request = fixture.request(&consent, Profile::ReadOnly, &args);
+    request.protected_paths = &protected;
+    assert!(matches!(
+        launch(request),
+        Err(SandboxError::ProtectedOverlap)
+    ));
+    let protected = vec![PathBuf::from("/usr")];
+    let mut request = fixture.request(&consent, Profile::ReadOnly, &args);
+    request.protected_paths = &protected;
+    assert!(matches!(
+        launch(request),
+        Err(SandboxError::ProtectedOverlap)
+    ));
+}
+
+#[test]
+fn changed_expired_revoked_or_underprivileged_consent_denies_launch() {
+    let fixture = Fixture::new();
+    let args = vec!["-c".into(), "print('{}')".into()];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    let changed = vec!["-c".into(), "print('changed')".into()];
+    assert!(matches!(
+        launch(fixture.request(&consent, Profile::ReadOnly, &changed)),
+        Err(SandboxError::ConsentDenied)
+    ));
+    assert!(matches!(
+        launch(fixture.request(&consent, Profile::WorktreeWrite, &args)),
+        Err(SandboxError::ConsentDenied)
+    ));
+    let mut expired = consent.clone();
+    expired.expires_at = Timestamp(9);
+    assert!(matches!(
+        launch(fixture.request(&expired, Profile::ReadOnly, &args)),
+        Err(SandboxError::ConsentDenied)
+    ));
+    let mut revoked = consent.clone();
+    revoked.revoked_at = Some(Timestamp(5));
+    assert!(matches!(
+        launch(fixture.request(&revoked, Profile::ReadOnly, &args)),
+        Err(SandboxError::ConsentDenied)
+    ));
+    let mut denied = consent.clone();
+    denied
+        .snapshot
+        .access
+        .grants
+        .remove(&Permission::ExecuteProcess);
+    assert!(matches!(
+        launch(fixture.request(&denied, Profile::ReadOnly, &args)),
+        Err(SandboxError::PermissionDenied)
+    ));
+    let mut write = fixture.consent(Profile::WorktreeWrite, &args);
+    write
+        .snapshot
+        .access
+        .grants
+        .remove(&Permission::MutateStream);
+    assert!(matches!(
+        launch(fixture.request(&write, Profile::WorktreeWrite, &args)),
+        Err(SandboxError::PermissionDenied)
+    ));
+}
+
+#[test]
+fn inherited_descriptor_boundary_child() {
+    if std::env::var_os("SYMBIOTE_FD_TEST_CHILD").is_none() {
+        return;
+    }
+    use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+    use std::{io::Write, os::fd::AsRawFd};
+    let (read, write) = nix::unistd::pipe().unwrap();
+    nix::unistd::write(&write, b"fixture-pipe").unwrap();
+    let (socket, mut peer) = std::os::unix::net::UnixStream::pair().unwrap();
+    peer.write_all(b"fixture-socket").unwrap();
+    // Isolated test process only: deliberately create inheritable capabilities
+    // to prove that the helper removes them, never changing the test runner's FDs.
+    for fd in [&read as &dyn std::os::fd::AsFd, &socket] {
+        fcntl(fd, FcntlArg::F_SETFD(FdFlag::empty())).unwrap();
+    }
+    let fixture = Fixture::new();
+    let script = "import os,sys,json\ndef closed(fd):\n try:os.fstat(int(fd));return False\n except OSError:return True\nprint(json.dumps({'closed':all(closed(x) for x in sys.argv[1:])}),flush=True)";
+    let args = vec![
+        "-c".into(),
+        script.into(),
+        read.as_raw_fd().to_string(),
+        socket.as_raw_fd().to_string(),
+    ];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    let mut child = launch(fixture.request(&consent, Profile::ReadOnly, &args)).unwrap();
+    assert_eq!(child.recv(Duration::from_secs(5)).unwrap()["closed"], true);
+}
+
+#[test]
+fn inherited_pipe_and_host_socket_are_closed_before_untrusted_exec() {
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "inherited_descriptor_boundary_child",
+            "--nocapture",
+        ])
+        .env("SYMBIOTE_FD_TEST_CHILD", "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn oversized_commands_and_untrusted_ancestors_are_rejected() {
+    use std::os::unix::fs::PermissionsExt;
+    let fixture = Fixture::new();
+    let root = RootId::new("root").unwrap();
+    assert!(
+        fingerprint_command(
+            &root,
+            &fixture.worktree,
+            Profile::ReadOnly,
+            &format!("/usr/bin/{}", "x".repeat(257)),
+            &[]
+        )
+        .is_err()
+    );
+    assert!(
+        fingerprint_command(
+            &root,
+            &PathBuf::from(format!("/{}", "x".repeat(4096))),
+            Profile::ReadOnly,
+            "/usr/bin/python3",
+            &[]
+        )
+        .is_err()
+    );
+    let args = vec!["-c".into(), "print('{}')".into()];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    fs::set_permissions(&fixture.base, fs::Permissions::from_mode(0o777)).unwrap();
+    assert!(matches!(
+        launch(fixture.request(&consent, Profile::ReadOnly, &args)),
+        Err(SandboxError::UnsafePath)
+    ));
+}
+
+#[test]
+fn sandbox_owner_death_child() {
+    let Some(base) = std::env::var_os("SYMBIOTE_OWNER_DEATH_BASE") else {
+        return;
+    };
+    let base = PathBuf::from(base);
+    let fixture = Fixture {
+        worktree: base.join("worktree"),
+        protected: vec![base.join("host")],
+        base,
+    };
+    let args=vec!["-c".into(),"import os,time\nif os.fork()==0:\n os.setsid()\n deadline=time.monotonic()+10\n while time.monotonic()<deadline:\n  with open('/workspace/owner-heartbeat','ab') as f:f.write(b'x')\n  time.sleep(.01)\n os._exit(0)\ntime.sleep(10)".into()];
+    let consent = fixture.consent(Profile::WorktreeWrite, &args);
+    let _child = launch(fixture.request(&consent, Profile::WorktreeWrite, &args)).unwrap();
+    std::thread::sleep(Duration::from_secs(60));
+}
+
+#[test]
+fn setsid_descendant_heartbeat_stops_after_launcher_owner_dies() {
+    struct Owner(std::process::Child);
+    impl Drop for Owner {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+    let fixture = Fixture::new();
+    let mut owner = Owner(
+        std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "sandbox_owner_death_child", "--nocapture"])
+            .env("SYMBIOTE_OWNER_DEATH_BASE", &fixture.base)
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+    let heartbeat = fixture.worktree.join("owner-heartbeat");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !fs::metadata(&heartbeat).is_ok_and(|m| m.len() > 0) {
+        assert!(
+            owner.0.try_wait().unwrap().is_none(),
+            "sandbox owner exited before heartbeat"
+        );
+        assert!(Instant::now() < deadline, "owner death fixture timed out");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    owner.0.kill().unwrap();
+    owner.0.wait().unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    let before = fs::metadata(&heartbeat).unwrap().len();
+    std::thread::sleep(Duration::from_millis(200));
+    assert_eq!(fs::metadata(&heartbeat).unwrap().len(), before);
+}

--- a/crates/symbiote-sandbox/tests/process.rs
+++ b/crates/symbiote-sandbox/tests/process.rs
@@ -16,6 +16,7 @@ use symbiote_sandbox::*;
 use symbiote_trust::*;
 static NEXT: AtomicU64 = AtomicU64::new(0);
 struct Fixture {
+    owns_directory: bool,
     base: PathBuf,
     worktree: PathBuf,
     protected: Vec<PathBuf>,
@@ -40,6 +41,7 @@ impl Fixture {
             DirBuilder::new().mode(0o700).create(path).unwrap();
         }
         Self {
+            owns_directory: true,
             base,
             worktree,
             protected: vec![host],
@@ -106,8 +108,25 @@ impl Fixture {
 }
 impl Drop for Fixture {
     fn drop(&mut self) {
-        fs::remove_dir_all(&self.base).unwrap();
+        if self.owns_directory {
+            // Cleanup must not turn an original setup failure into a double panic.
+            let _ = fs::remove_dir_all(&self.base);
+        }
     }
+}
+
+fn launch_ready(request: LaunchRequest<'_>) -> SandboxProcess {
+    launch(request).unwrap_or_else(|error| {
+        if let Some(setup) = error.setup_failure() {
+            for line in setup.diagnostics() {
+                eprintln!("sandbox setup stderr: {line}");
+            }
+            if setup.truncated() {
+                eprintln!("sandbox setup stderr truncated");
+            }
+        }
+        panic!("sandbox setup failed: {error}");
+    })
 }
 
 #[test]
@@ -138,7 +157,7 @@ print(json.dumps(result),flush=True)
         tcp.local_addr().unwrap().port().to_string(),
     ];
     let consent = fixture.consent(Profile::ReadOnly, &args);
-    let mut child = launch(fixture.request(&consent, Profile::ReadOnly, &args)).unwrap();
+    let mut child = launch_ready(fixture.request(&consent, Profile::ReadOnly, &args));
     let report = child.recv(Duration::from_secs(5)).unwrap();
     for key in [
         "credential_denied",
@@ -177,7 +196,7 @@ time.sleep(10)
 "#;
     let args = vec!["-c".into(), script.into()];
     let consent = fixture.consent(Profile::WorktreeWrite, &args);
-    let mut child = launch(fixture.request(&consent, Profile::WorktreeWrite, &args)).unwrap();
+    let mut child = launch_ready(fixture.request(&consent, Profile::WorktreeWrite, &args));
     assert_eq!(child.recv(Duration::from_secs(5)).unwrap()["started"], true);
     let deadline = Instant::now() + Duration::from_secs(3);
     while !fs::metadata(fixture.worktree.join("heartbeat")).is_ok_and(|m| m.len() > 0) {
@@ -313,7 +332,7 @@ fn inherited_descriptor_boundary_child() {
         socket.as_raw_fd().to_string(),
     ];
     let consent = fixture.consent(Profile::ReadOnly, &args);
-    let mut child = launch(fixture.request(&consent, Profile::ReadOnly, &args)).unwrap();
+    let mut child = launch_ready(fixture.request(&consent, Profile::ReadOnly, &args));
     assert_eq!(child.recv(Duration::from_secs(5)).unwrap()["closed"], true);
 }
 
@@ -376,13 +395,14 @@ fn sandbox_owner_death_child() {
     };
     let base = PathBuf::from(base);
     let fixture = Fixture {
+        owns_directory: false,
         worktree: base.join("worktree"),
         protected: vec![base.join("host")],
         base,
     };
     let args=vec!["-c".into(),"import os,time\nif os.fork()==0:\n os.setsid()\n deadline=time.monotonic()+10\n while time.monotonic()<deadline:\n  with open('/workspace/owner-heartbeat','ab') as f:f.write(b'x')\n  time.sleep(.01)\n os._exit(0)\ntime.sleep(10)".into()];
     let consent = fixture.consent(Profile::WorktreeWrite, &args);
-    let _child = launch(fixture.request(&consent, Profile::WorktreeWrite, &args)).unwrap();
+    let _child = launch_ready(fixture.request(&consent, Profile::WorktreeWrite, &args));
     std::thread::sleep(Duration::from_secs(60));
 }
 
@@ -420,4 +440,53 @@ fn setsid_descendant_heartbeat_stops_after_launcher_owner_dies() {
     let before = fs::metadata(&heartbeat).unwrap().len();
     std::thread::sleep(Duration::from_millis(200));
     assert_eq!(fs::metadata(&heartbeat).unwrap().len(), before);
+}
+
+#[test]
+fn setup_failure_stderr_is_bounded_explicit_and_debug_redacted() {
+    use std::os::unix::fs::PermissionsExt;
+    let fixture = Fixture::new();
+    // Deliberate trusted fixture helper that fails before executing any workload.
+    let helper = fixture.base.join("failing-helper");
+    fs::write(
+        &helper,
+        "#!/usr/bin/sh\nprintf 'fixture-private-detail\\n' >&2\nexit 42\n",
+    )
+    .unwrap();
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).unwrap();
+    let args = vec!["-c".into(), "print('{}')".into()];
+    let consent = fixture.consent(Profile::ReadOnly, &args);
+    let mut request = fixture.request(&consent, Profile::ReadOnly, &args);
+    request.helper_path = &helper;
+    let error = match launch(request) {
+        Err(error) => error,
+        Ok(_) => panic!("failing helper was accepted"),
+    };
+    let setup = error.setup_failure().expect("structured setup failure");
+    assert!(
+        setup
+            .diagnostics()
+            .iter()
+            .any(|line| line.contains("fixture-private-detail"))
+    );
+    assert!(!format!("{error:?}").contains("fixture-private-detail"));
+    assert!(!format!("{error}").contains("fixture-private-detail"));
+    assert!(setup.diagnostics().len() <= 8);
+    assert!(setup.diagnostics().iter().all(|line| line.len() <= 1024));
+    assert!(!setup.truncated());
+    assert!(fixture.worktree.exists());
+    fs::write(
+        &helper,
+        "#!/usr/bin/sh\nprintf '%02000d\\n' 0 >&2\nexit 42\n",
+    )
+    .unwrap();
+    let mut request = fixture.request(&consent, Profile::ReadOnly, &args);
+    request.helper_path = &helper;
+    let error = match launch(request) {
+        Err(error) => error,
+        Ok(_) => panic!("failing helper was accepted"),
+    };
+    let setup = error.setup_failure().unwrap();
+    assert!(setup.truncated());
+    assert_eq!(setup.diagnostics()[0].len(), 1024);
 }

--- a/docs/engineering-handoff.md
+++ b/docs/engineering-handoff.md
@@ -1,5 +1,29 @@
 # Engineering handoff
 
+## Linux process sandbox — 2026-09-08 UTC
+
+Change Stream `issue-218-linux-sandbox` starts from merged #480 at `06c81f9`.
+Owner #218 consumes the runtime and resource-consent foundations. The new
+launcher is a bounded internal Linux execution boundary, with read-only and
+worktree-write profiles, isolated networking and a trusted helper for closing
+inherited descriptors. It is not an authenticated Host worker endpoint.
+
+See [the sandbox contract](security/linux-sandbox.md) and
+[the live alias probes](proofs/linux-sandbox-aliases.md). Review identified
+pathname socket, hardlink and inherited-descriptor hazards; these require
+preventive checks in addition to namespace flags. One separate review agent's
+test-writing turn was stopped by an automatic security filter citing possible
+cybersecurity risk. That turn is not counted as completed review. Another
+independent reviewer completed the full crate, helper, test and documentation
+review with no blocking findings under the documented trust boundary. Heartbeat
+assertions were tightened and fixtures bounded to ten seconds; the example now
+asserts its report and exit.
+
+Current-head verification and integration evidence must be recorded before
+claiming this slice delivered. Full #218, production worktree provisioning,
+authenticated dispatch, both live runtimes and the first usable release remain
+open. The persistent build goal is not complete.
+
 ## Durable resource consent — 2026-09-08 UTC
 
 Change Stream `issue-174-191-trust` starts from merged #479 at `615e483`. Owners #174/#191 establish the trust/threat baseline and a durable exact-resource consent boundary. New `symbiote-trust` checks snapshots, expiry/revocation and current policy; Host protocol v1.1 records/reads/revokes consent using server-derived authority, and store schema v2 journals those decisions transactionally.

--- a/docs/proofs/linux-sandbox-aliases.md
+++ b/docs/proofs/linux-sandbox-aliases.md
@@ -1,0 +1,62 @@
+# Linux sandbox alias and parent-death probes
+
+Local evidence: bubblewrap 0.12.0, `/usr/bin/bwrap`, Linux development host. These are bounded private temporary-directory probes, not Ubuntu CI evidence or complete sandbox acceptance. No host policy was changed.
+
+## Exact namespace configuration
+
+```text
+bwrap --unshare-all --unshare-user --disable-userns --assert-userns-disabled
+  --die-with-parent --new-session --cap-drop ALL --clearenv
+  --ro-bind /usr /usr
+  --symlink usr/bin /bin --symlink usr/lib /lib --symlink usr/lib /lib64
+  --proc /proc --dev /dev --tmpfs /tmp
+  --bind PRIVATE_WORKTREE /work
+  /usr/bin/python3 -c FIXTURE
+```
+
+The `/lib` symlinks reflect this host. Ubuntu library layouts and namespace/AppArmor permission must be verified on its actual CI runner; do not infer support from this result or relax failures into unconfined execution.
+
+`--unshare-all --disable-userns` without explicit `--unshare-user` failed with `--disable-userns requires --unshare-user`. With the explicit flag, sandboxed `unshare -Ur /usr/bin/true` failed with `No space left on device`, exit 1. The installed bwrap manual describes disabling further user namespaces through a nested namespace and a namespace-local limit. Dropping capabilities alone does not replace that restriction.
+
+## Worktree aliases bypass the mount boundary
+
+Reproducible private fixture logic:
+
+1. Create a temporary parent directory, an empty `work` child directory, and an `outside` regular file containing `original`.
+2. `os.link(outside, work / "alias")` creates a hardlink into the worktree.
+3. Bind a host Python `AF_UNIX` stream listener to `work / "host.sock"`.
+4. Launch the configuration above, with a five-second subprocess timeout, executing:
+
+```python
+import socket, pathlib
+s = socket.socket(socket.AF_UNIX)
+s.connect('/work/host.sock')
+s.send(b'probe')
+pathlib.Path('/work/alias').write_text('changed')
+```
+
+5. Host accepts the connection, reads `probe`, and checks `outside` contents. Close all sockets and remove only the private fixture.
+
+Observed output:
+
+```text
+sandbox_exit 0
+host_pathname_socket_reached True
+outside_hardlink_modified True
+```
+
+Network namespaces do not isolate a pathname Unix socket exposed through a filesystem bind. A hardlink names the same inode, so a writable mount can modify content outside the worktree. A read-only bind prevents this write but still exposes the inode's content: confidentiality is not established merely by making the alias read-only. The read-only case is a filesystem consequence, not a separately executed probe here.
+
+Reject sockets, special files and external hardlink aliases before binding. A scan is insufficient if another host process can concurrently insert or replace entries after validation. The launcher must require trusted, nonconcurrent provisioning or use an independently protected staged tree that breaks hardlinks and excludes sockets/special files. Directory symlinks, nested mounts, inherited file descriptors and later host writes also need explicit control. Ordinary Git worktree `.git` links to outside administration state require a separate restricted design; do not expose the entire source home to repair Git access.
+
+## Parent death with a setsid descendant
+
+A private Python supervisor launched bwrap with the exact flags above. Inside it, a shell launched `setsid python3`, whose child wrote a heartbeat to `/work/heartbeat` every 30 ms. The outer probe sampled the host `/proc` descendant tree and recorded each PID's start time, killed only its own supervisor, then compared heartbeat content and process states after 300 ms and a further 200 ms. Any still-live matching owned PIDs would have been cleaned up with SIGKILL; none required cleanup.
+
+```text
+setsid_heartbeat_observed True
+heartbeat_stopped True
+observed_live_descendants_after_parent_death 0
+```
+
+This proves cleanup for this observed descendant tree, including a new session, on this host. It relies on the PID namespace and bwrap parent-death behavior, not a process-group-only kill claim. It does not establish CPU/memory/disk quotas, protection against kernel vulnerabilities, arbitrary descendant escape prevention, or cross-platform support.

--- a/docs/security/linux-sandbox.md
+++ b/docs/security/linux-sandbox.md
@@ -70,9 +70,18 @@ not a project-supplied executable or a resource selected by a prompt.
 ## Verification and remaining gates
 
 Tests must execute the real installed bubblewrap. An unavailable or rejected
-namespace setup is a failure, not a skipped security test. CI installs the
-distribution bubblewrap package and records its version without disabling host
-security policy. The local starting environment provides bubblewrap 0.12.0.
+namespace setup is a failure, not a skipped security test. CI builds bubblewrap
+0.12.0 from upstream commit `2a76602a8c71f36c1527cf9fc3417d9149822e0c` on Ubuntu
+22.04 and records its version without disabling host security policy. The local
+starting environment also provides bubblewrap 0.12.0. The upstream source is
+[pinned here](https://github.com/containers/bubblewrap/commit/2a76602a8c71f36c1527cf9fc3417d9149822e0c).
+
+The initial Ubuntu 24.04 runner with distribution bubblewrap 0.9.0 failed actual
+namespace setup: `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.
+[The failed setup run](https://github.com/RepairYourTech/SymbioteIDE/actions/runs/34194047726)
+remains evidence of unsupported configuration, not a passing platform result.
+No AppArmor/sysctl policy was disabled, and no invocation flags were relaxed.
+Ubuntu 24.04 compatibility needs a separate verified installation configuration.
 
 Run the focused verification with:
 
@@ -92,7 +101,7 @@ evidence must distinguish the launcher exit from descendant termination; process
 group signalling alone cannot prove that a setsid child is gone. Owner-death
 tests must cover that distinction before making a namespace cleanup claim.
 
-Local verification on 2026-09-08 passed all nine sandbox test entries (including
+Local verification on 2026-09-08 passed all ten sandbox test entries (including
 two subprocess fixture entry points), the workspace suite, strict workspace
 Clippy and formatting. Tests exercise consent changes/expiry/revocation and
 permission denial, aliases, command/path bounds, inaccessible Host files and
@@ -100,6 +109,12 @@ network, inherited fixture descriptors, permitted writes, cancellation and
 owner death. The last two observe a positive heartbeat stop; the public
 descendant-cleanup result deliberately remains `Unknown`. They do not certify
 every possible descendant or outstanding privileged side effect.
+
+Setup failures retain at most eight diagnostic lines of 1,024 UTF-8 bytes each,
+with truncation/incomplete-drain status. Debug and Display redact those lines;
+trusted callers must explicitly request them for troubleshooting and apply their
+own disclosure policy. This preserves the reason for a rejected namespace setup
+without automatically logging potentially sensitive child text.
 
 The `sandbox_probe` example was also executed with a private temporary fixture.
 It requires the exact report below and a successful target exit; it uses fixture

--- a/docs/security/linux-sandbox.md
+++ b/docs/security/linux-sandbox.md
@@ -1,0 +1,121 @@
+# Linux execution sandbox
+
+Canonical owner: #218. This implementation slice consumes the runtime transport
+and exact-resource consent foundations of #184/#185/#191. It does not activate
+native or Codex workers through the Host protocol. Those integrations and the
+full #218 acceptance criteria remain pending.
+
+## Boundary
+
+The intended boundary is an untrusted child process inside Linux namespaces.
+The Host, its current policy and persisted consent records, the worktree
+provisioner, kernel, bubblewrap installation and read-only system tool tree are
+trusted. A malicious process already running outside the sandbox under the
+Host's Unix account is outside this boundary: it can reach same-user files and
+the existing bootstrap Host socket. Never give a worker an unsandboxed fallback.
+
+The launcher supports read-only and worktree-write execution with network
+isolation. Other profiles are not implemented. Host integrations must obtain
+current persisted consent and current policy, resolve the canonical Root binding
+and provide all protected Host state and credential paths before invoking it.
+Supplying Rust structs is not authentication. A command fingerprint identifies
+the launch description; it does not certify executable bytes, transitive
+dependencies or a project's content. Resource loading still needs its own
+content-bound consent and check/use guarantees.
+
+The internal entry point is `symbiote_sandbox::launch(LaunchRequest)`. Its
+non-serialized request carries the trusted consent, observed command snapshot,
+current access policy, Host identity, time, Root ID, reserved worktree, protected
+directories, profile, program arguments and transport bounds. Only explicit
+`/usr/bin` commands are admitted. Both profiles require `ReadRoot` and
+`ExecuteProcess`; worktree-write also requires `MutateStream`. The command
+fingerprint includes the fixed invocation version, Root, absolute worktree,
+profile, program and arguments. Changing them requires matching consent.
+
+The returned process supports bounded JSONL send/receive, exit inspection and
+cancellation. Launch setup must succeed before a process handle is returned;
+that does not imply that the target command succeeds. Its eventual exit and
+verification evidence remain separate completion gates.
+
+The system tool tree is readable inside the sandbox. Do not store credentials
+there. No ambient environment, home directory, Host socket, canonical database,
+credential directory or unrelated repository should be mounted. The bound
+worktree needs a private parent controlled by the trusted provisioner, which
+must not expose Host IPC endpoints, devices or hardlinks to protected files.
+Namespace isolation does not make a maliciously provisioned mount safe.
+
+A live adversarial probe demonstrated why: a pathname Unix socket inside a
+mounted worktree reached a Host listener despite network namespace isolation,
+and a writable hardlink changed a file outside that mount. See the
+[alias probe evidence](../proofs/linux-sandbox-aliases.md). A filesystem preflight
+must reject these entries before launch. Such a check relies on the trusted
+provisioner reserving the source tree throughout execution: only the sandboxed
+process may perform permitted writes. It cannot protect against a concurrent
+unsandboxed process inserting or replacing entries, even after the mount exists.
+
+This initial preflight conservatively rejects all symlinks, multiple hardlinks
+and non-file/non-directory entries. It limits traversal to 100,000 entries and
+64 levels. Trees with unsupported entries require a future safe staging design;
+do not silently remove the checks to accommodate a project. Source tree owners
+and modes are checked, and the immediate parent must be owned and mode 0700.
+
+Inherited file descriptors are another independent boundary. Bubblewrap was
+observed preserving extra descriptors supplied by its parent. The trusted
+single-threaded launcher helper must close all descriptors above stderr before
+executing bubblewrap; clearing environment variables and hiding paths do not
+revoke an already-open descriptor. Host stdin/stdout/stderr use the bounded
+transport pipes. The helper executable itself is trusted installation content,
+not a project-supplied executable or a resource selected by a prompt.
+
+## Verification and remaining gates
+
+Tests must execute the real installed bubblewrap. An unavailable or rejected
+namespace setup is a failure, not a skipped security test. CI installs the
+distribution bubblewrap package and records its version without disabling host
+security policy. The local starting environment provides bubblewrap 0.12.0.
+
+Run the focused verification with:
+
+```sh
+cargo test -p symbiote-sandbox --locked
+```
+
+The tests require Linux, Python 3, bubblewrap and working unprivileged namespace
+creation. The launcher uses the merged `/usr` system layout and a separately
+built `symbiote-sandbox-launch` helper. Packaging must install that helper in a
+trusted location and pass its absolute path from Host configuration. Never
+search a project's PATH for it. Unsupported layouts or namespace policy must
+produce setup failure; portability needs actual platform evidence.
+
+The process transport retains bounded JSONL framing and diagnostics. Cancellation
+evidence must distinguish the launcher exit from descendant termination; process
+group signalling alone cannot prove that a setsid child is gone. Owner-death
+tests must cover that distinction before making a namespace cleanup claim.
+
+Local verification on 2026-09-08 passed all nine sandbox test entries (including
+two subprocess fixture entry points), the workspace suite, strict workspace
+Clippy and formatting. Tests exercise consent changes/expiry/revocation and
+permission denial, aliases, command/path bounds, inaccessible Host files and
+network, inherited fixture descriptors, permitted writes, cancellation and
+owner death. The last two observe a positive heartbeat stop; the public
+descendant-cleanup result deliberately remains `Unknown`. They do not certify
+every possible descendant or outstanding privileged side effect.
+
+The `sandbox_probe` example was also executed with a private temporary fixture.
+It requires the exact report below and a successful target exit; it uses fixture
+consent and performs no authenticated Host approval or paid inference:
+
+```json
+{"home":"/home/agent","sandbox":true,"write_denied":true}
+```
+
+The local Rust 1.85 installation reports a missing toolchain manifest. The CI
+matrix installs its own toolchains and is the minimum-version integration gate;
+the local failure is not a passing MSRV result.
+
+Pending acceptance includes production worktree provisioning, restricted worker
+protocol and authenticated launch integration, durable decision/effect journals,
+resource limits and disk quotas, network mediation, other sandbox profiles,
+active consent revocation, MCP/browser/hook mediation, real native/Codex packs,
+Windows/macOS enforcement and the complete first-release demonstration. This
+slice introduces no durable storage migration or user credential changes.


### PR DESCRIPTION
Adds a Linux sandbox launcher for read-only and worktree-write commands under #218. Current consent and explicit permissions are checked before a fixed bubblewrap invocation. A trusted helper closes inherited descriptors; namespace isolation hides Host state and network access, while a bounded preflight rejects filesystem aliases that would cross that boundary.

This is an internal launch substrate, not an authenticated Host worker endpoint. The caller must reserve a trusted, stable worktree and supply canonical bindings and current persisted authority. Symlinks, hardlinks and special entries are refused; unsupported namespace setup never falls back to unsandboxed execution. Native/Codex runtime integration, additional profiles, quotas and full #218 acceptance remain pending.

Validation: workspace tests, all ten sandbox test entries (two subprocess helpers), strict workspace Clippy, formatting and the asserted real sandbox demo pass locally. The demo reports private HOME and denied writes and requires successful target exit. Rust 1.85 needs fresh CI verification because the local toolchain manifest is missing.

Ubuntu 24.04 with bubblewrap 0.9.0 failed isolated loopback setup; this remains documented compatibility evidence. The revised CI uses Ubuntu 22.04 and upstream bubblewrap 0.12.0 pinned to commit 2a76602a8c71f36c1527cf9fc3417d9149822e0c. Mandatory flags remain unchanged, and no AppArmor/sysctl policy is disabled. Setup failures now retain bounded, explicitly accessed diagnostics with redacted Debug/Display.

Independent full code/test/documentation review found no blockers after filesystem, descriptor and ancestor fixes. One earlier reviewer test-writing turn was stopped by an automatic security filter and is not counted as completed review; the completed review was a separate code review. Cancellation tests establish stopped observed heartbeats while the public descendant-cleanup result remains Unknown. Broad #218 remains open.
