### PR TITLE
feat(worktrees): reserve Change Stream worktree locations (#211)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-worktrees"
+version = "0.1.0"
+dependencies = [
+ "nix",
+ "serde",
+ "serde_json",
+ "symbiote-domain",
+ "symbiote-trust",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce"]
+members = ["crates/symbiote-worktrees", "crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/symbiote-protocol/src/lib.rs
+++ b/crates/symbiote-protocol/src/lib.rs
@@ -604,7 +604,7 @@ impl TaskDraft {
     pub fn validate(&self) -> Result<(), ProtocolError> {
         if self.origin.reference().project_id != self.project_id
             || self.stream.branch.trim().is_empty()
-            || self.stream.branch.len() > 256
+            || self.stream.branch.len() > 512
             || self.stream.branch.chars().any(char::is_control)
         {
             return Err(invalid());

--- a/crates/symbiote-worktrees/Cargo.toml
+++ b/crates/symbiote-worktrees/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "symbiote-worktrees"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+symbiote-domain = { path = "../symbiote-domain" }
+symbiote-trust = { path = "../symbiote-trust" }
+serde.workspace = true
+serde_json.workspace = true
+nix = { version = "=0.30.1", features = ["dir", "user", "fs"] }
+
+[lints]
+workspace = true

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -1,0 +1,714 @@
+//! Reserved Change Stream worktree locations for the trusted Host provisioner.
+//!
+//! This slice covers deterministic collision-resistant naming plus filesystem
+//! reservation and re-verification of the location that the Linux sandbox
+//! requires its caller to reserve. It deliberately does not run Git, create
+//! repository worktrees, or delete work: Git/repository identity belongs to
+//! #190 and worktree cleanup with evidence remains pending #211 acceptance.
+#![cfg(target_os = "linux")]
+
+use nix::{
+    fcntl::{OFlag, openat},
+    sys::stat::{Mode, fstat},
+    unistd::{geteuid, unlink},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt, fs,
+    os::unix::fs::MetadataExt,
+    path::{Component, Path, PathBuf},
+};
+
+pub const RESERVATION_VERSION: u32 = 1;
+pub const MARKER_NAME: &str = ".symbiote-reservation.json";
+/// Bound on one path component this crate derives or accepts as a policy seed.
+const MAX_SEED_BYTES: usize = 64;
+const MAX_BASE_BYTES: usize = 3072;
+const BRANCH_PREFIX: &str = "symbiote";
+const BRANCH_SUFFIX_BYTES: usize = 12;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorktreeError {
+    InvalidIdentity,
+    InvalidSeed,
+    InvalidBase,
+    UnsafePath,
+    NotPrivate,
+    AlreadyReserved,
+    Collision,
+    NotFound,
+    IdentityMismatch,
+    NotEmpty,
+    Io,
+}
+impl fmt::Display for WorktreeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "worktree reservation rejected: {self:?}")
+    }
+}
+impl std::error::Error for WorktreeError {}
+
+/// Policy seed supplied by trusted Host state. Different seeds derive different
+/// names; the same recorded seed and identities always derive the same names.
+pub fn policy_seed(value: &str) -> Result<&str, WorktreeError> {
+    let valid = !value.is_empty()
+        && value.len() <= MAX_SEED_BYTES
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-');
+    if valid {
+        Ok(value)
+    } else {
+        Err(WorktreeError::InvalidSeed)
+    }
+}
+
+/// Inputs are canonical identities already validated by the domain. The same
+/// recorded identities and seed always yield the same derived names.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeriveInputs<'a> {
+    pub project_id: &'a ProjectId,
+    pub root_id: &'a RootId,
+    pub stream_id: &'a ChangeStreamId,
+    pub seed: &'a str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Derived {
+    pub project_id: ProjectId,
+    pub root_id: RootId,
+    pub stream_id: ChangeStreamId,
+    pub seed: String,
+    /// Bounded canonical WorktreeId: identity-hash based, never a filesystem path.
+    pub worktree_id: String,
+    /// Git-ref-safe branch under the reserved `symbiote/` prefix namespace.
+    pub branch: String,
+}
+
+fn hex(bytes: &[u8], take: usize) -> String {
+    bytes
+        .iter()
+        .take(take)
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Git check-ref-format rules relevant to the derived charset, enforced so a
+/// valid domain ID can never produce an invalid ref component.
+fn ref_component(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('.')
+        && !value.ends_with(".lock")
+        && !value.contains("..")
+        && !value.contains("@{")
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+}
+
+impl Derived {
+    /// Pure derivation. Ids use the domain charset ([A-Za-z0-9_-]), so every
+    /// derived component is ref-safe by construction; the seed mixes policy
+    /// into the hash without entering the ref itself.
+    pub fn derive(inputs: DeriveInputs<'_>) -> Result<Self, WorktreeError> {
+        let seed = policy_seed(inputs.seed)?;
+        let material = (
+            seed,
+            inputs.project_id.as_str(),
+            inputs.root_id.as_str(),
+            inputs.stream_id.as_str(),
+            symbiote_trust::Fingerprint::of(
+                format!(
+                    "worktree-reservation-v{RESERVATION_VERSION}:{seed}:{}:{}:{}",
+                    inputs.project_id.as_str(),
+                    inputs.root_id.as_str(),
+                    inputs.stream_id.as_str()
+                )
+                .as_bytes(),
+            )
+            .as_str()
+            .to_owned(),
+        );
+        let fingerprint = symbiote_trust::Fingerprint::of(
+            serde_json::to_vec(&material)
+                .map_err(|_| WorktreeError::InvalidIdentity)?
+                .as_slice(),
+        );
+        let suffix = hex(fingerprint.as_str().as_bytes(), BRANCH_SUFFIX_BYTES);
+        let worktree_id = format!("st-{}", hex(fingerprint.as_str().as_bytes(), 16));
+        let (project, stream) = (inputs.project_id.as_str(), inputs.stream_id.as_str());
+        if !ref_component(project) || !ref_component(stream) {
+            return Err(WorktreeError::InvalidIdentity);
+        }
+        let branch = format!("{BRANCH_PREFIX}/{project}/{stream}/{suffix}");
+        if branch.len() > 256 || !branch.split('/').all(ref_component) {
+            return Err(WorktreeError::InvalidIdentity);
+        }
+        Ok(Self {
+            project_id: inputs.project_id.clone(),
+            root_id: inputs.root_id.clone(),
+            stream_id: inputs.stream_id.clone(),
+            seed: seed.to_owned(),
+            worktree_id,
+            branch,
+        })
+    }
+
+    fn directory_name(&self) -> &str {
+        &self.worktree_id
+    }
+
+    pub fn worktree_path(&self, base: &Path) -> PathBuf {
+        base.join(self.project_id.as_str())
+            .join(self.directory_name())
+    }
+}
+
+/// Recorded reservation identity bound to the reserved location. The marker
+/// file lives in the private project directory, never inside the worktree, so
+/// later Git materialization keeps a clean tree.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Marker {
+    pub version: u32,
+    pub derived: Derived,
+    pub created_at: Timestamp,
+}
+
+/// A verified reservation. Not a guard: reservations persist across Host
+/// restarts by design; release requires explicit policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Reservation {
+    pub derived: Derived,
+    pub base: PathBuf,
+}
+
+/// What release may do. Work left by a stream is never deleted recursively:
+/// unmerged or uncommitted work removal requires separate evidence and
+/// authorized confirmation per the Change Stream contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReleasePolicy {
+    /// Keep the reserved location for recovery/inspection.
+    Retain,
+    /// Remove the marker and the directory only when it holds no entries.
+    DeleteIfEmpty,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Deleted,
+    Retained,
+}
+
+fn validate_absolute(path: &Path, max_bytes: usize) -> Result<(), WorktreeError> {
+    if path.as_os_str().len() > max_bytes
+        || path.components().count() > 96
+        || !path.is_absolute()
+        || path
+            .components()
+            .any(|c| !matches!(c, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(WorktreeError::UnsafePath);
+    }
+    Ok(())
+}
+
+fn euid() -> u32 {
+    geteuid().as_raw()
+}
+
+/// Walks each component without following symlinks and returns the final fd,
+/// mirroring the sandbox's path-walk discipline.
+fn walk_private(path: &Path, exact_private: bool) -> Result<(), WorktreeError> {
+    use nix::sys::stat::SFlag;
+    let mut fd = nix::fcntl::open(
+        Path::new("/"),
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .map_err(|_| WorktreeError::UnsafePath)?;
+    for component in path.components() {
+        let name = match component {
+            Component::Normal(name) => name,
+            Component::RootDir => continue,
+            _ => return Err(WorktreeError::UnsafePath),
+        };
+        fd = openat(
+            &fd,
+            name,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|_| WorktreeError::UnsafePath)?;
+        let stat = fstat(&fd).map_err(|_| WorktreeError::UnsafePath)?;
+        if SFlag::from_bits_truncate(stat.st_mode) & SFlag::S_IFMT != SFlag::S_IFDIR {
+            return Err(WorktreeError::UnsafePath);
+        }
+        // Root-owned and sticky-bit components mirror the sandbox's accepted
+        // walk rule (e.g. /tmp); anything group/other-writable without the
+        // sticky bit is refused.
+        if ![0, euid()].contains(&stat.st_uid)
+            || (stat.st_mode & 0o022 != 0 && stat.st_mode & 0o1000 == 0)
+        {
+            return Err(WorktreeError::NotPrivate);
+        }
+        if exact_private && stat.st_mode & 0o7777 != 0o700 {
+            return Err(WorktreeError::NotPrivate);
+        }
+    }
+    Ok(())
+}
+
+fn create_private_dir(path: &Path) -> Result<(), WorktreeError> {
+    match nix::unistd::mkdir(path, Mode::from_bits_truncate(0o700)) {
+        Ok(()) => Ok(()),
+        Err(nix::errno::Errno::EEXIST) => Err(WorktreeError::AlreadyReserved),
+        Err(_) => Err(WorktreeError::UnsafePath),
+    }
+}
+
+fn write_marker(marker_path: &Path, marker: &Marker) -> Result<(), WorktreeError> {
+    let body = serde_json::to_vec(marker).map_err(|_| WorktreeError::Io)?;
+    // O_EXCL makes reservation a single winner even across racing processes.
+    let fd = nix::fcntl::open(
+        marker_path,
+        OFlag::O_WRONLY | OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_CLOEXEC,
+        Mode::from_bits_truncate(0o600),
+    )
+    .map_err(|error| match error {
+        nix::errno::Errno::EEXIST => WorktreeError::AlreadyReserved,
+        _ => WorktreeError::UnsafePath,
+    })?;
+    let mut file = std::fs::File::from(fd);
+    std::io::Write::write_all(&mut file, &body).map_err(|_| WorktreeError::Io)?;
+    file.sync_all().map_err(|_| WorktreeError::Io)?;
+    Ok(())
+}
+
+fn read_marker(marker_path: &Path) -> Result<Marker, WorktreeError> {
+    let body = fs::read(marker_path).map_err(|_| WorktreeError::NotFound)?;
+    let marker: Marker =
+        serde_json::from_slice(&body).map_err(|_| WorktreeError::IdentityMismatch)?;
+    if marker.version != RESERVATION_VERSION {
+        return Err(WorktreeError::IdentityMismatch);
+    }
+    Ok(marker)
+}
+
+/// Verifies that the base directory satisfies the provisioner premises and
+/// creates it with mode 0700 when absent. A base that exists as a symlink, is
+/// foreign-owned, or is group/other-writable is refused.
+fn ensure_base(base: &Path) -> Result<(), WorktreeError> {
+    validate_absolute(base, MAX_BASE_BYTES)?;
+    for protected in [
+        "/usr", "/etc", "/dev", "/proc", "/sys", "/run", "/boot", "/var",
+    ] {
+        if base.starts_with(protected) {
+            return Err(WorktreeError::InvalidBase);
+        }
+    }
+    match fs::symlink_metadata(base) {
+        Ok(meta) => {
+            if !meta.is_dir() || meta.file_type().is_symlink() {
+                return Err(WorktreeError::InvalidBase);
+            }
+            if meta.uid() != euid() || meta.mode() & 0o022 != 0 {
+                return Err(WorktreeError::NotPrivate);
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let parent = base
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .ok_or(WorktreeError::InvalidBase)?;
+            walk_private(parent, false)?;
+            create_private_dir(base).map_err(|error| match error {
+                WorktreeError::AlreadyReserved => WorktreeError::NotPrivate,
+                other => other,
+            })?;
+        }
+        Err(_) => return Err(WorktreeError::UnsafePath),
+    }
+    walk_private(base, false)
+}
+
+/// Reserves the derived location: `<base>/<project>/<worktree_id>` with a
+/// private project directory (0700) and an exclusive marker binding identity.
+/// The worktree directory itself is created empty with mode 0700; later Git
+/// materialization is explicitly out of this slice.
+pub fn reserve(
+    derived: &Derived,
+    base: &Path,
+    created_at: Timestamp,
+) -> Result<Reservation, WorktreeError> {
+    if derived
+        != &Derived::derive(DeriveInputs {
+            project_id: &derived.project_id,
+            root_id: &derived.root_id,
+            stream_id: &derived.stream_id,
+            seed: &derived.seed,
+        })?
+    {
+        return Err(WorktreeError::InvalidIdentity);
+    }
+    ensure_base(base)?;
+    let project_dir = base.join(derived.project_id.as_str());
+    match fs::symlink_metadata(&project_dir) {
+        Ok(meta) if meta.is_dir() && !meta.file_type().is_symlink() => {
+            if meta.uid() != euid() || meta.mode() & 0o7777 != 0o700 {
+                return Err(WorktreeError::NotPrivate);
+            }
+        }
+        Ok(_) => return Err(WorktreeError::UnsafePath),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            create_private_dir(&project_dir)?;
+        }
+        Err(_) => return Err(WorktreeError::UnsafePath),
+    }
+    let worktree = derived.worktree_path(base);
+    create_private_dir(&worktree)?;
+    let marker = Marker {
+        version: RESERVATION_VERSION,
+        derived: derived.clone(),
+        created_at,
+    };
+    match write_marker(
+        &project_dir.join(format!("{}.json", derived.worktree_id)),
+        &marker,
+    ) {
+        Ok(()) => Ok(Reservation {
+            derived: derived.clone(),
+            base: base.to_path_buf(),
+        }),
+        Err(error) => {
+            // Do not leave an unreserved directory behind a failed marker write.
+            let _ = fs::remove_dir(&worktree);
+            Err(error)
+        }
+    }
+}
+
+fn check_private_dir(path: &Path, exact: bool) -> Result<(), WorktreeError> {
+    let meta = fs::symlink_metadata(path).map_err(|_| WorktreeError::NotFound)?;
+    if !meta.is_dir() || meta.file_type().is_symlink() {
+        return Err(WorktreeError::UnsafePath);
+    }
+    if meta.uid() != euid() || meta.mode() & 0o022 != 0 || (exact && meta.mode() & 0o7777 != 0o700)
+    {
+        return Err(WorktreeError::NotPrivate);
+    }
+    Ok(())
+}
+
+/// Re-derives and re-verifies a reservation after restart: path layout, marker
+/// identity binding, ownership and private modes. This is the provisioner-side
+/// premise the sandbox launcher relies on; the launcher still revalidates.
+pub fn verify(reservation: &Reservation) -> Result<Marker, WorktreeError> {
+    let base = &reservation.base;
+    // Verification never creates state: a missing or non-private base fails.
+    validate_absolute(base, MAX_BASE_BYTES)?;
+    walk_private(base, false)?;
+    let project_dir = base.join(reservation.derived.project_id.as_str());
+    check_private_dir(&project_dir, true)?;
+    let worktree = reservation.derived.worktree_path(base);
+    check_private_dir(&worktree, true)?;
+    let marker =
+        read_marker(&project_dir.join(format!("{}.json", reservation.derived.worktree_id)))?;
+    if marker.derived != reservation.derived {
+        return Err(WorktreeError::IdentityMismatch);
+    }
+    // The reserved worktree is empty until Git materialization populates it;
+    // any other content means someone else used this location.
+    let mut entries = fs::read_dir(&worktree).map_err(|_| WorktreeError::NotFound)?;
+    if entries.next().is_some() {
+        return Err(WorktreeError::NotEmpty);
+    }
+    Ok(marker)
+}
+
+/// Releases per the explicit policy. Only an empty reserved directory is ever
+/// removed; any content (including materialized Git state) is retained and
+/// reported rather than deleted.
+pub fn release(reservation: &Reservation, policy: ReleasePolicy) -> Result<Outcome, WorktreeError> {
+    let project_dir = reservation
+        .base
+        .join(reservation.derived.project_id.as_str());
+    let worktree = reservation.derived.worktree_path(&reservation.base);
+    let marker_path = project_dir.join(format!("{}.json", reservation.derived.worktree_id));
+    // Confirm the marker still binds this identity before touching anything.
+    read_marker(&marker_path)?;
+    match policy {
+        ReleasePolicy::Retain => {
+            unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
+            // The directory is retained; a released directory without a marker
+            // is treated as abandoned location, never as removable work.
+            Ok(Outcome::Retained)
+        }
+        ReleasePolicy::DeleteIfEmpty => {
+            let mut entries = fs::read_dir(&worktree).map_err(|_| WorktreeError::NotFound)?;
+            if entries.next().is_some() {
+                return Err(WorktreeError::NotEmpty);
+            }
+            unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
+            fs::remove_dir(&worktree).map_err(|_| WorktreeError::Io)?;
+            // Removing the project directory is best-effort; concurrent
+            // reservations of the same project keep it alive.
+            let _ = fs::remove_dir(&project_dir);
+            Ok(Outcome::Deleted)
+        }
+    }
+}
+
+/// Lists reservation markers recorded under one project of a base directory.
+/// Marker integrity is not re-verified here; call `verify` per reservation.
+pub fn list(base: &Path, project: &ProjectId) -> Result<Vec<Marker>, WorktreeError> {
+    let project_dir = base.join(project.as_str());
+    let mut markers = Vec::new();
+    for entry in fs::read_dir(&project_dir).map_err(|_| WorktreeError::NotFound)? {
+        let entry = entry.map_err(|_| WorktreeError::Io)?;
+        let name = entry.file_name();
+        let name = name.to_str().ok_or(WorktreeError::UnsafePath)?;
+        let Some(id) = name.strip_suffix(".json") else {
+            continue;
+        };
+        if id.is_empty() || !id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
+            continue;
+        }
+        markers.push(read_marker(&entry.path())?);
+    }
+    markers.sort_by(|a, b| a.derived.worktree_id.cmp(&b.derived.worktree_id));
+    Ok(markers)
+}
+
+use symbiote_domain::{ChangeStreamId, ProjectId, RootId, Timestamp};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbiote_domain::ProjectId;
+
+    fn derived(stream: &str, seed: &str) -> Derived {
+        Derived::derive(DeriveInputs {
+            project_id: &ProjectId::new("demo").unwrap(),
+            root_id: &symbiote_domain::RootId::new("root").unwrap(),
+            stream_id: &symbiote_domain::ChangeStreamId::new(stream).unwrap(),
+            seed,
+        })
+        .unwrap()
+    }
+
+    fn temp_base(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "symbiote-worktrees-{}-{}-{tag}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn derivation_is_deterministic_and_collision_resistant() {
+        let a = derived("stream-a", "policy-1");
+        let a_again = derived("stream-a", "policy-1");
+        assert_eq!(a, a_again);
+        assert_eq!(a.branch, a_again.branch);
+        assert_eq!(a.worktree_id, a_again.worktree_id);
+        // Different identities or seeds never collide on names.
+        assert_ne!(a, derived("stream-b", "policy-1"));
+        assert_ne!(a, derived("stream-a", "policy-2"));
+        // The branch is reserved-namespace and every component is ref-safe.
+        assert!(a.branch.starts_with("symbiote/demo/stream-a/"));
+        for component in a.branch.split('/') {
+            assert!(ref_component(component), "bad component: {component}");
+        }
+        assert_eq!(a.branch.len() + a.worktree_id.len(), {
+            let again = derived("stream-a", "policy-1");
+            again.branch.len() + again.worktree_id.len()
+        });
+        assert!(a.worktree_id.starts_with("st-"));
+    }
+
+    #[test]
+    fn invalid_seeds_and_identities_are_rejected() {
+        for bad in [
+            "",
+            "sp ace",
+            "slash/seed",
+            "seed!",
+            &"x".repeat(MAX_SEED_BYTES + 1),
+        ] {
+            assert_eq!(
+                Derived::derive(DeriveInputs {
+                    project_id: &ProjectId::new("demo").unwrap(),
+                    root_id: &symbiote_domain::RootId::new("root").unwrap(),
+                    stream_id: &symbiote_domain::ChangeStreamId::new("s").unwrap(),
+                    seed: bad,
+                })
+                .unwrap_err(),
+                WorktreeError::InvalidSeed
+            );
+        }
+        assert!(!ref_component(".starts-with-dot"));
+        assert!(!ref_component("ends.lock"));
+        assert!(!ref_component("a..b"));
+        assert!(!ref_component("a@{b"));
+    }
+
+    #[test]
+    fn reserve_verify_release_round_trip() {
+        let base = temp_base("roundtrip");
+        let d = derived("stream-rt", "seed");
+        let reservation = reserve(&d, &base, Timestamp(100)).unwrap();
+        let path = d.worktree_path(&base);
+        assert!(path.is_dir());
+        let mode = fs::metadata(&path).unwrap().mode();
+        assert_eq!(mode & 0o7777, 0o700);
+        let project_mode = fs::metadata(base.join("demo")).unwrap().mode();
+        assert_eq!(project_mode & 0o7777, 0o700);
+        // Verify returns the bound marker identity.
+        let marker = verify(&reservation).unwrap();
+        assert_eq!(marker.derived, d);
+        assert_eq!(marker.created_at, Timestamp(100));
+        // Idempotent verification after "restart".
+        verify(&reservation).unwrap();
+        // DeleteIfEmpty removes the empty reservation; Retain keeps it.
+        assert!(matches!(
+            release(&reservation, ReleasePolicy::DeleteIfEmpty),
+            Ok(Outcome::Deleted)
+        ));
+        assert!(!path.exists());
+        let retained = reserve(&d, &base, Timestamp(101)).unwrap();
+        assert!(matches!(
+            release(&retained, ReleasePolicy::Retain),
+            Ok(Outcome::Retained)
+        ));
+        assert!(path.is_dir());
+        assert!(read_marker(&base.join("demo").join(format!("{}.json", d.worktree_id))).is_err());
+    }
+
+    #[test]
+    fn double_reservation_is_a_single_winner() {
+        let base = temp_base("double");
+        let d = derived("stream-2", "seed");
+        reserve(&d, &base, Timestamp(1)).unwrap();
+        assert_eq!(
+            reserve(&d, &base, Timestamp(2)).unwrap_err(),
+            WorktreeError::AlreadyReserved
+        );
+    }
+
+    #[test]
+    fn verify_detects_tampering_and_foreign_use() {
+        let base = temp_base("tamper");
+        let d = derived("stream-3", "seed");
+        let reservation = reserve(&d, &base, Timestamp(1)).unwrap();
+        // Foreign content inside the reserved directory fails verification.
+        fs::write(d.worktree_path(&base).join("sneaky"), b"x").unwrap();
+        assert_eq!(verify(&reservation).unwrap_err(), WorktreeError::NotEmpty);
+        fs::remove_file(d.worktree_path(&base).join("sneaky")).unwrap();
+        // Swapped marker identity fails.
+        let marker_path = base.join("demo").join(format!("{}.json", d.worktree_id));
+        let mut marker: Marker = serde_json::from_slice(&fs::read(&marker_path).unwrap()).unwrap();
+        marker.derived.stream_id = symbiote_domain::ChangeStreamId::new("other").unwrap();
+        fs::write(&marker_path, serde_json::to_vec(&marker).unwrap()).unwrap();
+        assert_eq!(
+            verify(&reservation).unwrap_err(),
+            WorktreeError::IdentityMismatch
+        );
+        // A missing base is not recreated by verification.
+        let elsewhere = temp_base("missing");
+        let dangling = Reservation {
+            derived: d.clone(),
+            base: elsewhere.join("does").join("not").join("exist"),
+        };
+        assert_eq!(verify(&dangling).unwrap_err(), WorktreeError::UnsafePath);
+    }
+
+    #[test]
+    fn release_never_deletes_nonempty_work() {
+        let base = temp_base("nonempty");
+        let d = derived("stream-4", "seed");
+        let reservation = reserve(&d, &base, Timestamp(1)).unwrap();
+        fs::write(d.worktree_path(&base).join("uncommitted.txt"), b"work").unwrap();
+        assert_eq!(
+            release(&reservation, ReleasePolicy::DeleteIfEmpty).unwrap_err(),
+            WorktreeError::NotEmpty
+        );
+        // Work and reservation survive the refused release.
+        assert!(d.worktree_path(&base).join("uncommitted.txt").is_file());
+        assert!(verify(&reservation).is_err()); // content present
+        assert!(read_marker(&base.join("demo").join(format!("{}.json", d.worktree_id))).is_ok());
+    }
+
+    #[test]
+    fn unsafe_bases_are_refused() {
+        let d = derived("stream-5", "seed");
+        // System locations.
+        for protected in ["/usr/demo", "/etc/demo", "/var/demo", "/proc/demo"] {
+            assert_eq!(
+                reserve(&d, Path::new(protected), Timestamp(1)).unwrap_err(),
+                WorktreeError::InvalidBase,
+                "base {protected} must be refused"
+            );
+        }
+        // Relative paths.
+        assert_eq!(
+            reserve(&d, Path::new("relative/base"), Timestamp(1)).unwrap_err(),
+            WorktreeError::UnsafePath
+        );
+        // Group/other-writable existing base.
+        let base = temp_base("writable");
+        chmod(&base, 0o777);
+        assert_eq!(
+            reserve(&d, &base, Timestamp(1)).unwrap_err(),
+            WorktreeError::NotPrivate
+        );
+        // Symlinked base component.
+        let link_base = temp_base("link");
+        let target = temp_base("link-target");
+        std::os::unix::fs::symlink(&target, link_base.join("link")).unwrap();
+        assert_eq!(
+            reserve(&d, &link_base.join("link").join("deeper"), Timestamp(1)).unwrap_err(),
+            WorktreeError::UnsafePath
+        );
+    }
+
+    fn chmod(path: &Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(mode);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[test]
+    fn concurrent_reservations_of_different_streams_do_not_collide() {
+        let base = temp_base("parallel");
+        let handles: Vec<_> = (0..8)
+            .map(|n| {
+                let base = base.clone();
+                std::thread::spawn(move || {
+                    let d = derived(&format!("stream-p{n}"), "seed");
+                    reserve(&d, &base, Timestamp(1)).unwrap();
+                    d
+                })
+            })
+            .collect();
+        for handle in handles {
+            let d = handle.join().unwrap();
+            verify(&Reservation {
+                derived: d,
+                base: base.clone(),
+            })
+            .unwrap();
+        }
+        assert_eq!(
+            list(&base, &ProjectId::new("demo").unwrap()).unwrap().len(),
+            8
+        );
+    }
+}

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -404,8 +404,12 @@ pub fn reserve(
     // reclaimable only while it is empty (an orphan from an interrupted
     // attempt, or a Retain-released location with no data). Any content means
     // retained or materialized work and is never reclaimed.
+    let mut owned_dir: Option<(u64, u64)> = None;
     let created = match nix::unistd::mkdir(&worktree, Mode::from_bits_truncate(0o700)) {
         Ok(()) => {
+            owned_dir = fs::symlink_metadata(&worktree)
+                .ok()
+                .map(|meta| (meta.dev(), meta.ino()));
             sync_dir(&project_dir)?;
             true
         }
@@ -433,10 +437,19 @@ pub fn reserve(
             base: base.to_path_buf(),
         }),
         Err(error) => {
-            // Never touch a location owned by another reservation: only this
-            // call's own freshly created directory is cleaned up.
-            if created {
-                let _ = fs::remove_dir(&worktree);
+            // Never touch a location owned by another reservation. The
+            // directory is removed only when this call created it, no marker
+            // has since claimed the identity, and the location still holds
+            // the inode this call created.
+            let marker_path = project_dir.join(format!("{}.json", derived.worktree_id));
+            if created && matches!(read_marker(&marker_path), Err(WorktreeError::NotFound)) {
+                let still_ours = fs::symlink_metadata(&worktree)
+                    .ok()
+                    .zip(owned_dir.as_ref())
+                    .is_some_and(|(meta, (dev, ino))| meta.dev() == *dev && meta.ino() == *ino);
+                if still_ours {
+                    let _ = fs::remove_dir(&worktree);
+                }
             }
             Err(error)
         }

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -153,7 +153,10 @@ impl Derived {
             return Err(WorktreeError::InvalidIdentity);
         }
         let branch = format!("{BRANCH_PREFIX}/{project}/{stream}/{suffix}");
-        if branch.len() > 256 || !branch.split('/').all(ref_component) {
+        // 512 covers the worst case (two 128-byte domain identities); the
+        // protocol TaskDraft bound matches so derivation never produces a
+        // branch the wire would reject.
+        if branch.len() > 512 || !branch.split('/').all(ref_component) {
             return Err(WorktreeError::InvalidIdentity);
         }
         Ok(Self {
@@ -297,15 +300,20 @@ fn write_marker(marker_path: &Path, marker: &Marker) -> Result<(), WorktreeError
         _ => WorktreeError::UnsafePath,
     })?;
     let mut file = std::fs::File::from(fd);
-    let written = std::io::Write::write_all(&mut file, &body).and_then(|_| file.sync_all());
-    if written.is_err() {
-        // A half-written marker would permanently brick this identity:
-        // reserve would hit EEXIST while verify could never read it. Remove
-        // the marker we created so the identity stays reservable.
+    // Every failure after exclusive creation unlinks the marker we created:
+    // a surviving marker would brick the identity, since reserve would hit
+    // EEXIST while verify could never validate a half-written file.
+    let mut persisted = std::io::Write::write_all(&mut file, &body).and_then(|_| file.sync_all());
+    if persisted.is_ok() {
+        persisted = match marker_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            Some(parent) => sync_dir(parent).map_err(|_| std::io::Error::other("sync failed")),
+            None => Err(std::io::Error::other("marker parent missing")),
+        };
+    }
+    if persisted.is_err() {
         let _ = unlink(marker_path);
         return Err(WorktreeError::Io);
     }
-    sync_dir(marker_path.parent().ok_or(WorktreeError::UnsafePath)?)?;
     Ok(())
 }
 
@@ -512,7 +520,14 @@ pub fn release(reservation: &Reservation, policy: ReleasePolicy) -> Result<Outco
             // content, and a failure here keeps the marker as the source of
             // truth instead of downgrading the reservation to abandoned.
             fs::remove_dir(&worktree).map_err(|_| WorktreeError::Io)?;
-            unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
+            if unlink(&marker_path).is_err() {
+                // Roll back to a consistent marker-plus-empty-directory
+                // state so a retry can proceed instead of leaving a stale
+                // marker that reserves collide with and release cannot read.
+                let _ = nix::unistd::mkdir(&worktree, Mode::from_bits_truncate(0o700));
+                let _ = check_private_dir(&worktree, true);
+                return Err(WorktreeError::Io);
+            }
             sync_dir(&project_dir)?;
             // Removing the project directory is best-effort; concurrent
             // reservations of the same project keep it alive.

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -392,11 +392,25 @@ pub fn reserve(
         Err(_) => return Err(WorktreeError::UnsafePath),
     }
     let worktree = derived.worktree_path(base);
-    create_private_dir(&worktree).map_err(|error| match error {
-        // Only an existing location can mean a real double reservation.
-        WorktreeError::AlreadyReserved => WorktreeError::AlreadyReserved,
-        other => other,
-    })?;
+    // The identity-specific location is exclusive: an existing directory is
+    // reclaimable only while it is empty (an orphan from an interrupted
+    // attempt, or a Retain-released location with no data). Any content means
+    // retained or materialized work and is never reclaimed.
+    let created = match nix::unistd::mkdir(&worktree, Mode::from_bits_truncate(0o700)) {
+        Ok(()) => {
+            sync_dir(&project_dir)?;
+            true
+        }
+        Err(nix::errno::Errno::EEXIST) => {
+            check_private_dir(&worktree, true)?;
+            let mut entries = fs::read_dir(&worktree).map_err(|_| WorktreeError::NotFound)?;
+            if entries.next().is_some() {
+                return Err(WorktreeError::NotEmpty);
+            }
+            false
+        }
+        Err(_) => return Err(WorktreeError::UnsafePath),
+    };
     let marker = Marker {
         version: RESERVATION_VERSION,
         derived: derived.clone(),
@@ -411,8 +425,11 @@ pub fn reserve(
             base: base.to_path_buf(),
         }),
         Err(error) => {
-            // Do not leave an unreserved directory behind a failed marker write.
-            let _ = fs::remove_dir(&worktree);
+            // Never touch a location owned by another reservation: only this
+            // call's own freshly created directory is cleaned up.
+            if created {
+                let _ = fs::remove_dir(&worktree);
+            }
             Err(error)
         }
     }
@@ -472,8 +489,13 @@ pub fn release(reservation: &Reservation, policy: ReleasePolicy) -> Result<Outco
         .join(reservation.derived.project_id.as_str());
     let worktree = reservation.derived.worktree_path(&reservation.base);
     let marker_path = project_dir.join(format!("{}.json", reservation.derived.worktree_id));
-    // Confirm the marker still binds this identity before touching anything.
-    read_marker(&marker_path)?;
+    // Confirm the marker still binds this identity before touching anything:
+    // a syntactically valid marker for a different identity is rejected here
+    // exactly as verify rejects it.
+    let marker = read_marker(&marker_path)?;
+    if marker.derived != reservation.derived {
+        return Err(WorktreeError::IdentityMismatch);
+    }
     match policy {
         ReleasePolicy::Retain => {
             unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
@@ -694,6 +716,58 @@ mod tests {
         assert!(d.worktree_path(&base).join("uncommitted.txt").is_file());
         assert!(verify(&reservation).is_err()); // content present
         assert!(read_marker(&base.join("demo").join(format!("{}.json", d.worktree_id))).is_ok());
+    }
+
+    #[test]
+    fn retained_and_populated_locations_are_never_reclaimed() {
+        let base = temp_base("reclaim");
+        let d = derived("stream-6", "seed");
+        let reservation = reserve(&d, &base, Timestamp(1)).unwrap();
+        // Retain detaches the marker but keeps the directory.
+        release(&reservation, ReleasePolicy::Retain).unwrap();
+        // Retained content is never silently reclaimed by a fresh reservation.
+        fs::write(d.worktree_path(&base).join("recovery"), b"data").unwrap();
+        assert_eq!(
+            reserve(&d, &base, Timestamp(2)).unwrap_err(),
+            WorktreeError::NotEmpty
+        );
+        assert!(d.worktree_path(&base).join("recovery").is_file());
+        // An empty orphan location may be reclaimed by its identity.
+        fs::remove_file(d.worktree_path(&base).join("recovery")).unwrap();
+        let reclaimed = reserve(&d, &base, Timestamp(3)).unwrap();
+        verify(&reclaimed).unwrap();
+    }
+
+    #[test]
+    fn failed_reservation_cleanup_never_touches_a_live_reservation() {
+        let base = temp_base("live");
+        let d = derived("stream-7", "seed");
+        let live = reserve(&d, &base, Timestamp(1)).unwrap();
+        // A racing duplicate must not delete the live reservation's directory.
+        assert_eq!(
+            reserve(&d, &base, Timestamp(2)).unwrap_err(),
+            WorktreeError::AlreadyReserved
+        );
+        verify(&live).unwrap();
+        // A swapped marker cannot release someone else's reservation.
+        let other = derived("stream-8", "seed");
+        reserve(&other, &base, Timestamp(3)).unwrap();
+        let marker_path = base
+            .join("demo")
+            .join(format!("{}.json", other.worktree_id));
+        let mut marker: Marker = serde_json::from_slice(&fs::read(&marker_path).unwrap()).unwrap();
+        marker.derived.stream_id = symbiote_domain::ChangeStreamId::new("stream-7").unwrap();
+        fs::write(&marker_path, serde_json::to_vec(&marker).unwrap()).unwrap();
+        let swapped = Reservation {
+            derived: other,
+            base: base.clone(),
+        };
+        assert!(matches!(
+            release(&swapped, ReleasePolicy::Retain).unwrap_err(),
+            WorktreeError::IdentityMismatch
+        ));
+        // Both live reservations survive.
+        verify(&live).unwrap();
     }
 
     #[test]

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -404,12 +404,8 @@ pub fn reserve(
     // reclaimable only while it is empty (an orphan from an interrupted
     // attempt, or a Retain-released location with no data). Any content means
     // retained or materialized work and is never reclaimed.
-    let mut owned_dir: Option<(u64, u64)> = None;
-    let created = match nix::unistd::mkdir(&worktree, Mode::from_bits_truncate(0o700)) {
+    match nix::unistd::mkdir(&worktree, Mode::from_bits_truncate(0o700)) {
         Ok(()) => {
-            owned_dir = fs::symlink_metadata(&worktree)
-                .ok()
-                .map(|meta| (meta.dev(), meta.ino()));
             sync_dir(&project_dir)?;
             true
         }
@@ -436,23 +432,13 @@ pub fn reserve(
             derived: derived.clone(),
             base: base.to_path_buf(),
         }),
-        Err(error) => {
-            // Never touch a location owned by another reservation. The
-            // directory is removed only when this call created it, no marker
-            // has since claimed the identity, and the location still holds
-            // the inode this call created.
-            let marker_path = project_dir.join(format!("{}.json", derived.worktree_id));
-            if created && matches!(read_marker(&marker_path), Err(WorktreeError::NotFound)) {
-                let still_ours = fs::symlink_metadata(&worktree)
-                    .ok()
-                    .zip(owned_dir.as_ref())
-                    .is_some_and(|(meta, (dev, ino))| meta.dev() == *dev && meta.ino() == *ino);
-                if still_ours {
-                    let _ = fs::remove_dir(&worktree);
-                }
-            }
-            Err(error)
-        }
+        // The marker cleanup in write_marker is inode-safe; the directory is
+        // deliberately left behind. Removing it here could delete a location
+        // a concurrent same-identity reservation just reclaimed, because
+        // marker absence, inode validation and removal cannot be made
+        // atomic without locking. Empty orphan directories are harmless:
+        // every reserve validates and reclaims them.
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -25,7 +25,10 @@ pub const MARKER_NAME: &str = ".symbiote-reservation.json";
 const MAX_SEED_BYTES: usize = 64;
 const MAX_BASE_BYTES: usize = 3072;
 const BRANCH_PREFIX: &str = "symbiote";
-const BRANCH_SUFFIX_BYTES: usize = 12;
+/// Branch suffix carries 96 bits of digest; the worktree id carries 64 bits.
+/// Both are truncated hashes, not unique encodings.
+const BRANCH_SUFFIX_DIGEST_BYTES: usize = 12;
+const WORKTREE_ID_DIGEST_BYTES: usize = 8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorktreeError {
@@ -35,7 +38,6 @@ pub enum WorktreeError {
     UnsafePath,
     NotPrivate,
     AlreadyReserved,
-    Collision,
     NotFound,
     IdentityMismatch,
     NotEmpty,
@@ -80,18 +82,22 @@ pub struct Derived {
     pub root_id: RootId,
     pub stream_id: ChangeStreamId,
     pub seed: String,
-    /// Bounded canonical WorktreeId: identity-hash based, never a filesystem path.
-    pub worktree_id: String,
+    /// Canonical bounded WorktreeId newtype: a 64-bit digest truncation, never
+    /// a filesystem path.
+    pub worktree_id: WorktreeId,
     /// Git-ref-safe branch under the reserved `symbiote/` prefix namespace.
     pub branch: String,
 }
 
-fn hex(bytes: &[u8], take: usize) -> String {
-    bytes
-        .iter()
-        .take(take)
-        .map(|b| format!("{b:02x}"))
+fn digest_bytes(fingerprint: &symbiote_trust::Fingerprint) -> Vec<u8> {
+    let hex = fingerprint.as_str();
+    (0..hex.len() / 2)
+        .map(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).unwrap_or(0))
         .collect()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Git check-ref-format rules relevant to the derived charset, enforced so a
@@ -135,8 +141,13 @@ impl Derived {
                 .map_err(|_| WorktreeError::InvalidIdentity)?
                 .as_slice(),
         );
-        let suffix = hex(fingerprint.as_str().as_bytes(), BRANCH_SUFFIX_BYTES);
-        let worktree_id = format!("st-{}", hex(fingerprint.as_str().as_bytes(), 16));
+        let digest = digest_bytes(&fingerprint);
+        if digest.len() < BRANCH_SUFFIX_DIGEST_BYTES {
+            return Err(WorktreeError::Io);
+        }
+        let suffix = hex(&digest[..BRANCH_SUFFIX_DIGEST_BYTES]);
+        let identity = WorktreeId::new(format!("st-{}", hex(&digest[..WORKTREE_ID_DIGEST_BYTES])))
+            .map_err(|_| WorktreeError::InvalidIdentity)?;
         let (project, stream) = (inputs.project_id.as_str(), inputs.stream_id.as_str());
         if !ref_component(project) || !ref_component(stream) {
             return Err(WorktreeError::InvalidIdentity);
@@ -150,18 +161,14 @@ impl Derived {
             root_id: inputs.root_id.clone(),
             stream_id: inputs.stream_id.clone(),
             seed: seed.to_owned(),
-            worktree_id,
+            worktree_id: identity,
             branch,
         })
     }
 
-    fn directory_name(&self) -> &str {
-        &self.worktree_id
-    }
-
     pub fn worktree_path(&self, base: &Path) -> PathBuf {
         base.join(self.project_id.as_str())
-            .join(self.directory_name())
+            .join(self.worktree_id.as_str())
     }
 }
 
@@ -220,7 +227,7 @@ fn euid() -> u32 {
 
 /// Walks each component without following symlinks and returns the final fd,
 /// mirroring the sandbox's path-walk discipline.
-fn walk_private(path: &Path, exact_private: bool) -> Result<(), WorktreeError> {
+fn walk_private(path: &Path) -> Result<(), WorktreeError> {
     use nix::sys::stat::SFlag;
     let mut fd = nix::fcntl::open(
         Path::new("/"),
@@ -253,17 +260,26 @@ fn walk_private(path: &Path, exact_private: bool) -> Result<(), WorktreeError> {
         {
             return Err(WorktreeError::NotPrivate);
         }
-        if exact_private && stat.st_mode & 0o7777 != 0o700 {
-            return Err(WorktreeError::NotPrivate);
-        }
     }
     Ok(())
 }
 
+fn sync_dir(path: &Path) -> Result<(), WorktreeError> {
+    fs::File::open(path)
+        .and_then(|handle| handle.sync_all())
+        .map_err(|_| WorktreeError::Io)
+}
+
+/// Creates the directory with mode 0700, or accepts an existing directory that
+/// already satisfies the private-premise checks. Racing creators fall through
+/// to the checks instead of failing.
 fn create_private_dir(path: &Path) -> Result<(), WorktreeError> {
     match nix::unistd::mkdir(path, Mode::from_bits_truncate(0o700)) {
-        Ok(()) => Ok(()),
-        Err(nix::errno::Errno::EEXIST) => Err(WorktreeError::AlreadyReserved),
+        Ok(()) => {
+            sync_dir(path.parent().ok_or(WorktreeError::UnsafePath)?)?;
+            check_private_dir(path, true)
+        }
+        Err(nix::errno::Errno::EEXIST) => check_private_dir(path, true),
         Err(_) => Err(WorktreeError::UnsafePath),
     }
 }
@@ -281,8 +297,15 @@ fn write_marker(marker_path: &Path, marker: &Marker) -> Result<(), WorktreeError
         _ => WorktreeError::UnsafePath,
     })?;
     let mut file = std::fs::File::from(fd);
-    std::io::Write::write_all(&mut file, &body).map_err(|_| WorktreeError::Io)?;
-    file.sync_all().map_err(|_| WorktreeError::Io)?;
+    let written = std::io::Write::write_all(&mut file, &body).and_then(|_| file.sync_all());
+    if written.is_err() {
+        // A half-written marker would permanently brick this identity:
+        // reserve would hit EEXIST while verify could never read it. Remove
+        // the marker we created so the identity stays reservable.
+        let _ = unlink(marker_path);
+        return Err(WorktreeError::Io);
+    }
+    sync_dir(marker_path.parent().ok_or(WorktreeError::UnsafePath)?)?;
     Ok(())
 }
 
@@ -322,15 +345,15 @@ fn ensure_base(base: &Path) -> Result<(), WorktreeError> {
                 .parent()
                 .filter(|p| !p.as_os_str().is_empty())
                 .ok_or(WorktreeError::InvalidBase)?;
-            walk_private(parent, false)?;
-            create_private_dir(base).map_err(|error| match error {
-                WorktreeError::AlreadyReserved => WorktreeError::NotPrivate,
-                other => other,
-            })?;
+            walk_private(parent)?;
+            // A racing creator may have made it exist between the metadata
+            // check and mkdir; create_private_dir falls through to the same
+            // private-premise checks for EEXIST instead of failing.
+            create_private_dir(base)?;
         }
         Err(_) => return Err(WorktreeError::UnsafePath),
     }
-    walk_private(base, false)
+    walk_private(base)
 }
 
 /// Reserves the derived location: `<base>/<project>/<worktree_id>` with a
@@ -362,12 +385,18 @@ pub fn reserve(
         }
         Ok(_) => return Err(WorktreeError::UnsafePath),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            // EEXIST from a racing sibling stream's creator falls through to
+            // the same checks rather than failing this reservation.
             create_private_dir(&project_dir)?;
         }
         Err(_) => return Err(WorktreeError::UnsafePath),
     }
     let worktree = derived.worktree_path(base);
-    create_private_dir(&worktree)?;
+    create_private_dir(&worktree).map_err(|error| match error {
+        // Only an existing location can mean a real double reservation.
+        WorktreeError::AlreadyReserved => WorktreeError::AlreadyReserved,
+        other => other,
+    })?;
     let marker = Marker {
         version: RESERVATION_VERSION,
         derived: derived.clone(),
@@ -408,7 +437,14 @@ pub fn verify(reservation: &Reservation) -> Result<Marker, WorktreeError> {
     let base = &reservation.base;
     // Verification never creates state: a missing or non-private base fails.
     validate_absolute(base, MAX_BASE_BYTES)?;
-    walk_private(base, false)?;
+    for protected in [
+        "/usr", "/etc", "/dev", "/proc", "/sys", "/run", "/boot", "/var",
+    ] {
+        if base.starts_with(protected) {
+            return Err(WorktreeError::InvalidBase);
+        }
+    }
+    walk_private(base)?;
     let project_dir = base.join(reservation.derived.project_id.as_str());
     check_private_dir(&project_dir, true)?;
     let worktree = reservation.derived.worktree_path(base);
@@ -450,8 +486,12 @@ pub fn release(reservation: &Reservation, policy: ReleasePolicy) -> Result<Outco
             if entries.next().is_some() {
                 return Err(WorktreeError::NotEmpty);
             }
-            unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
+            // Remove the directory first: remove_dir fails closed on any
+            // content, and a failure here keeps the marker as the source of
+            // truth instead of downgrading the reservation to abandoned.
             fs::remove_dir(&worktree).map_err(|_| WorktreeError::Io)?;
+            unlink(&marker_path).map_err(|_| WorktreeError::Io)?;
+            sync_dir(&project_dir)?;
             // Removing the project directory is best-effort; concurrent
             // reservations of the same project keep it alive.
             let _ = fs::remove_dir(&project_dir);
@@ -475,13 +515,17 @@ pub fn list(base: &Path, project: &ProjectId) -> Result<Vec<Marker>, WorktreeErr
         if id.is_empty() || !id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-') {
             continue;
         }
-        markers.push(read_marker(&entry.path())?);
+        // One unreadable or foreign marker does not hide the others; callers
+        // verify individual reservations for integrity.
+        if let Ok(marker) = read_marker(&entry.path()) {
+            markers.push(marker);
+        }
     }
     markers.sort_by(|a, b| a.derived.worktree_id.cmp(&b.derived.worktree_id));
     Ok(markers)
 }
 
-use symbiote_domain::{ChangeStreamId, ProjectId, RootId, Timestamp};
+use symbiote_domain::{ChangeStreamId, ProjectId, RootId, Timestamp, WorktreeId};
 
 #[cfg(test)]
 mod tests {
@@ -526,11 +570,18 @@ mod tests {
         for component in a.branch.split('/') {
             assert!(ref_component(component), "bad component: {component}");
         }
-        assert_eq!(a.branch.len() + a.worktree_id.len(), {
-            let again = derived("stream-a", "policy-1");
-            again.branch.len() + again.worktree_id.len()
-        });
-        assert!(a.worktree_id.starts_with("st-"));
+        assert!(a.worktree_id.as_str().starts_with("st-"));
+        assert!(a.worktree_id.as_str().len() == 3 + 2 * WORKTREE_ID_DIGEST_BYTES);
+        assert_eq!(
+            a.branch.len() - a.project_id.as_str().len() - a.stream_id.as_str().len(),
+            {
+                // The invariant part of the branch (prefix + separators + suffix) is fixed-length.
+                let again = derived("stream-a", "policy-1");
+                again.branch.len()
+                    - again.project_id.as_str().len()
+                    - again.stream_id.as_str().len()
+            }
+        );
     }
 
     #[test]

--- a/crates/symbiote-worktrees/src/lib.rs
+++ b/crates/symbiote-worktrees/src/lib.rs
@@ -311,7 +311,16 @@ fn write_marker(marker_path: &Path, marker: &Marker) -> Result<(), WorktreeError
         };
     }
     if persisted.is_err() {
-        let _ = unlink(marker_path);
+        // Unlink only when the path still names the inode this call created:
+        // a concurrent release-plus-re-reservation may have replaced the path
+        // with a new valid marker, which is never ours to remove.
+        if let Ok(created) = file.metadata() {
+            if let Ok(current) = fs::symlink_metadata(marker_path) {
+                if current.ino() == created.ino() && current.dev() == created.dev() {
+                    let _ = unlink(marker_path);
+                }
+            }
+        }
         return Err(WorktreeError::Io);
     }
     Ok(())

--- a/docs/contracts/worktrees.md
+++ b/docs/contracts/worktrees.md
@@ -7,7 +7,7 @@ Canonical owner: [#211](https://github.com/RepairYourTech/SymbioteIDE/issues/211
 `Derived::derive(DeriveInputs)` is a pure function of canonical Project/Root/Change Stream identities plus a trusted policy seed (1–64 characters of `[A-Za-z0-9_-]`, supplied by Host state, never client JSON). The same recorded identities and seed always derive the same names:
 
 - `worktree_id`: the canonical `WorktreeId` newtype, `st-` plus 16 hex characters carrying a 64-bit digest truncation. It is a bounded identity string, never a path.
-- `branch`: `symbiote/<project>/<stream>/<24-hex>` — a Git-ref-safe branch in a reserved namespace; the suffix carries a 96-bit digest truncation. Every component passes check-ref-format rules (no leading dot, no `.lock`, no `..`, no `@{`, safe charset), and branch length is bounded to 256 bytes.
+- `branch`: `symbiote/<project>/<stream>/<24-hex>` — a Git-ref-safe branch in a reserved namespace; the suffix carries a 96-bit digest truncation. Every component passes check-ref-format rules (no leading dot, no `.lock`, no `..`, no `@{`, safe charset), and branch length is bounded to 512 bytes (the worst case of two 128-byte domain identities; the protocol TaskDraft bound matches).
 
 Both suffixes are truncated hashes: collision-resistant for any realistic stream count (a birthday collision on the branch suffix needs on the order of 2^48 derived names), not mathematically impossible. `derived(seed, ids)` feeds the store's existing worktree/branch uniqueness enforcement at Task creation, which remains the durable backstop; the seed choice is durable policy, because changing it changes every subsequent derived name.
 

--- a/docs/contracts/worktrees.md
+++ b/docs/contracts/worktrees.md
@@ -6,10 +6,10 @@ Canonical owner: [#211](https://github.com/RepairYourTech/SymbioteIDE/issues/211
 
 `Derived::derive(DeriveInputs)` is a pure function of canonical Project/Root/Change Stream identities plus a trusted policy seed (1–64 characters of `[A-Za-z0-9_-]`, supplied by Host state, never client JSON). The same recorded identities and seed always derive the same names:
 
-- `worktree_id`: `st-` plus 16 hash-hex characters. This is a bounded identity string, never a path; it is suitable for the canonical `WorktreeId` reference the store already treats as globally unique.
-- `branch`: `symbiote/<project>/<stream>/<12-hex>` — a Git-ref-safe branch in a reserved namespace. Every component passes check-ref-format rules (no leading dot, no `.lock`, no `..`, no `@{`, safe charset), and branch length is bounded to 256 bytes.
+- `worktree_id`: the canonical `WorktreeId` newtype, `st-` plus 16 hex characters carrying a 64-bit digest truncation. It is a bounded identity string, never a path.
+- `branch`: `symbiote/<project>/<stream>/<24-hex>` — a Git-ref-safe branch in a reserved namespace; the suffix carries a 96-bit digest truncation. Every component passes check-ref-format rules (no leading dot, no `.lock`, no `..`, no `@{`, safe charset), and branch length is bounded to 256 bytes.
 
-Different seeds or identities derive different names. `derived(seed, ids)` feeds the store's existing worktree/branch uniqueness enforcement at Task creation; the seed choice is durable policy, because changing it changes every subsequent derived name.
+Both suffixes are truncated hashes: collision-resistant for any realistic stream count (a birthday collision on the branch suffix needs on the order of 2^48 derived names), not mathematically impossible. `derived(seed, ids)` feeds the store's existing worktree/branch uniqueness enforcement at Task creation, which remains the durable backstop; the seed choice is durable policy, because changing it changes every subsequent derived name.
 
 ## Reservation premises
 
@@ -32,7 +32,9 @@ The marker lives in the private project directory, never inside the worktree, so
 
 ## Evidence and remaining acceptance
 
-Covered by unit tests: determinism/collision resistance, seed/ref-safety rejection, reserve-verify-release round trip (both release policies, mode checks), single-winner reservation, tamper detection (foreign content, swapped marker identity, missing base not recreated), refusal to delete nonempty work, unsafe base rejection (system trees, relative paths, writable base, symlink components), and eight concurrent reservations without collision.
+Covered by unit tests: determinism, seed/ref-safety rejection, reserve-verify-release round trip (both release policies, mode checks), single-winner reservation, tamper detection (foreign content, swapped marker identity, missing base not recreated), refusal to delete nonempty work, unsafe base rejection (system trees, relative paths, writable base, symlink components), and repeated runs of eight concurrent reservations — including concurrent first-time creation of the shared project directory, which falls through to the private-premise checks rather than failing.
+
+Marker writes are fsynced together with their parent directory entries; a failed or interrupted marker write removes the marker it created so the identity stays reservable. `release(DeleteIfEmpty)` removes the directory before unlinking the marker, so any failure leaves the marker as the source of truth. `list` skips unreadable or foreign marker entries rather than failing the whole enumeration; call `verify` per reservation for integrity.
 
 Pending #211 acceptance, tracked in the issue: actual `git worktree add` materialization against #190's repository abstraction, base-commit validation before dispatch, read-only vs sole-mutation vs parallel-mutation policy, no-worktree verified read-only tasks, synchronization/rebase/restack preparation, integration state, and evidence-confirmed cleanup. Store integration for recorded stream identity is exercised through the existing `create_task` worktree/branch uniqueness tests.
 

--- a/docs/contracts/worktrees.md
+++ b/docs/contracts/worktrees.md
@@ -1,0 +1,39 @@
+# Reserved Change Stream worktree locations
+
+Canonical owner: [#211](https://github.com/RepairYourTech/SymbioteIDE/issues/211), depending on #189 and respecting the #190 repository abstraction. `symbiote-worktrees` implements the location layer of Change Stream mutation isolation: deterministic collision-resistant naming plus filesystem reservation and re-verification of the exact location the [Linux sandbox](../security/linux-sandbox.md) requires its caller to reserve. This is not full #211 acceptance: no Git is executed, no repository worktree is created, no checkout or synchronization happens, and cleanup with evidence remains pending. Git/repository identity stays with #190; this crate never second-guesses it.
+
+## Deterministic naming
+
+`Derived::derive(DeriveInputs)` is a pure function of canonical Project/Root/Change Stream identities plus a trusted policy seed (1–64 characters of `[A-Za-z0-9_-]`, supplied by Host state, never client JSON). The same recorded identities and seed always derive the same names:
+
+- `worktree_id`: `st-` plus 16 hash-hex characters. This is a bounded identity string, never a path; it is suitable for the canonical `WorktreeId` reference the store already treats as globally unique.
+- `branch`: `symbiote/<project>/<stream>/<12-hex>` — a Git-ref-safe branch in a reserved namespace. Every component passes check-ref-format rules (no leading dot, no `.lock`, no `..`, no `@{`, safe charset), and branch length is bounded to 256 bytes.
+
+Different seeds or identities derive different names. `derived(seed, ids)` feeds the store's existing worktree/branch uniqueness enforcement at Task creation; the seed choice is durable policy, because changing it changes every subsequent derived name.
+
+## Reservation premises
+
+`reserve(derived, base, created_at)` creates `<base>/<project>/<worktree_id>/` with an exclusive marker binding the derived identity and creation time. Premises match the sandbox launcher exactly:
+
+- The base directory is absolute, bounded, symlink-free, and outside system trees (`/usr`, `/etc`, `/dev`, `/proc`, `/sys`, `/run`, `/boot`, `/var`). A missing base is created with mode 0700; an existing base must be euid-owned (root-owned components like `/tmp` are accepted with the sticky-bit discipline, mirroring the sandbox walk rule).
+- The project directory and the reserved worktree are created with mode 0700 and verified euid-owned.
+- The marker is written `O_EXCL` with mode 0600 and fsynced: concurrent reservations of the same identity have exactly one winner (`AlreadyReserved`), and a failed marker write removes the directory it created.
+
+The marker lives in the private project directory, never inside the worktree, so later Git materialization keeps a clean tree. `verify(reservation)` re-derives nothing new and creates nothing: it re-walks base/project/worktree without following symlinks, checks ownership and modes, reads the marker, rejects identity mismatch (including a swapped stream identity), and rejects any content in the reserved directory — foreign use fails loudly instead of being absorbed. This is the provisioner-side premise the launcher relies on; the launcher still revalidates independently at launch.
+
+## Release and content discipline
+
+`release(reservation, policy)` has exactly two outcomes:
+
+- `Retain` removes only the marker; the directory is kept for recovery/inspection and becomes an abandoned location, never removable work.
+- `DeleteIfEmpty` removes marker and directory only when the directory holds no entries. Any content — including materialized Git state or uncommitted files — fails with `NotEmpty` and touches nothing. Unmerged or uncommitted work is never deleted recursively; that requires separate evidence and authorized confirmation under the Change Stream contract.
+
+`list(base, project)` enumerates a project's markers; integrity is not re-verified by `list` — callers verify per reservation.
+
+## Evidence and remaining acceptance
+
+Covered by unit tests: determinism/collision resistance, seed/ref-safety rejection, reserve-verify-release round trip (both release policies, mode checks), single-winner reservation, tamper detection (foreign content, swapped marker identity, missing base not recreated), refusal to delete nonempty work, unsafe base rejection (system trees, relative paths, writable base, symlink components), and eight concurrent reservations without collision.
+
+Pending #211 acceptance, tracked in the issue: actual `git worktree add` materialization against #190's repository abstraction, base-commit validation before dispatch, read-only vs sole-mutation vs parallel-mutation policy, no-worktree verified read-only tasks, synchronization/rebase/restack preparation, integration state, and evidence-confirmed cleanup. Store integration for recorded stream identity is exercised through the existing `create_task` worktree/branch uniqueness tests.
+
+Applicability: security/privacy — the crate enforces the private-parent premise the sandbox documents and never follows symlinks; it grants no authority by itself and holds no credentials. Accessibility is not applicable to a filesystem provisioner library. Performance is bounded by path/component limits, not benchmarked. Linux-only today (`#![cfg(target_os = "linux")]`), matching the sandbox; Windows/macOS placement is separately pending with the platform work.


### PR DESCRIPTION
Closes toward #211 (location layer only; the issue remains open for Git materialization and the rest of its acceptance). Respects the #190 repository abstraction boundary: this crate never runs Git.

## What this adds

**`symbiote-worktrees`** — deterministic collision-resistant naming plus filesystem reservation and re-verification of the location the Linux sandbox requires its caller to reserve (the trusted-provisioner premise documented in `docs/security/linux-sandbox.md`).

- **Deterministic naming.** `Derived::derive` is a pure function of canonical Project/Root/Change Stream identities plus a trusted policy seed (1–64 chars `[A-Za-z0-9_-]`, from Host state, never client JSON). It yields a bounded `st-…` WorktreeId string and a Git-ref-safe branch `symbiote/<project>/<stream>/<12hex>` (every component check-ref-format validated; no leading dot, no `.lock`, no `..`, no `@{`). Same recorded inputs → same names; different identities or seeds never collide. The derived names feed the store's existing `create_task` worktree/branch uniqueness enforcement.
- **Reservation.** `reserve()` creates `<base>/<project>/<worktree_id>/` with mode-0700 private directories and an `O_EXCL` fsynced marker binding the derived identity, so concurrent reservations have exactly one winner. Premises mirror the sandbox launcher: bounded absolute symlink-free paths, system trees (`/usr`, `/etc`, `/dev`, `/proc`, `/sys`, `/run`, `/boot`, `/var`) refused, euid/root ownership with the sandbox's exact sticky-bit walk rule, failed marker writes clean up their directory.
- **Verification.** `verify()` creates nothing: it re-walks without following symlinks, checks ownership/modes, reads the marker, rejects identity mismatch and any foreign content in the reserved directory. The sandbox launcher still revalidates independently; this is the provisioner side of the documented premise.
- **Release discipline.** `release()` has exactly two outcomes: `Retain` (marker removed, directory kept as an abandoned location) or `DeleteIfEmpty` (only when the directory holds zero entries). Any content — materialized Git state or uncommitted files — fails `NotEmpty` and touches nothing. Unmerged work is never deleted without evidence and authorized confirmation, per the Change Stream contract.

The marker lives in the private project directory, not inside the worktree, so later `git worktree add` materialization keeps a clean tree.

## Honest non-claims

No Git execution, no repository worktree creation, no checkout/synchronization, no base-commit validation, no read-only/sole-mutation/parallel-mutation policy, no integration state, no evidence-confirmed cleanup — all remaining under #211 with #190 dependency noted in the new `docs/contracts/worktrees.md`.

## Verification

- `cargo test --workspace`: 281 passed, 0 failed (8 new: determinism/collision, seed/ref-safety rejection, reserve-verify-release round trip with mode checks, single-winner race, tamper detection — foreign content/swapped marker/missing base not recreated — nonempty-work release refusal, unsafe base rejection, 8-way concurrent reservation)
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean

## Review scope

Reservation/verification premises vs the sandbox's documented contract (sticky-bit walk-rule equivalence, `verify` never creating state, marker in parent not worktree) and the release non-deletion discipline are the areas I most want independent eyes on.


---

## Review dispositions (heads 79ece8e5 → 265f9b8e)

**Independent reviewer agent** (head `79ece8e5`): no P0/P1-blocking security gaps; 3 P1 + 6 P2 findings — all fixed in `f2f2d5d2` (races fall through to premise checks, orphaned-marker cleanup, digest-byte derivation with honest truncation + `WorktreeId` newtype, verify re-checks protected prefixes, release ordering, `list` skip policy, dead surface removed).

**Qodo** (triggered per commit, latest full pass at head `a39e06e`/`265f9b8e`): 14 findings raised across passes; every finding marked ✓ Resolved except one — "A failed reservation can erase a winner" — whose demanded behavior (unlink only when the path still names the inode this call created) is implemented in `265f9b8e` (`crates/symbiote-worktrees/src/lib.rs`, `write_marker` failure branch) but the bot's re-review of that hunk has not yet refreshed; its Evidence still cites the pre-fix line. CI is green at `265f9b8e` and the full workspace suite (283 tests, 10 worktree-crate tests incl. concurrency stress) passes locally.

Residual known limits, honestly stated: marker cleanup after a persistence failure is best-effort (a marker that persists is detected, not silent); empty orphan directories are reclaimed only through the exclusive mkdir + content checks; no locking between concurrent processes (same-UID adversary remains out of scope per the crate header and sandbox boundary docs).
