### PR TITLE
feat(runtime): discover pinned Codex in an isolated offline profile

### DIFF
--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -42,3 +42,19 @@ jobs:
       - if: matrix.toolchain == 'stable'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
+      - name: Prove pinned Codex discovery without credentials or network
+        if: matrix.toolchain == 'stable'
+        run: |
+          mkdir "$RUNNER_TEMP/codex-proof"
+          cd "$RUNNER_TEMP/codex-proof"
+          npm pack --ignore-scripts @openai/codex@0.118.0-linux-x64
+          test "$(openssl dgst -sha512 -binary openai-codex-0.118.0-linux-x64.tgz | openssl base64 -A)" = 'vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ=='
+          tar -xzf openai-codex-0.118.0-linux-x64.tgz
+          sudo install -m 0755 package/vendor/x86_64-unknown-linux-musl/codex/codex /usr/bin/codex
+          cd "$GITHUB_WORKSPACE"
+          cargo build --locked -p symbiote-sandbox --bin symbiote-sandbox-launch
+          proof_root=$(mktemp -d "$RUNNER_TEMP/discovery.XXXXXXXX")
+          mkdir -m 700 "$proof_root/worktree" "$proof_root/protected"
+          cargo run --locked -p symbiote-runtime-discovery --example codex_discover -- \
+            "$GITHUB_WORKSPACE/target/debug/symbiote-sandbox-launch" \
+            "$proof_root/worktree" "$proof_root/protected"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-runtime-discovery"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "symbiote-domain",
+ "symbiote-runtime-transport",
+ "symbiote-sandbox",
+ "symbiote-trust",
+]
+
+[[package]]
 name = "symbiote-runtime-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox"]
+members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/symbiote-runtime-discovery/Cargo.toml
+++ b/crates/symbiote-runtime-discovery/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "symbiote-runtime-discovery"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+symbiote-domain = { path = "../symbiote-domain" }
+serde.workspace = true
+serde_json.workspace = true
+schemars.workspace = true
+
+[dev-dependencies]
+symbiote-runtime-transport = { path = "../symbiote-runtime-transport" }
+symbiote-sandbox = { path = "../symbiote-sandbox" }
+symbiote-trust = { path = "../symbiote-trust" }
+
+[lints]
+workspace = true

--- a/crates/symbiote-runtime-discovery/examples/codex_discover.rs
+++ b/crates/symbiote-runtime-discovery/examples/codex_discover.rs
@@ -1,0 +1,106 @@
+//! Offline compatibility proof with fixture consent, not Host activation authority.
+use serde_json::Value;
+use std::{collections::BTreeSet, path::PathBuf, time::Duration};
+use symbiote_domain::*;
+use symbiote_runtime_discovery::codex::{self, CodexDiscoveryError, DiscoveryTransport};
+use symbiote_runtime_transport::TransportLimits;
+use symbiote_sandbox::{LaunchRequest, Profile, SandboxProcess, fingerprint_command, launch};
+use symbiote_trust::*;
+
+struct Probe(SandboxProcess);
+impl DiscoveryTransport for Probe {
+    fn send(&mut self, value: &Value, timeout: Duration) -> Result<(), CodexDiscoveryError> {
+        self.0
+            .send(value, timeout)
+            .map_err(|_| CodexDiscoveryError::Transport)
+    }
+    fn recv(&mut self, timeout: Duration) -> Result<Value, CodexDiscoveryError> {
+        let value = self
+            .0
+            .recv(timeout)
+            .map_err(|_| CodexDiscoveryError::Transport)?;
+        if value.pointer("/result/userAgent").is_some()
+            && value.pointer("/result/codexHome").and_then(Value::as_str)
+                != Some("/home/agent/.codex")
+        {
+            return Err(CodexDiscoveryError::MalformedFrame);
+        }
+        Ok(value)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let inputs: Vec<_> = std::env::args_os().skip(1).map(PathBuf::from).collect();
+    if inputs.len() != 3 {
+        return Err(
+            "expected absolute helper, private empty worktree, protected Host directory".into(),
+        );
+    }
+    if std::fs::read_dir(&inputs[1])?.next().is_some() {
+        return Err("discovery proof requires an empty worktree".into());
+    }
+    let root = RootId::new("discovery-root")?;
+    let args = vec!["app-server".into(), "--listen".into(), "stdio://".into()];
+    let snapshot = ResourceSnapshot {
+        project_id: ProjectId::new("discovery-project")?,
+        role_id: RoleId::new("discovery-role")?,
+        profile_id: RuntimeProfileId::new("discovery-profile")?,
+        host_id: HostId::new("discovery-host")?,
+        resource_ref: "offline-codex-discovery".into(),
+        fingerprint: fingerprint_command(
+            &root,
+            &inputs[1],
+            Profile::ReadOnly,
+            "/usr/bin/codex",
+            &args,
+        )?,
+        access: AccessSnapshot {
+            project_id: ProjectId::new("discovery-project")?,
+            roots: BTreeSet::from([root.clone()]),
+            grants: BTreeSet::from([Permission::ReadRoot, Permission::ExecuteProcess]),
+            policy_revision: Revision(1),
+        },
+    };
+    let consent = ResourceConsent {
+        id: CommandId::new("discovery-consent")?,
+        snapshot: snapshot.clone(),
+        user_id: UserId::new("discovery-user")?,
+        issued_at: Timestamp(1),
+        expires_at: Timestamp(3),
+        revoked_at: None,
+    };
+    let mut probe = Probe(launch(LaunchRequest {
+        helper_path: &inputs[0],
+        consent: &consent,
+        snapshot: &snapshot,
+        policy: &snapshot.access,
+        host: &snapshot.host_id,
+        at: Timestamp(2),
+        root_id: &root,
+        worktree: &inputs[1],
+        protected_paths: &inputs[2..],
+        profile: Profile::ReadOnly,
+        program: "/usr/bin/codex",
+        args: &args,
+        limits: TransportLimits::default(),
+    })?);
+    let report = codex::discover(&mut probe, Duration::from_secs(20));
+    let _cleanup = probe.0.cancel(Duration::from_secs(2))?;
+    let report = report?;
+    if report.authentication != codex::CodexAuthentication::Required {
+        return Err("fresh isolated profile did not report authentication required".into());
+    }
+    println!(
+        "{}",
+        serde_json::json!({
+            "server_version": report.server_version,
+            "authentication": report.authentication,
+            "listed_models": report.models.len(),
+            "model_usability": "unknown",
+            "model_turn_started": false,
+            "profile": "fresh_disposable_home",
+            "network": "denied_by_sandbox"
+        })
+    );
+    Ok(())
+}

--- a/crates/symbiote-runtime-discovery/examples/discovery_schema.rs
+++ b/crates/symbiote-runtime-discovery/examples/discovery_schema.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), serde_json::Error> {
+    let schemas = serde_json::json!({"inventory":schemars::schema_for!(symbiote_runtime_discovery::Inventory),"eligibility_query":schemars::schema_for!(symbiote_runtime_discovery::EligibilityQuery)});
+    println!("{}", serde_json::to_string_pretty(&schemas)?);
+    Ok(())
+}

--- a/crates/symbiote-runtime-discovery/src/codex.rs
+++ b/crates/symbiote-runtime-discovery/src/codex.rs
@@ -1,0 +1,376 @@
+//! Read-only Codex App Server discovery. Results are advertisements, never proof
+//! of credential validity, entitlement, model usability or execution authority.
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeSet,
+    time::{Duration, Instant},
+};
+
+pub const CODEX_VERSION: &str = "0.118.0";
+const MAX_MODELS: usize = 256;
+const PAGE_SIZE: usize = 32;
+const MAX_PAGES: usize = 8;
+const MAX_NOTIFICATIONS: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexDiscoveryError {
+    Transport,
+    Deadline,
+    MalformedFrame,
+    UnexpectedResponse,
+    RpcFailure,
+    UnsupportedVersion,
+    LimitExceeded,
+    DuplicateModel,
+    RepeatedCursor,
+}
+impl std::fmt::Display for CodexDiscoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Codex discovery failed")
+    }
+}
+impl std::error::Error for CodexDiscoveryError {}
+
+/// Implementations must bound framing and reject duplicate JSON object keys
+/// before producing Value (the shared JsonlTransport does both). No raw transport
+/// error strings may be retained. Every call must respect its supplied timeout.
+pub trait DiscoveryTransport {
+    fn send(&mut self, message: &Value, timeout: Duration) -> Result<(), CodexDiscoveryError>;
+    fn recv(&mut self, timeout: Duration) -> Result<Value, CodexDiscoveryError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexAuthentication {
+    Required,
+    NotRequired,
+    ApiKeyReported,
+    ChatGptReported,
+    Unknown,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexInputModality {
+    Text,
+    Image,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexModel {
+    /// Server picker identity, distinct from model name and canonical domain ID.
+    pub listing_id: String,
+    pub provider_model: String,
+    pub is_default: bool,
+    pub hidden: bool,
+    pub supported_reasoning: BTreeSet<CodexReasoningEffort>,
+    pub default_reasoning: CodexReasoningEffort,
+    /// Absent fields remain unknown, even if upstream schema declares defaults.
+    pub input_modalities: Option<BTreeSet<CodexInputModality>>,
+    pub context_tokens: Option<u64>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexProbeReport {
+    pub server_version: String,
+    pub authentication: CodexAuthentication,
+    pub models: Vec<CodexModel>,
+}
+
+fn remaining(deadline: Instant) -> Result<Duration, CodexDiscoveryError> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|d| !d.is_zero())
+        .ok_or(CodexDiscoveryError::Deadline)
+}
+fn bounded_frame(value: &Value) -> Result<(), CodexDiscoveryError> {
+    let mut stack = vec![(value, 0)];
+    let mut nodes = 0;
+    let mut bytes = 0usize;
+    while let Some((value, depth)) = stack.pop() {
+        nodes += 1;
+        if nodes > 65_536 || depth > 64 {
+            return Err(CodexDiscoveryError::LimitExceeded);
+        }
+        match value {
+            Value::String(s) => bytes = bytes.saturating_add(s.len()),
+            Value::Array(a) => {
+                if a.len() > 65_536usize.saturating_sub(nodes + stack.len()) {
+                    return Err(CodexDiscoveryError::LimitExceeded);
+                }
+                stack.extend(a.iter().map(|v| (v, depth + 1)));
+            }
+            Value::Object(o) => {
+                if o.len() > 65_536usize.saturating_sub(nodes + stack.len()) {
+                    return Err(CodexDiscoveryError::LimitExceeded);
+                }
+                for (k, v) in o {
+                    bytes = bytes.saturating_add(k.len());
+                    stack.push((v, depth + 1));
+                }
+            }
+            _ => {}
+        }
+        if bytes > 1_048_576 {
+            return Err(CodexDiscoveryError::LimitExceeded);
+        }
+    }
+    Ok(())
+}
+fn response(
+    transport: &mut impl DiscoveryTransport,
+    id: u64,
+    deadline: Instant,
+    notifications: &mut usize,
+) -> Result<Value, CodexDiscoveryError> {
+    loop {
+        let frame = transport.recv(remaining(deadline)?)?;
+        remaining(deadline)?;
+        bounded_frame(&frame)?;
+        let object = frame
+            .as_object()
+            .ok_or(CodexDiscoveryError::MalformedFrame)?;
+        if object.contains_key("method") {
+            if object
+                .keys()
+                .any(|k| !matches!(k.as_str(), "method" | "params"))
+                || !object["method"]
+                    .as_str()
+                    .is_some_and(|s| !s.is_empty() && s.len() <= 256)
+            {
+                return Err(CodexDiscoveryError::MalformedFrame);
+            }
+            *notifications += 1;
+            if *notifications > MAX_NOTIFICATIONS {
+                return Err(CodexDiscoveryError::LimitExceeded);
+            }
+            continue;
+        }
+        if object
+            .keys()
+            .any(|k| !matches!(k.as_str(), "id" | "result" | "error"))
+            || object.get("id").and_then(Value::as_u64) != Some(id)
+        {
+            return Err(CodexDiscoveryError::UnexpectedResponse);
+        }
+        match (object.get("result"), object.get("error")) {
+            (Some(result), None) if result.is_object() => return Ok(result.clone()),
+            (None, Some(error)) if error.is_object() => {
+                return Err(CodexDiscoveryError::RpcFailure);
+            }
+            _ => return Err(CodexDiscoveryError::MalformedFrame),
+        }
+    }
+}
+fn call(
+    transport: &mut impl DiscoveryTransport,
+    id: u64,
+    method: &str,
+    params: Value,
+    deadline: Instant,
+    notifications: &mut usize,
+) -> Result<Value, CodexDiscoveryError> {
+    transport.send(
+        &json!({"id":id,"method":method,"params":params}),
+        remaining(deadline)?,
+    )?;
+    response(transport, id, deadline, notifications)
+}
+fn identifier(value: Option<&Value>) -> Result<String, CodexDiscoveryError> {
+    let s = value
+        .and_then(Value::as_str)
+        .ok_or(CodexDiscoveryError::MalformedFrame)?;
+    if s.is_empty()
+        || s.len() > 128
+        || !s
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._:/-".contains(&b))
+    {
+        return Err(CodexDiscoveryError::MalformedFrame);
+    }
+    Ok(s.into())
+}
+fn effort(value: Option<&Value>) -> Result<CodexReasoningEffort, CodexDiscoveryError> {
+    match value.and_then(Value::as_str) {
+        Some("none") => Ok(CodexReasoningEffort::None),
+        Some("minimal") => Ok(CodexReasoningEffort::Minimal),
+        Some("low") => Ok(CodexReasoningEffort::Low),
+        Some("medium") => Ok(CodexReasoningEffort::Medium),
+        Some("high") => Ok(CodexReasoningEffort::High),
+        Some("xhigh") => Ok(CodexReasoningEffort::Xhigh),
+        _ => Err(CodexDiscoveryError::MalformedFrame),
+    }
+}
+fn model(value: &Value) -> Result<CodexModel, CodexDiscoveryError> {
+    let options = value
+        .get("supportedReasoningEfforts")
+        .and_then(Value::as_array)
+        .ok_or(CodexDiscoveryError::MalformedFrame)?;
+    if options.len() > 6 {
+        return Err(CodexDiscoveryError::LimitExceeded);
+    }
+    let mut supported_reasoning = BTreeSet::new();
+    for option in options {
+        if !supported_reasoning.insert(effort(option.get("reasoningEffort"))?) {
+            return Err(CodexDiscoveryError::MalformedFrame);
+        }
+    }
+    let default_reasoning = effort(value.get("defaultReasoningEffort"))?;
+    if !supported_reasoning.contains(&default_reasoning) {
+        return Err(CodexDiscoveryError::MalformedFrame);
+    }
+    let input_modalities = match value.get("inputModalities") {
+        None => None,
+        Some(Value::Array(options)) if options.len() <= 2 => {
+            let mut set = BTreeSet::new();
+            for option in options {
+                let modality = match option.as_str() {
+                    Some("text") => CodexInputModality::Text,
+                    Some("image") => CodexInputModality::Image,
+                    _ => return Err(CodexDiscoveryError::MalformedFrame),
+                };
+                if !set.insert(modality) {
+                    return Err(CodexDiscoveryError::MalformedFrame);
+                }
+            }
+            Some(set)
+        }
+        _ => return Err(CodexDiscoveryError::MalformedFrame),
+    };
+    Ok(CodexModel {
+        listing_id: identifier(value.get("id"))?,
+        provider_model: identifier(value.get("model"))?,
+        is_default: value
+            .get("isDefault")
+            .and_then(Value::as_bool)
+            .ok_or(CodexDiscoveryError::MalformedFrame)?,
+        hidden: value
+            .get("hidden")
+            .and_then(Value::as_bool)
+            .ok_or(CodexDiscoveryError::MalformedFrame)?,
+        supported_reasoning,
+        default_reasoning,
+        input_modalities,
+        context_tokens: None,
+    })
+}
+
+/// Probe exactly initialize/initialized/account-read/model-list, never a login,
+/// thread, turn, install, configuration write or credential refresh operation.
+pub fn discover(
+    transport: &mut impl DiscoveryTransport,
+    timeout: Duration,
+) -> Result<CodexProbeReport, CodexDiscoveryError> {
+    if timeout.is_zero() || timeout > Duration::from_secs(30) {
+        return Err(CodexDiscoveryError::Deadline);
+    }
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or(CodexDiscoveryError::Deadline)?;
+    let mut notifications = 0;
+    let initialized = call(
+        transport,
+        1,
+        "initialize",
+        json!({"clientInfo":{"name":"symbiote","version":"0.1.0","title":"Symbiote"}}),
+        deadline,
+        &mut notifications,
+    )?;
+    let user_agent = initialized
+        .get("userAgent")
+        .and_then(Value::as_str)
+        .ok_or(CodexDiscoveryError::MalformedFrame)?;
+    if user_agent.len() > 1024 || user_agent.split_whitespace().next() != Some("symbiote/0.118.0") {
+        return Err(CodexDiscoveryError::UnsupportedVersion);
+    }
+    transport.send(
+        &json!({"method":"initialized","params":{}}),
+        remaining(deadline)?,
+    )?;
+    let account = call(
+        transport,
+        2,
+        "account/read",
+        json!({"refreshToken":false}),
+        deadline,
+        &mut notifications,
+    )?;
+    let required = account
+        .get("requiresOpenaiAuth")
+        .and_then(Value::as_bool)
+        .ok_or(CodexDiscoveryError::MalformedFrame)?;
+    let authentication = match account.get("account") {
+        None | Some(Value::Null) => {
+            if required {
+                CodexAuthentication::Required
+            } else {
+                CodexAuthentication::NotRequired
+            }
+        }
+        Some(account) => match account.get("type").and_then(Value::as_str) {
+            Some("apiKey") => CodexAuthentication::ApiKeyReported,
+            Some("chatgpt") => CodexAuthentication::ChatGptReported,
+            Some(_) => CodexAuthentication::Unknown,
+            None => return Err(CodexDiscoveryError::MalformedFrame),
+        },
+    };
+    let mut models = Vec::new();
+    let mut ids = BTreeSet::new();
+    let mut cursors = BTreeSet::new();
+    let mut cursor = None;
+    for page in 0..MAX_PAGES {
+        let result = call(
+            transport,
+            3 + page as u64,
+            "model/list",
+            json!({"limit":PAGE_SIZE,"includeHidden":false,"cursor":cursor}),
+            deadline,
+            &mut notifications,
+        )?;
+        let data = result
+            .get("data")
+            .and_then(Value::as_array)
+            .ok_or(CodexDiscoveryError::MalformedFrame)?;
+        if data.len() > PAGE_SIZE || models.len() + data.len() > MAX_MODELS {
+            return Err(CodexDiscoveryError::LimitExceeded);
+        }
+        for item in data {
+            let item = model(item)?;
+            if !ids.insert(item.listing_id.clone()) {
+                return Err(CodexDiscoveryError::DuplicateModel);
+            }
+            models.push(item);
+        }
+        match result.get("nextCursor") {
+            None | Some(Value::Null) => {
+                remaining(deadline)?;
+                models.sort_by(|a, b| a.listing_id.cmp(&b.listing_id));
+                return Ok(CodexProbeReport {
+                    server_version: CODEX_VERSION.into(),
+                    authentication,
+                    models,
+                });
+            }
+            Some(Value::String(next))
+                if !next.is_empty()
+                    && next.len() <= 1024
+                    && !next.chars().any(char::is_control) =>
+            {
+                if !cursors.insert(next.clone()) {
+                    return Err(CodexDiscoveryError::RepeatedCursor);
+                }
+                cursor = Some(next.clone());
+            }
+            _ => return Err(CodexDiscoveryError::MalformedFrame),
+        }
+    }
+    Err(CodexDiscoveryError::LimitExceeded)
+}

--- a/crates/symbiote-runtime-discovery/src/lib.rs
+++ b/crates/symbiote-runtime-discovery/src/lib.rs
@@ -1,0 +1,500 @@
+//! Host-local runtime inventory. Discovery never grants activation, credential,
+//! installation or billing authority. Caller-supplied observations require Host provenance.
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+use symbiote_domain::*;
+pub mod codex;
+pub const DISCOVERY_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(
+    tag = "status",
+    content = "value",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+pub enum Fact<T> {
+    Unknown,
+    Known(T),
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeInstanceIntent {
+    pub profile_id: RuntimeProfileId,
+    pub installation_id: InstallationId,
+    pub host_id: HostId,
+    pub runtime_kind: RuntimeKind,
+    pub adapter_id: AgentRuntimeAdapterId,
+    /// Display label only; never used for eligibility or adapter dispatch.
+    pub instance_name: String,
+    /// Symbolic identity, never an absolute HOME, credential or native configuration path.
+    pub config_identity: String,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InterfaceIdentity {
+    pub name: String,
+    pub version: String,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Health {
+    Reachable,
+    Unavailable,
+    RateLimited,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMode {
+    None,
+    ApiKey,
+    ChatGpt,
+    Other,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthState {
+    NotRequired,
+    Required,
+    Authenticated,
+    Expired,
+    RateLimited,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Authentication {
+    pub mode: AuthMode,
+    pub state: AuthState,
+    /// Host-generated opaque reference only. Never copy an email, token or account payload here.
+    pub account_ref: Option<String>,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ModelListing {
+    /// External model identifiers remain separate from canonical Model identity.
+    pub upstream_model: String,
+    pub canonical_model_id: Option<ModelId>,
+    pub context_tokens: Fact<u64>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MethodAvailability {
+    Unknown,
+    Available,
+    Unsupported,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct IsolationEvidence {
+    pub verified_by: HostId,
+    pub evidence_id: EvidenceId,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DiscoveryFacts {
+    pub health: Fact<Health>,
+    pub authentication: Fact<Authentication>,
+    pub models: Fact<Vec<ModelListing>>,
+    #[serde(deserialize_with = "methods_decode")]
+    pub methods: BTreeMap<String, MethodAvailability>,
+    pub isolation: Fact<IsolationEvidence>,
+}
+fn methods_decode<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<BTreeMap<String, MethodAvailability>, D::Error> {
+    struct Methods;
+    impl<'de> serde::de::Visitor<'de> for Methods {
+        type Value = BTreeMap<String, MethodAvailability>;
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("at most 64 unique method names")
+        }
+        fn visit_map<A: serde::de::MapAccess<'de>>(
+            self,
+            mut map: A,
+        ) -> Result<Self::Value, A::Error> {
+            let mut methods = BTreeMap::new();
+            while let Some((name, state)) = map.next_entry()? {
+                if methods.len() == 64 || methods.insert(name, state).is_some() {
+                    return Err(serde::de::Error::custom("invalid methods"));
+                }
+            }
+            Ok(methods)
+        }
+    }
+    deserializer.deserialize_map(Methods)
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationSource {
+    SandboxedProbe,
+    TrustedHostProbe,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeProvenance {
+    pub probe_id: CommandId,
+    pub source: ObservationSource,
+    pub adapter_revision: String,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct InstallationObservation {
+    pub config_identity: String,
+    pub profile_id: RuntimeProfileId,
+    pub installation_id: InstallationId,
+    pub host_id: HostId,
+    pub runtime_kind: RuntimeKind,
+    pub adapter_id: AgentRuntimeAdapterId,
+    pub version: Fact<String>,
+    pub interface: Fact<InterfaceIdentity>,
+    pub facts: DiscoveryFacts,
+    pub observed_at: Timestamp,
+    pub expires_at: Timestamp,
+    pub provenance: ProbeProvenance,
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "RecordWire")]
+pub struct DiscoveryRecord {
+    pub schema_version: u32,
+    pub intent: RuntimeInstanceIntent,
+    pub observation: InstallationObservation,
+}
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct RecordWire {
+    schema_version: u32,
+    intent: RuntimeInstanceIntent,
+    observation: InstallationObservation,
+}
+impl TryFrom<RecordWire> for DiscoveryRecord {
+    type Error = DiscoveryError;
+    fn try_from(w: RecordWire) -> Result<Self, Self::Error> {
+        let value = Self {
+            schema_version: w.schema_version,
+            intent: w.intent,
+            observation: w.observation,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiscoveryError {
+    InvalidRecord,
+    ResourceLimit,
+    UnsupportedVersion,
+    NotFound,
+    IdentityMismatch,
+    VersionMismatch,
+    Stale,
+    UnknownMandatoryFact,
+    Unhealthy,
+    AuthenticationRequired,
+    AuthenticationExpired,
+    RateLimited,
+    UnsupportedMethod,
+    ModelNotListed,
+    InsufficientContext,
+    IsolationUnverified,
+}
+impl fmt::Display for DiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for DiscoveryError {}
+fn symbol(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+}
+fn version(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._-+".contains(&b))
+}
+fn method(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/_-.".contains(&b))
+}
+fn model(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/_-.:".contains(&b))
+}
+struct Size(usize, usize);
+impl std::io::Write for Size {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > self.1 - self.0 {
+            return Err(std::io::Error::other("discovery limit"));
+        }
+        self.0 += bytes.len();
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+impl DiscoveryRecord {
+    pub fn validate(&self) -> Result<(), DiscoveryError> {
+        if self.schema_version != DISCOVERY_VERSION {
+            return Err(DiscoveryError::UnsupportedVersion);
+        }
+        let i = &self.intent;
+        let o = &self.observation;
+        if i.instance_name.trim().is_empty()
+            || i.instance_name.len() > 128
+            || i.instance_name.chars().any(char::is_control)
+            || !symbol(&i.config_identity)
+            || !symbol(&o.config_identity)
+            || !version(&o.provenance.adapter_revision)
+        {
+            return Err(DiscoveryError::InvalidRecord);
+        }
+        if o.expires_at.0 <= o.observed_at.0 || o.expires_at.0 - o.observed_at.0 > 86_400_000 {
+            return Err(DiscoveryError::InvalidRecord);
+        }
+        if let Fact::Known(v) = &o.version {
+            if !version(v) {
+                return Err(DiscoveryError::InvalidRecord);
+            }
+        }
+        if let Fact::Known(interface) = &o.interface {
+            if !symbol(&interface.name) || !version(&interface.version) {
+                return Err(DiscoveryError::InvalidRecord);
+            }
+        }
+        if o.facts.methods.len() > 64 {
+            return Err(DiscoveryError::ResourceLimit);
+        }
+        if o.facts.methods.keys().any(|s| !method(s)) {
+            return Err(DiscoveryError::InvalidRecord);
+        }
+        if let Fact::Known(auth) = &o.facts.authentication {
+            if auth
+                .account_ref
+                .as_ref()
+                .is_some_and(|s| !symbol(s) || !s.starts_with("account_"))
+                || ((auth.state == AuthState::Authenticated) && (auth.mode == AuthMode::None))
+                || ((auth.state == AuthState::Required || auth.state == AuthState::NotRequired)
+                    && auth.account_ref.is_some())
+            {
+                return Err(DiscoveryError::InvalidRecord);
+            }
+        }
+        if let Fact::Known(models) = &o.facts.models {
+            if models.len() > 256 {
+                return Err(DiscoveryError::ResourceLimit);
+            }
+            let mut names = BTreeSet::new();
+            let mut mapped = BTreeSet::new();
+            for m in models {
+                if !model(&m.upstream_model)
+                    || !names.insert(&m.upstream_model)
+                    || m.canonical_model_id
+                        .as_ref()
+                        .is_some_and(|id| !mapped.insert(id))
+                    || matches!(m.context_tokens, Fact::Known(0))
+                {
+                    return Err(DiscoveryError::InvalidRecord);
+                }
+            }
+        }
+        if let Fact::Known(isolation) = &o.facts.isolation {
+            if isolation.verified_by != o.host_id {
+                return Err(DiscoveryError::IdentityMismatch);
+            }
+        }
+        serde_json::to_writer(Size(0, 65_536), self).map_err(|_| DiscoveryError::ResourceLimit)?;
+        Ok(())
+    }
+    /// Qualification is an observation match, never permission to launch or bill.
+    pub fn qualify(&self, q: &EligibilityQuery, at: Timestamp) -> Result<(), DiscoveryError> {
+        self.validate()?;
+        q.validate()?;
+        let i = &self.intent;
+        let o = &self.observation;
+        if i.config_identity != q.config_identity
+            || o.config_identity != q.config_identity
+            || i.host_id != q.host_id
+            || o.host_id != q.host_id
+            || i.profile_id != q.profile_id
+            || o.profile_id != q.profile_id
+            || i.installation_id != q.installation_id
+            || o.installation_id != q.installation_id
+            || i.runtime_kind != q.runtime_kind
+            || o.runtime_kind != q.runtime_kind
+            || i.adapter_id != q.adapter_id
+            || o.adapter_id != q.adapter_id
+        {
+            return Err(DiscoveryError::IdentityMismatch);
+        }
+        if at.0 < o.observed_at.0 || at.0 >= o.expires_at.0 {
+            return Err(DiscoveryError::Stale);
+        }
+        match (&o.version, &o.interface) {
+            (Fact::Known(v), Fact::Known(interface))
+                if v == &q.version && interface == &q.interface => {}
+            (Fact::Unknown, _) | (_, Fact::Unknown) => {
+                return Err(DiscoveryError::UnknownMandatoryFact);
+            }
+            _ => return Err(DiscoveryError::VersionMismatch),
+        }
+        match o.facts.health {
+            Fact::Known(Health::Reachable) => {}
+            Fact::Known(Health::RateLimited) => return Err(DiscoveryError::RateLimited),
+            Fact::Known(Health::Unavailable) => return Err(DiscoveryError::Unhealthy),
+            Fact::Unknown => return Err(DiscoveryError::UnknownMandatoryFact),
+        }
+        for name in &q.required_methods {
+            match o.facts.methods.get(name) {
+                Some(MethodAvailability::Available) => {}
+                Some(MethodAvailability::Unsupported) => {
+                    return Err(DiscoveryError::UnsupportedMethod);
+                }
+                _ => return Err(DiscoveryError::UnknownMandatoryFact),
+            }
+        }
+        if q.requires_authenticated {
+            match &o.facts.authentication {
+                Fact::Known(Authentication {
+                    state: AuthState::Authenticated,
+                    ..
+                }) => {}
+                Fact::Known(Authentication {
+                    state: AuthState::Expired,
+                    ..
+                }) => return Err(DiscoveryError::AuthenticationExpired),
+                Fact::Known(Authentication {
+                    state: AuthState::RateLimited,
+                    ..
+                }) => return Err(DiscoveryError::RateLimited),
+                Fact::Unknown => return Err(DiscoveryError::UnknownMandatoryFact),
+                _ => return Err(DiscoveryError::AuthenticationRequired),
+            }
+        }
+        if let Some(name) = &q.upstream_model {
+            let Fact::Known(models) = &o.facts.models else {
+                return Err(DiscoveryError::UnknownMandatoryFact);
+            };
+            let listed = models
+                .iter()
+                .find(|m| &m.upstream_model == name)
+                .ok_or(DiscoveryError::ModelNotListed)?;
+            if let Some(min) = q.minimum_context_tokens {
+                match listed.context_tokens {
+                    Fact::Known(tokens) if tokens >= min => {}
+                    Fact::Known(_) => return Err(DiscoveryError::InsufficientContext),
+                    Fact::Unknown => return Err(DiscoveryError::UnknownMandatoryFact),
+                }
+            }
+        }
+        if q.requires_isolation && matches!(o.facts.isolation, Fact::Unknown) {
+            return Err(DiscoveryError::IsolationUnverified);
+        }
+        Ok(())
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EligibilityQuery {
+    pub config_identity: String,
+    pub profile_id: RuntimeProfileId,
+    pub installation_id: InstallationId,
+    pub host_id: HostId,
+    pub runtime_kind: RuntimeKind,
+    pub adapter_id: AgentRuntimeAdapterId,
+    pub version: String,
+    pub interface: InterfaceIdentity,
+    pub required_methods: BTreeSet<String>,
+    pub requires_authenticated: bool,
+    pub upstream_model: Option<String>,
+    pub minimum_context_tokens: Option<u64>,
+    pub requires_isolation: bool,
+}
+impl EligibilityQuery {
+    pub fn validate(&self) -> Result<(), DiscoveryError> {
+        if !symbol(&self.config_identity)
+            || !version(&self.version)
+            || !symbol(&self.interface.name)
+            || !version(&self.interface.version)
+            || self.required_methods.len() > 64
+            || self.required_methods.iter().any(|m| !method(m))
+            || self.upstream_model.as_ref().is_some_and(|s| !model(s))
+            || self
+                .minimum_context_tokens
+                .is_some_and(|n| n == 0 || self.upstream_model.is_none())
+        {
+            return Err(DiscoveryError::InvalidRecord);
+        }
+        Ok(())
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(try_from = "InventoryWire")]
+pub struct Inventory {
+    schema_version: u32,
+    records: Vec<DiscoveryRecord>,
+}
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct InventoryWire {
+    schema_version: u32,
+    records: Vec<DiscoveryRecord>,
+}
+impl TryFrom<InventoryWire> for Inventory {
+    type Error = DiscoveryError;
+    fn try_from(w: InventoryWire) -> Result<Self, Self::Error> {
+        if w.schema_version != DISCOVERY_VERSION {
+            return Err(DiscoveryError::UnsupportedVersion);
+        }
+        Self::new(w.records)
+    }
+}
+impl Inventory {
+    pub fn new(records: Vec<DiscoveryRecord>) -> Result<Self, DiscoveryError> {
+        if records.len() > 256 {
+            return Err(DiscoveryError::ResourceLimit);
+        }
+        let mut identities = BTreeSet::new();
+        for record in &records {
+            record.validate()?;
+            if !identities.insert((&record.intent.host_id, &record.intent.profile_id)) {
+                return Err(DiscoveryError::IdentityMismatch);
+            }
+        }
+        let inventory = Self {
+            schema_version: DISCOVERY_VERSION,
+            records,
+        };
+        serde_json::to_writer(Size(0, 4_194_304), &inventory)
+            .map_err(|_| DiscoveryError::ResourceLimit)?;
+        Ok(inventory)
+    }
+    pub fn parse(input: &str) -> Result<Self, DiscoveryError> {
+        if input.len() > 4_194_304 {
+            return Err(DiscoveryError::ResourceLimit);
+        }
+        serde_json::from_str(input).map_err(|_| DiscoveryError::InvalidRecord)
+    }
+    pub fn records(&self) -> &[DiscoveryRecord] {
+        &self.records
+    }
+    pub fn qualify(&self, q: &EligibilityQuery, at: Timestamp) -> Result<(), DiscoveryError> {
+        self.records
+            .iter()
+            .find(|r| r.intent.host_id == q.host_id && r.intent.profile_id == q.profile_id)
+            .ok_or(DiscoveryError::NotFound)?
+            .qualify(q, at)
+    }
+}

--- a/crates/symbiote-runtime-discovery/tests/codex.rs
+++ b/crates/symbiote-runtime-discovery/tests/codex.rs
@@ -1,0 +1,179 @@
+//! Mock transport tests establish discovery contracts, not a live integration.
+use serde_json::{Value, json};
+use std::{collections::VecDeque, time::Duration};
+use symbiote_runtime_discovery::codex::*;
+
+struct Fixture {
+    replies: VecDeque<Value>,
+    sent: Vec<Value>,
+    delay: Duration,
+}
+impl DiscoveryTransport for Fixture {
+    fn send(&mut self, value: &Value, _: Duration) -> Result<(), CodexDiscoveryError> {
+        self.sent.push(value.clone());
+        Ok(())
+    }
+    fn recv(&mut self, _: Duration) -> Result<Value, CodexDiscoveryError> {
+        std::thread::sleep(self.delay);
+        self.replies
+            .pop_front()
+            .ok_or(CodexDiscoveryError::Transport)
+    }
+}
+fn model(id: &str) -> Value {
+    json!({"id":id,"model":"gpt-5.4","isDefault":true,"hidden":false,"defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"medium","description":"ignored"}],"displayName":"ignored","description":"ignored"})
+}
+fn fixture() -> Fixture {
+    Fixture {
+        sent: vec![],
+        delay: Duration::ZERO,
+        replies: VecDeque::from([
+            json!({"id":1,"result":{"userAgent":"symbiote/0.118.0 (Linux)"}}),
+            json!({"id":2,"result":{"requiresOpenaiAuth":true,"account":null}}),
+            json!({"id":3,"result":{"data":[model("picker.one")],"nextCursor":null}}),
+        ]),
+    }
+}
+
+#[test]
+fn handshake_is_versionless_read_only_and_fields_not_reported_remain_unknown() {
+    let mut fixture = fixture();
+    let report = discover(&mut fixture, Duration::from_secs(1)).unwrap();
+    assert_eq!(report.authentication, CodexAuthentication::Required);
+    assert_eq!(report.server_version, "0.118.0");
+    assert_eq!(fixture.sent[0]["params"]["clientInfo"]["version"], "0.1.0");
+    assert_eq!(report.models[0].provider_model, "gpt-5.4");
+    assert_eq!(report.models[0].context_tokens, None);
+    assert_eq!(report.models[0].input_modalities, None);
+    let methods: Vec<_> = fixture
+        .sent
+        .iter()
+        .map(|v| v["method"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        methods,
+        ["initialize", "initialized", "account/read", "model/list"]
+    );
+    assert!(fixture.sent.iter().all(|v| v.get("jsonrpc").is_none()));
+    assert_eq!(fixture.sent[2]["params"]["refreshToken"], false);
+    assert_eq!(fixture.sent[3]["params"]["limit"], 32);
+}
+
+#[test]
+fn account_metadata_and_error_contents_are_discarded() {
+    let mut fixture = fixture();
+    fixture.replies[1] = json!({"id":2,"result":{"requiresOpenaiAuth":true,"account":{"type":"chatgpt","email":"private@example.test","planType":"pro","token":"private-token"}}});
+    let report = discover(&mut fixture, Duration::from_secs(1)).unwrap();
+    assert_eq!(report.authentication, CodexAuthentication::ChatGptReported);
+    let output = format!("{report:?}{}", serde_json::to_string(&report).unwrap());
+    assert!(!output.contains("private"));
+    assert!(!output.contains("pro\""));
+    let mut fixture = crate::fixture();
+    fixture.replies[1] = json!({"id":2,"error":{"code":-1,"message":"private-token","data":{"email":"private@example.test"}}});
+    let error = discover(&mut fixture, Duration::from_secs(1)).unwrap_err();
+    assert_eq!(error, CodexDiscoveryError::RpcFailure);
+    assert!(!format!("{error:?} {error}").contains("private"));
+}
+
+#[test]
+fn exact_server_version_and_correlation_are_required() {
+    for frame in [
+        json!({"id":1,"result":{"userAgent":"symbiote/0.118.1 (Linux)"}}),
+        json!({"id":1,"result":{"userAgent":"unrelated symbiote/0.118.0"}}),
+        json!({"id":2,"result":{}}),
+        json!({"id":1,"result":{},"error":{}}),
+        json!({"id":1,"method":"initialize","params":{}}),
+    ] {
+        let mut fixture = fixture();
+        fixture.replies[0] = frame;
+        assert!(discover(&mut fixture, Duration::from_secs(1)).is_err());
+    }
+    let mut fixture = fixture();
+    fixture.replies[1] = fixture.replies[0].clone();
+    assert_eq!(
+        discover(&mut fixture, Duration::from_secs(1)),
+        Err(CodexDiscoveryError::UnexpectedResponse)
+    );
+}
+
+#[test]
+fn pagination_is_bounded_correlated_and_deterministic() {
+    let mut fixture = fixture();
+    fixture.replies[2]["result"]["nextCursor"] = json!("page-two");
+    fixture
+        .replies
+        .push_back(json!({"id":4,"result":{"data":[model("a-picker")],"nextCursor":null}}));
+    let report = discover(&mut fixture, Duration::from_secs(1)).unwrap();
+    assert_eq!(report.models[0].listing_id, "a-picker");
+    assert_eq!(fixture.sent[4]["params"]["cursor"], "page-two");
+    let mut fixture = crate::fixture();
+    fixture.replies[2]["result"]["nextCursor"] = json!("same");
+    fixture
+        .replies
+        .push_back(json!({"id":4,"result":{"data":[],"nextCursor":"same"}}));
+    assert_eq!(
+        discover(&mut fixture, Duration::from_secs(1)),
+        Err(CodexDiscoveryError::RepeatedCursor)
+    );
+    let mut fixture = crate::fixture();
+    fixture.replies[2]["result"]["data"] = json!([model("same"), model("same")]);
+    assert_eq!(
+        discover(&mut fixture, Duration::from_secs(1)),
+        Err(CodexDiscoveryError::DuplicateModel)
+    );
+}
+
+#[test]
+fn notification_flood_and_absolute_deadline_fail_without_reset() {
+    let mut fixture = fixture();
+    for _ in 0..33 {
+        fixture
+            .replies
+            .push_front(json!({"method":"account/updated","params":{"ignored":"private"}}));
+    }
+    assert_eq!(
+        discover(&mut fixture, Duration::from_secs(1)),
+        Err(CodexDiscoveryError::LimitExceeded)
+    );
+    let mut fixture = crate::fixture();
+    fixture.delay = Duration::from_millis(10);
+    assert_eq!(
+        discover(&mut fixture, Duration::from_millis(1)),
+        Err(CodexDiscoveryError::Deadline)
+    );
+    assert_eq!(fixture.sent.len(), 1);
+}
+
+#[test]
+fn advertised_capabilities_are_never_guessed() {
+    let mut fixture = fixture();
+    fixture.replies[2]["result"]["data"][0]["inputModalities"] = json!(["text"]);
+    fixture.replies[2]["result"]["data"][0]["contextWindow"] = json!(99999);
+    let report = discover(&mut fixture, Duration::from_secs(1)).unwrap();
+    assert_eq!(report.models[0].context_tokens, None);
+    assert_eq!(report.models[0].input_modalities.as_ref().unwrap().len(), 1);
+    let mut fixture = crate::fixture();
+    fixture.replies[2]["result"]["data"][0]["defaultReasoningEffort"] = json!("ultra");
+    assert_eq!(
+        discover(&mut fixture, Duration::from_secs(1)),
+        Err(CodexDiscoveryError::MalformedFrame)
+    );
+}
+
+#[test]
+fn optional_account_and_cursor_follow_pinned_schema() {
+    // 0.118.0 GetAccountResponse requires only requiresOpenaiAuth;
+    // ModelListResponse requires only data. Optional account/cursor may be absent.
+    let mut fixture = fixture();
+    fixture.replies[1]["result"]
+        .as_object_mut()
+        .unwrap()
+        .remove("account");
+    fixture.replies[2]["result"]
+        .as_object_mut()
+        .unwrap()
+        .remove("nextCursor");
+    let report = discover(&mut fixture, Duration::from_secs(1)).unwrap();
+    assert_eq!(report.authentication, CodexAuthentication::Required);
+    assert_eq!(report.models.len(), 1);
+}

--- a/crates/symbiote-runtime-discovery/tests/inventory.rs
+++ b/crates/symbiote-runtime-discovery/tests/inventory.rs
@@ -1,0 +1,269 @@
+use std::collections::{BTreeMap, BTreeSet};
+use symbiote_domain::*;
+use symbiote_runtime_discovery::*;
+fn record() -> DiscoveryRecord {
+    let intent = RuntimeInstanceIntent {
+        profile_id: RuntimeProfileId::new("profile").unwrap(),
+        installation_id: InstallationId::new("installation").unwrap(),
+        host_id: HostId::new("host").unwrap(),
+        runtime_kind: RuntimeKind::ExternalHarness,
+        adapter_id: AgentRuntimeAdapterId::new("adapter").unwrap(),
+        instance_name: "Named coding worker".into(),
+        config_identity: "private-config".into(),
+    };
+    DiscoveryRecord {
+        schema_version: 1,
+        observation: InstallationObservation {
+            config_identity: intent.config_identity.clone(),
+            profile_id: intent.profile_id.clone(),
+            installation_id: intent.installation_id.clone(),
+            host_id: intent.host_id.clone(),
+            runtime_kind: intent.runtime_kind,
+            adapter_id: intent.adapter_id.clone(),
+            version: Fact::Known("0.118.0".into()),
+            interface: Fact::Known(InterfaceIdentity {
+                name: "app-server".into(),
+                version: "0.118.0".into(),
+            }),
+            facts: DiscoveryFacts {
+                health: Fact::Known(Health::Reachable),
+                authentication: Fact::Known(Authentication {
+                    mode: AuthMode::None,
+                    state: AuthState::Required,
+                    account_ref: None,
+                }),
+                models: Fact::Known(vec![ModelListing {
+                    upstream_model: "provider/model-1.2".into(),
+                    canonical_model_id: None,
+                    context_tokens: Fact::Unknown,
+                }]),
+                methods: BTreeMap::from([("model/list".into(), MethodAvailability::Available)]),
+                isolation: Fact::Unknown,
+            },
+            observed_at: Timestamp(100),
+            expires_at: Timestamp(200),
+            provenance: ProbeProvenance {
+                probe_id: CommandId::new("probe").unwrap(),
+                source: ObservationSource::SandboxedProbe,
+                adapter_revision: "v1".into(),
+            },
+        },
+        intent,
+    }
+}
+fn query(r: &DiscoveryRecord) -> EligibilityQuery {
+    EligibilityQuery {
+        config_identity: r.intent.config_identity.clone(),
+        profile_id: r.intent.profile_id.clone(),
+        installation_id: r.intent.installation_id.clone(),
+        host_id: r.intent.host_id.clone(),
+        runtime_kind: r.intent.runtime_kind,
+        adapter_id: r.intent.adapter_id.clone(),
+        version: "0.118.0".into(),
+        interface: InterfaceIdentity {
+            name: "app-server".into(),
+            version: "0.118.0".into(),
+        },
+        required_methods: BTreeSet::from(["model/list".into()]),
+        requires_authenticated: false,
+        upstream_model: Some("provider/model-1.2".into()),
+        minimum_context_tokens: None,
+        requires_isolation: false,
+    }
+}
+#[test]
+fn named_intent_and_fresh_observed_facts_roundtrip_without_inferred_auth_or_context() {
+    let r = record();
+    let q = query(&r);
+    let inventory = Inventory::new(vec![r.clone()]).unwrap();
+    assert!(inventory.qualify(&q, Timestamp(150)).is_ok());
+    assert_eq!(
+        Inventory::parse(&serde_json::to_string(&inventory).unwrap()).unwrap(),
+        inventory
+    );
+    let mut renamed = r.clone();
+    renamed.intent.instance_name = "Native sounding display label".into();
+    assert!(renamed.qualify(&q, Timestamp(150)).is_ok());
+    let mut authenticated = q.clone();
+    authenticated.requires_authenticated = true;
+    assert_eq!(
+        r.qualify(&authenticated, Timestamp(150)),
+        Err(DiscoveryError::AuthenticationRequired)
+    );
+    let mut context = q.clone();
+    context.minimum_context_tokens = Some(1);
+    assert_eq!(
+        r.qualify(&context, Timestamp(150)),
+        Err(DiscoveryError::UnknownMandatoryFact)
+    );
+    let mut isolation = q;
+    isolation.requires_isolation = true;
+    assert_eq!(
+        r.qualify(&isolation, Timestamp(150)),
+        Err(DiscoveryError::IsolationUnverified)
+    );
+}
+#[test]
+fn stale_and_all_identity_version_interface_mismatches_are_rejected() {
+    let r = record();
+    let q = query(&r);
+    for at in [99, 200, 201] {
+        assert_eq!(r.qualify(&q, Timestamp(at)), Err(DiscoveryError::Stale));
+    }
+    let mut variants = Vec::new();
+    let mut v = r.clone();
+    v.observation.host_id = HostId::new("other").unwrap();
+    variants.push(v);
+    let mut v = r.clone();
+    v.observation.profile_id = RuntimeProfileId::new("other").unwrap();
+    variants.push(v);
+    let mut v = r.clone();
+    v.observation.installation_id = InstallationId::new("other").unwrap();
+    variants.push(v);
+    let mut v = r.clone();
+    v.observation.runtime_kind = RuntimeKind::NativeSymbiote;
+    variants.push(v);
+    let mut v = r.clone();
+    v.observation.adapter_id = AgentRuntimeAdapterId::new("other").unwrap();
+    variants.push(v);
+    let mut v = r.clone();
+    v.observation.config_identity = "other".into();
+    variants.push(v);
+    for v in variants {
+        assert_eq!(
+            v.qualify(&q, Timestamp(150)),
+            Err(DiscoveryError::IdentityMismatch)
+        );
+    }
+    let mut v = r.clone();
+    v.observation.version = Fact::Known("0.119.0".into());
+    assert_eq!(
+        v.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::VersionMismatch)
+    );
+    let mut v = r;
+    v.observation.interface = Fact::Known(InterfaceIdentity {
+        name: "other".into(),
+        version: "0.118.0".into(),
+    });
+    assert_eq!(
+        v.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::VersionMismatch)
+    );
+}
+#[test]
+fn unknown_none_expired_rate_limits_and_model_absence_stay_distinct() {
+    let mut r = record();
+    let mut q = query(&r);
+    r.observation.facts.models = Fact::Unknown;
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::UnknownMandatoryFact)
+    );
+    r.observation.facts.models = Fact::Known(vec![]);
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::ModelNotListed)
+    );
+    q.upstream_model = None;
+    q.requires_authenticated = true;
+    r.observation.facts.authentication = Fact::Unknown;
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::UnknownMandatoryFact)
+    );
+    r.observation.facts.authentication = Fact::Known(Authentication {
+        mode: AuthMode::ChatGpt,
+        state: AuthState::Expired,
+        account_ref: Some("account_local".into()),
+    });
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::AuthenticationExpired)
+    );
+    r.observation.facts.authentication = Fact::Known(Authentication {
+        mode: AuthMode::ApiKey,
+        state: AuthState::RateLimited,
+        account_ref: None,
+    });
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::RateLimited)
+    );
+    q.requires_authenticated = false;
+    r.observation
+        .facts
+        .methods
+        .insert("model/list".into(), MethodAvailability::Unknown);
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::UnknownMandatoryFact)
+    );
+    r.observation
+        .facts
+        .methods
+        .insert("model/list".into(), MethodAvailability::Unsupported);
+    assert_eq!(
+        r.qualify(&q, Timestamp(150)),
+        Err(DiscoveryError::UnsupportedMethod)
+    );
+}
+#[test]
+fn malformed_duplicate_and_oversized_inventory_is_rejected() {
+    let r = record();
+    assert!(Inventory::new(vec![r.clone(); 257]).is_err());
+    assert!(Inventory::new(vec![r.clone(), r.clone()]).is_err());
+    let mut value = serde_json::to_value(&r).unwrap();
+    value["schema_version"] = serde_json::json!(2);
+    assert!(serde_json::from_value::<DiscoveryRecord>(value).is_err());
+    let mut invalid = r.clone();
+    invalid.observation.facts.authentication = Fact::Known(Authentication {
+        mode: AuthMode::ChatGpt,
+        state: AuthState::Authenticated,
+        account_ref: Some("someone@example.com".into()),
+    });
+    assert!(invalid.validate().is_err());
+    let mut invalid = r.clone();
+    invalid.intent.config_identity = "/home/user/.codex".into();
+    assert!(invalid.validate().is_err());
+    let mut invalid = r.clone();
+    invalid.observation.expires_at = Timestamp(100);
+    assert!(invalid.validate().is_err());
+    let encoded = serde_json::to_string(&r).unwrap().replace(
+        "\"model/list\":\"available\"",
+        "\"model/list\":\"available\",\"model/list\":\"unsupported\"",
+    );
+    assert!(serde_json::from_str::<DiscoveryRecord>(&encoded).is_err());
+    let mut invalid = r;
+    invalid.observation.facts.models = Fact::Known(vec![ModelListing {
+        upstream_model: "m".into(),
+        canonical_model_id: None,
+        context_tokens: Fact::Known(0),
+    }]);
+    assert!(invalid.validate().is_err());
+}
+#[test]
+fn native_runtime_uses_same_contract_without_provider_adapter_conflation() {
+    let mut r = record();
+    r.intent.runtime_kind = RuntimeKind::NativeSymbiote;
+    r.observation.runtime_kind = RuntimeKind::NativeSymbiote;
+    r.intent.adapter_id = AgentRuntimeAdapterId::new("native-rust-loop").unwrap();
+    r.observation.adapter_id = r.intent.adapter_id.clone();
+    let q = query(&r);
+    assert!(r.qualify(&q, Timestamp(150)).is_ok());
+    let external = query(&record());
+    assert_eq!(
+        r.qualify(&external, Timestamp(150)),
+        Err(DiscoveryError::IdentityMismatch)
+    );
+}
+
+#[test]
+fn unknown_fact_cannot_silently_discard_claimed_payload() {
+    for input in [
+        r#"{"status":"unknown","value":{"account":"discarded"}}"#,
+        r#"{"status":"unknown","value":"discarded"}"#,
+    ] {
+        assert!(serde_json::from_str::<Fact<String>>(input).is_err());
+    }
+}

--- a/docs/contracts/runtime-discovery.md
+++ b/docs/contracts/runtime-discovery.md
@@ -1,0 +1,55 @@
+# Runtime discovery foundation (#186)
+
+`symbiote-runtime-discovery` provides version 1 inventory contracts and an actual
+read-only Codex App Server probe. It grants no execution, installation, login,
+credential or billing authority. #186 remains open for its full acceptance.
+
+Desired instance identity is separate from observations: Host, runtime kind,
+adapter, installation, profile and symbolic configuration identity must match.
+Qualification checks freshness, pinned interface/version and explicit required
+facts. Missing context limits, isolation or methods remain unknown. A model
+listing is not proof the account can use that model. External model strings are
+distinct from canonical Model IDs. Discovery cannot authorize worker activation.
+Caller-created observations require trusted Host provenance; serialized provenance
+labels are not signatures. The inventory is bounded and currently in memory.
+
+## Pinned Codex interface
+
+The tested release is `codex-cli 0.118.0`. The probe uses versionless JSONL RPC:
+`initialize`, `initialized`, `account/read` with `refreshToken: false`, then bounded
+`model/list` pagination. It never sends login, logout, thread or turn requests.
+Frames, notifications, pages, IDs and the overall deadline are bounded. Raw
+account identities, error payloads and user agents are not retained in reports.
+An account type is reported metadata, not a verified credential or billing route.
+
+The [official App Server documentation](https://learn.chatgpt.com/docs/app-server)
+describes the handshake and methods. Version-specific shapes were checked against
+the installed executable's `app-server generate-json-schema` output, without
+experimental methods. Actual initialization reports `symbiote/0.118.0` for our
+client name, despite clientInfo.version being `0.1.0`. The live probe caught the
+initial incorrect `codex_cli_rs` prefix assumption. Context limits are absent from
+this pinned model schema and remain unknown.
+
+## Actual Linux proof
+
+Build `symbiote-sandbox-launch`, then run the `codex_discover` example with its
+absolute path, an empty worktree under a private 0700 parent, and a separate
+protected Host directory. The sandbox runs `/usr/bin/codex` with a disposable
+`/home/agent` HOME, an empty environment, read-only project and isolated network.
+Initialization must report `/home/agent/.codex`. No real account directory is
+mounted. The runner checks cancellation errors; descendant cleanup remains
+`Unknown` under the shared transport contract.
+
+The local installed binary returned version `0.118.0`, authentication `required`
+and six listed models with model usability unknown. No model turn was started.
+CI repeats this with the exact Linux x64 npm artifact and its SHA-512 integrity
+before installing the binary on the disposable runner only. CI does not update
+the user's Codex installation. Unit fixtures prove rejection contracts; the real
+binary proof establishes this narrow offline protocol compatibility only.
+
+Pending: durable inventory/Host endpoints, discovery of configured profiles,
+native-provider discovery, executable provenance beyond the trusted `/usr`
+premise, explicit install/update consent, authentication/quota/entitlement health,
+account isolation acceptance, authenticated online model calls and coding tasks.
+No credentials, spending, runtime activation or first-release completion are
+implied by this foundation.

--- a/docs/engineering-handoff.md
+++ b/docs/engineering-handoff.md
@@ -1,5 +1,14 @@
 # Engineering handoff
 
+## Runtime discovery — 2026-09-08 UTC
+
+Change Stream `issue-186-runtime-discovery` starts from merged #482 at `1735a48`.
+The versioned inventory and read-only Codex probe distinguish observations from
+activation authority. See [runtime discovery](contracts/runtime-discovery.md)
+for the real offline sandbox proof, pinned compatibility and pending acceptance.
+The application is not ready to ship: discovery is not worker execution, and both
+native and external coding workflows still need end-to-end integration.
+
 ## Canonical work hierarchy — 2026-09-08 UTC
 
 Change Stream `issue-189-work-hierarchy` starts from merged #481 at `bb95e49`.


### PR DESCRIPTION
Adds a versioned, bounded runtime inventory and a real read-only Codex App Server discovery probe under #186. Qualification rejects stale or mismatched identities and unknown mandatory facts; observed account/model metadata grants no execution or billing authority.

The installed Codex 0.118.0 successfully completes initialization, account/read without refresh, and model/list in the Linux sandbox with a fresh disposable HOME and denied network. It reports authentication required and six listed models; no coding turn starts. CI repeats this proof using an exact Linux binary artifact with SHA-512 verification.

Validation: workspace tests, strict workspace Clippy, formatting and 13 focused discovery tests pass. Independent cross-review fixed empty-worktree enforcement and propagated cancellation errors. The live handshake corrected the initially assumed user-agent prefix; generated version-specific schemas establish optional-field handling.

See docs/contracts/runtime-discovery.md for evidence and limits. #186 remains open: durable Host integration, configured account instances, authentication and entitlement checks, installation consent and actual coding workflows are pending. This does not complete native or external execution or first-release acceptance.
