### PR TITLE
feat(external): add the sandboxed production transport and real-binary handshake proof

### DIFF
--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -58,3 +58,12 @@ jobs:
           cargo run --locked -p symbiote-runtime-discovery --example codex_discover -- \
             "$GITHUB_WORKSPACE/target/debug/symbiote-sandbox-launch" \
             "$proof_root/worktree" "$proof_root/protected"
+      - name: Prove pinned Codex driver handshake and thread start without a model turn
+        if: matrix.toolchain == 'stable'
+        run: |
+          cargo build --locked -p symbiote-external-agent --example codex_thread_smoke
+          smoke_root=$(mktemp -d "$RUNNER_TEMP/smoke.XXXXXXXX")
+          mkdir -m 700 "$smoke_root/worktree" "$smoke_root/protected"
+          cargo run --locked -p symbiote-external-agent --example codex_thread_smoke -- \
+            "$GITHUB_WORKSPACE/target/debug/symbiote-sandbox-launch" \
+            "$smoke_root/worktree" "$smoke_root/protected"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,11 @@ dependencies = [
  "serde",
  "serde_json",
  "symbiote-domain",
+ "symbiote-runtime-discovery",
  "symbiote-runtime-sdk",
+ "symbiote-runtime-transport",
+ "symbiote-sandbox",
+ "symbiote-trust",
 ]
 
 [[package]]

--- a/crates/symbiote-external-agent/Cargo.toml
+++ b/crates/symbiote-external-agent/Cargo.toml
@@ -7,6 +7,13 @@ publish = false
 [dependencies]
 symbiote-domain = { path = "../symbiote-domain" }
 symbiote-runtime-sdk = { path = "../symbiote-runtime-sdk" }
+symbiote-runtime-discovery = { path = "../symbiote-runtime-discovery" }
+symbiote-runtime-transport = { path = "../symbiote-runtime-transport" }
+symbiote-sandbox = { path = "../symbiote-sandbox" }
+symbiote-trust = { path = "../symbiote-trust" }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[[example]]
+name = "codex_thread_smoke"

--- a/crates/symbiote-external-agent/examples/codex_thread_smoke.rs
+++ b/crates/symbiote-external-agent/examples/codex_thread_smoke.rs
@@ -1,0 +1,109 @@
+//! Offline compatibility proof with fixture consent, not Host activation
+//! authority: launch the pinned Codex App Server inside the Symbiote sandbox,
+//! complete the driver's real handshake (initialize → pinned version →
+//! initialized → thread/start), and stop. No turn starts, so no model is
+//! called, no credential is read (fresh disposable HOME) and nothing is
+//! spent. Usage:
+//!   codex_thread_smoke <helper> <empty-worktree> <protected-dir>...
+use serde_json::json;
+use std::{collections::BTreeSet, path::PathBuf};
+use symbiote_domain::*;
+use symbiote_external_agent::CodexTransport;
+use symbiote_external_agent::process::{codex_launch_fingerprint, launch_sandboxed};
+use symbiote_sandbox::Profile;
+use symbiote_trust::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let inputs: Vec<_> = std::env::args_os().skip(1).map(PathBuf::from).collect();
+    if inputs.len() != 3 {
+        return Err(
+            "expected absolute helper, private empty worktree, protected Host directory".into(),
+        );
+    }
+    if std::fs::read_dir(&inputs[1])?.next().is_some() {
+        return Err("thread smoke requires an empty worktree".into());
+    }
+    let root = RootId::new("smoke-root")?;
+    let profile = Profile::ReadOnly;
+    let snapshot = ResourceSnapshot {
+        project_id: ProjectId::new("smoke-project")?,
+        role_id: RoleId::new("smoke-role")?,
+        profile_id: RuntimeProfileId::new("smoke-profile")?,
+        host_id: HostId::new("smoke-host")?,
+        resource_ref: "offline-codex-thread-smoke".into(),
+        fingerprint: codex_launch_fingerprint(&root, &inputs[1], profile)?,
+        access: AccessSnapshot {
+            project_id: ProjectId::new("smoke-project")?,
+            roots: BTreeSet::from([root.clone()]),
+            grants: BTreeSet::from([Permission::ReadRoot, Permission::ExecuteProcess]),
+            policy_revision: Revision(1),
+        },
+    };
+    let consent = ResourceConsent {
+        id: CommandId::new("smoke-consent")?,
+        snapshot: snapshot.clone(),
+        user_id: UserId::new("smoke-user")?,
+        issued_at: Timestamp(1),
+        expires_at: Timestamp(3),
+        revoked_at: None,
+    };
+    let mut server = launch_sandboxed(
+        &inputs[0],
+        &consent,
+        &snapshot.access,
+        &snapshot.host_id,
+        Timestamp(2),
+        &root,
+        &inputs[1],
+        &inputs[2..],
+        profile,
+        symbiote_runtime_transport::TransportLimits::default(),
+    )?;
+    // Real handshake against the real binary through the real framing.
+    let initialized = server.call(
+        "initialize",
+        &json!({"clientInfo": {"name": "symbiote", "version": "0.1.0", "title": "Symbiote"}}),
+    )?;
+    let user_agent = initialized
+        .get("userAgent")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("server did not report a user agent")?
+        .to_owned();
+    let expected = format!(
+        "symbiote/{}",
+        symbiote_runtime_discovery::codex::CODEX_VERSION
+    );
+    if user_agent.split_whitespace().next() != Some(&expected) {
+        return Err(format!("unexpected server version: {user_agent}").into());
+    }
+    server.notify("initialized", &json!({}))?;
+    let thread = server.call(
+        "thread/start",
+        &json!({
+            "cwd": "/workspace",
+            "sandbox": "read-only",
+            "approvalPolicy": "never",
+        }),
+    )?;
+    let thread_id = thread
+        .get("thread")
+        .and_then(|t| t.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or("server did not report a thread id")?
+        .to_owned();
+    let _cleanup = server.io().cancel(std::time::Duration::from_secs(2))?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "server_version": expected,
+            "handshake": "initialize_initialized_ok",
+            "thread_started": !thread_id.is_empty(),
+            "turn_started": false,
+            "model_called": false,
+            "credentials_mounted": false,
+            "profile": "fresh_disposable_home",
+            "network": "denied_by_sandbox"
+        })
+    );
+    Ok(())
+}

--- a/crates/symbiote-external-agent/examples/codex_thread_smoke.rs
+++ b/crates/symbiote-external-agent/examples/codex_thread_smoke.rs
@@ -1,14 +1,17 @@
 //! Offline compatibility proof with fixture consent, not Host activation
-//! authority: launch the pinned Codex App Server inside the Symbiote sandbox,
-//! complete the driver's real handshake (initialize → pinned version →
-//! initialized → thread/start), and stop. No turn starts, so no model is
-//! called, no credential is read (fresh disposable HOME) and nothing is
-//! spent. Usage:
+//! authority: launch the pinned Codex App Server inside the Symbiote sandbox
+//! and drive the real driver-level handshake — `ExternalSession::begin_thread`
+//! over the production `CodexServerProcess` framing (initialize → pinned
+//! version → initialized → thread/start), then stop. No turn starts, so no
+//! model is called, no credential is read (fresh disposable HOME) and nothing
+//! is spent. Usage:
 //!   codex_thread_smoke <helper> <empty-worktree> <protected-dir>...
-use serde_json::json;
+//! The driver session needs a dispatch; the smoke proof mints a fixture
+//! dispatch with fixture consent exactly like the #483 discovery example.
+//! This is protocol compatibility evidence, not Host activation authority.
 use std::{collections::BTreeSet, path::PathBuf};
 use symbiote_domain::*;
-use symbiote_external_agent::CodexTransport;
+use symbiote_external_agent::ExternalSession;
 use symbiote_external_agent::process::{codex_launch_fingerprint, launch_sandboxed};
 use symbiote_sandbox::Profile;
 use symbiote_trust::*;
@@ -47,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         expires_at: Timestamp(3),
         revoked_at: None,
     };
-    let mut server = launch_sandboxed(
+    let mut server = match launch_sandboxed(
         &inputs[0],
         &consent,
         &snapshot.access,
@@ -58,45 +61,46 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &inputs[2..],
         profile,
         symbiote_runtime_transport::TransportLimits::default(),
-    )?;
-    // Real handshake against the real binary through the real framing.
-    let initialized = server.call(
-        "initialize",
-        &json!({"clientInfo": {"name": "symbiote", "version": "0.1.0", "title": "Symbiote"}}),
-    )?;
-    let user_agent = initialized
-        .get("userAgent")
-        .and_then(serde_json::Value::as_str)
-        .ok_or("server did not report a user agent")?
-        .to_owned();
-    let expected = format!(
-        "symbiote/{}",
-        symbiote_runtime_discovery::codex::CODEX_VERSION
+    ) {
+        Ok(server) => server,
+        Err(error) => {
+            eprintln!("launch_sandboxed error: {error:?}");
+            return Err(error.into());
+        }
+    };
+    // The driver path, not a hand-rolled handshake: a real ExternalSession
+    // validates its contract, records Ready, performs the full handshake and
+    // starts the thread. The sandbox mounts the worktree at /workspace and
+    // the host path is invisible, so that is the cwd the driver must send.
+    let task = Task::new(
+        TaskId::new("smoke-task")?,
+        ProjectId::new("smoke-project")?,
+        RootId::new("smoke-root")?,
+        RoleId::new("smoke-role")?,
+        ChangeStreamId::new("smoke-stream")?,
+        VersionedTaskContract {
+            id: TaskContractId::new("smoke-contract")?,
+            revision: Revision(1),
+        },
     );
-    if user_agent.split_whitespace().next() != Some(&expected) {
-        return Err(format!("unexpected server version: {user_agent}").into());
-    }
-    server.notify("initialized", &json!({}))?;
-    let thread = server.call(
-        "thread/start",
-        &json!({
-            "cwd": "/workspace",
-            "sandbox": "read-only",
-            "approvalPolicy": "never",
-        }),
-    )?;
-    let thread_id = thread
-        .get("thread")
-        .and_then(|t| t.get("id"))
-        .and_then(serde_json::Value::as_str)
-        .ok_or("server did not report a thread id")?
-        .to_owned();
+    let dispatch = smoke_dispatch(&task)?;
+    let mut session = ExternalSession::new(&dispatch, Timestamp(2))?;
+    session.begin_thread("/workspace", &mut server)?;
+    let thread_id = session.harness_thread_id().unwrap_or_default().to_owned();
+    let stopped = session.run_summary().stopped;
     let _cleanup = server.io().cancel(std::time::Duration::from_secs(2))?;
+    if stopped.is_some() {
+        return Err("driver reported a stop during the handshake".into());
+    }
     println!(
         "{}",
         serde_json::json!({
-            "server_version": expected,
-            "handshake": "initialize_initialized_ok",
+            "server_version": format!(
+                "symbiote/{}",
+                symbiote_runtime_discovery::codex::CODEX_VERSION
+            ),
+            "handshake": "driver_begin_thread_ok",
+            "events": session.events().len(),
             "thread_started": !thread_id.is_empty(),
             "turn_started": false,
             "model_called": false,
@@ -106,4 +110,97 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
     );
     Ok(())
+}
+
+/// The minimal external-harness dispatch for the smoke session. Fixture
+/// identities throughout; no real Project, Role, binding or Host exists.
+fn smoke_dispatch(task: &Task) -> Result<Dispatch, Box<dyn std::error::Error>> {
+    let host_id = HostId::new("smoke-host")?;
+    let profile = RuntimeProfile {
+        id: RuntimeProfileId::new("smoke-profile")?,
+        revision: Revision(0),
+        runtime: RuntimeKind::ExternalHarness,
+        adapter: AgentRuntimeAdapterId::new("codex-harness")?,
+        installation: Some(InstallationId::new("codex-0-118-0")?),
+        provider: ProviderConnectionId::new("smoke-provider")?,
+        credential: CredentialReferenceId::new("smoke-credential")?,
+        billing_entitlement: BillingEntitlementId::new("smoke-entitlement")?,
+        model: ModelId::new("smoke-model")?,
+        eligible_hosts: BTreeSet::from([host_id.clone()]),
+    };
+    let binding = WorkforceBinding {
+        id: BindingId::new("smoke-binding")?,
+        revision: Revision(0),
+        project_id: task.project_id().clone(),
+        role_id: task.role_id().clone(),
+        profile_id: profile.id.clone(),
+        profile_revision: profile.revision,
+        protocol: VersionedProtocol {
+            id: ProtocolId::new("smoke-protocol")?,
+            revision: Revision(1),
+        },
+        access: AccessSnapshot {
+            project_id: task.project_id().clone(),
+            roots: BTreeSet::from([task.root_id().clone()]),
+            grants: BTreeSet::from([Permission::ReadRoot, Permission::MutateStream]),
+            policy_revision: Revision(1),
+        },
+        required_controls: BTreeSet::new(),
+        context: ContextPolicy {
+            bundle: ContextBundleId::new("smoke-context")?,
+            revision: Revision(1),
+            max_input_tokens: 1024,
+            reserved_output_tokens: 1024,
+        },
+        required_tools: BTreeSet::new(),
+        required_skills: BTreeSet::new(),
+        escalation: EscalationPolicy::StopAndRequestHuman,
+    };
+    let host = Host {
+        id: host_id,
+        revision: Revision(0),
+        device: DeviceId::new("smoke-device")?,
+        fabric: None,
+        supported_runtimes: vec![RuntimeKind::ExternalHarness],
+        controls: BTreeSet::from([
+            symbiote_domain::Control::Filesystem,
+            symbiote_domain::Control::Cancellation,
+            symbiote_domain::Control::CompletionAuthority,
+        ])
+        .into_iter()
+        .map(|control| {
+            (
+                control,
+                EnforcementClaim {
+                    strength: EnforcementStrength::HostEnforced,
+                    evidence: EvidenceId::new("smoke-evidence").expect("valid fixture id"),
+                    verified_at: Timestamp(1),
+                    expires_at: Timestamp(1_000_000),
+                },
+            )
+        })
+        .collect(),
+    };
+    let role = Role {
+        id: task.role_id().clone(),
+        project_id: task.project_id().clone(),
+        revision: Revision(0),
+        name: "Smoke".into(),
+        operating_contract: VersionedRoleContract {
+            id: RoleContractId::new("smoke-role-contract")?,
+            revision: Revision(1),
+        },
+    };
+    Ok(Dispatch::compile(
+        DispatchId::new("smoke-dispatch")?,
+        RuntimeContractId::new("smoke-rtc")?,
+        symbiote_domain::DispatchInputs {
+            task,
+            role: &role,
+            binding: &binding,
+            profile: &profile,
+            host: &host,
+            now: Timestamp(2),
+        },
+    )?)
 }

--- a/crates/symbiote-external-agent/src/lib.rs
+++ b/crates/symbiote-external-agent/src/lib.rs
@@ -37,16 +37,16 @@ use symbiote_runtime_sdk::events::{
 pub mod process;
 
 pub const EXTERNAL_LOOP_VERSION: u32 = 1;
-/// A single `call` may legally interleave this many notifications before its
-/// response; beyond it the harness is misbehaving. One observed turn may see
-/// at most `MAX_NOTIFICATIONS_PER_CALL * MAX_TURNS_NOTIFICATION_ROUNDS`
-/// frames before the driver gives up rather than buffering unboundedly.
-pub const MAX_NOTIFICATIONS_PER_CALL: usize = 64;
-/// How many notification reads one observed turn may span.
-pub const MAX_TURNS_NOTIFICATION_ROUNDS: usize = 16;
+/// One observed turn may absorb at most
+/// `MAX_TURN_NOTIFICATION_FRAMES` harness frames before the driver gives up
+/// rather than journaling unboundedly. (The transport separately bounds how
+/// many frames one `call` may buffer: 1024.)
+pub const MAX_TURN_NOTIFICATION_FRAMES: usize = 1024;
 /// Empty polls while waiting for harness frames. The production transport
-/// blocks on each poll, so this bounds a silent-but-alive harness (a long
-/// model turn) without falsely reporting a live run as lost.
+/// polls at 250 ms, so this bounds a silent-but-alive harness (a long model
+/// turn) at roughly 17 minutes before declaring the transport lost. Frames
+/// that surfaced server requests do not count as silence: the harness was
+/// alive and conversed with.
 pub const MAX_EMPTY_NOTIFICATION_POLLS: usize = 4096;
 /// Notification text (agent messages, command output) is bounded by the SDK
 /// event contract; oversized text truncates on char boundaries with a marker.
@@ -355,15 +355,24 @@ impl ExternalSession {
     }
 
     /// Completes the pinned App Server handshake and starts the harness
-    /// thread bound to the task worktree. `worktree` is the reserved worktree
-    /// path the Host authorized in the dispatch's root; the harness's
-    /// internal sandbox policy is pinned to read-only and its approval
-    /// policy to never — the outer Host sandbox is the enforcement boundary.
-    /// No model turn starts here; the `codex_thread_smoke` proof stops after
-    /// this step.
+    /// thread. `worktree_cwd` is the worktree path **as visible to the
+    /// harness process**: through the sandboxed launcher the Host path is
+    /// mounted at `/workspace` and invisible by its host name, so callers
+    /// composing with [`process::launch_sandboxed`] pass `/workspace`; a
+    /// caller owning the process directly passes its own authorized path.
+    /// The harness's internal sandbox policy is pinned to read-only and its
+    /// approval policy to never — the outer Host sandbox is the enforcement
+    /// boundary. No model turn starts here; the `codex_thread_smoke` proof
+    /// stops after this step.
+    ///
+    /// Once the handshake begins, the session is single-shot: any failure
+    /// after the Ready event is terminal (the driver records a
+    /// `TransportLost` stop and a diagnostic), because a retry would record
+    /// a second Ready and make the journal unreplayable for the SDK's
+    /// session tracker. Recovery is a fresh session with a fresh dispatch.
     pub fn begin_thread(
         &mut self,
-        worktree: &str,
+        worktree_cwd: &str,
         transport: &mut impl CodexTransport,
     ) -> Result<(), DriverError> {
         if self.completion_report.is_some() || self.stopped.is_some() {
@@ -372,11 +381,28 @@ impl ExternalSession {
         if self.harness_thread_id.is_some() {
             return Err(DriverError::ContractMismatch);
         }
-        if worktree.is_empty() || worktree.len() > 4096 || !worktree.starts_with('/') {
+        if worktree_cwd.is_empty() || worktree_cwd.len() > 4096 || !worktree_cwd.starts_with('/') {
             return Err(DriverError::InvalidInput);
         }
         // The SDK's session consumers require Ready before any other event.
         self.record(RuntimeEventKind::Ready {})?;
+        // From here the session has begun journaling: a failure must be
+        // terminal so no entry point can append to a half-open session.
+        if let Err(error) = self.complete_handshake(worktree_cwd, transport) {
+            self.stopped = Some(StopKind::TransportLost);
+            self.record(RuntimeEventKind::Diagnostic {
+                message: truncate_event_text(&format!("harness handshake failed: {error}")),
+            })?;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn complete_handshake(
+        &mut self,
+        worktree_cwd: &str,
+        transport: &mut impl CodexTransport,
+    ) -> Result<(), DriverError> {
         // Handshake first: initialize → pinned version check → initialized.
         // The pin mirrors the #483 discovery probe exactly; a server that
         // does not report the pinned version is refused before any thread,
@@ -400,7 +426,7 @@ impl ExternalSession {
         // Thread identity is minted by the harness, not the driver. The
         // thread id is the correlation key for every later notification.
         let params = serde_json::json!({
-            "cwd": worktree,
+            "cwd": worktree_cwd,
             "sandbox": "read-only",
             "approvalPolicy": "never",
         });
@@ -520,9 +546,20 @@ impl ExternalSession {
                     // is invented. Recorded, never an approval.
                     ApprovalDecision::Unanswered
                 };
-                if decision != ApprovalDecision::Unanswered {
-                    transport.refuse_server_request(&request, decision)?;
+                if decision != ApprovalDecision::Unanswered
+                    && let Err(error) = transport.refuse_server_request(&request, decision)
+                {
+                    self.stopped = Some(StopKind::TransportLost);
+                    self.record(RuntimeEventKind::Diagnostic {
+                        message: truncate_event_text(&format!(
+                            "refusal reply failed; run is terminal: {error}"
+                        )),
+                    })?;
+                    return Err(error);
                 }
+                // The harness escalated: it is alive and conversed with, so
+                // this interaction is not silence.
+                empty_polls = 0;
                 self.record(RuntimeEventKind::Diagnostic {
                     message: truncate_event_text(&format!(
                         "refused harness approval request: {:?} ({refusal:?}, {decision:?})",
@@ -534,7 +571,7 @@ impl ExternalSession {
                 continue;
             };
             frames += 1;
-            if frames > MAX_NOTIFICATIONS_PER_CALL * MAX_TURNS_NOTIFICATION_ROUNDS {
+            if frames > MAX_TURN_NOTIFICATION_FRAMES {
                 self.stopped = Some(StopKind::TransportLost);
                 self.record(RuntimeEventKind::Diagnostic {
                     message: truncate_event_text("notification budget exceeded"),
@@ -558,7 +595,15 @@ impl ExternalSession {
                 })?;
                 continue;
             }
-            self.absorb_notification(&notification)?;
+            if let Err(error) = self.absorb_notification(&notification) {
+                self.stopped = Some(StopKind::TransportLost);
+                self.record(RuntimeEventKind::Diagnostic {
+                    message: truncate_event_text(&format!(
+                        "unabsorbable harness frame; run is terminal: {error}"
+                    )),
+                })?;
+                return Err(error);
+            }
             if method == "turn/completed" {
                 let status = params
                     .pointer("/turn/status")
@@ -1177,6 +1222,73 @@ mod tests {
     }
 
     #[test]
+    fn failed_handshake_is_terminal_and_retry_never_doubles_ready() {
+        // A server reporting a foreign version is refused after Ready; the
+        // session must be terminal so a retry cannot append a second Ready
+        // (which the SDK tracker would reject) to a half-open journal.
+        for bad_agent in ["symbiote/0.117.0", "unrelated", "symbiote/0.118.0evil"] {
+            let mut session = session();
+            let mut transport = FixtureTransport::new(
+                vec![Ok(serde_json::json!({
+                    "userAgent": format!("{bad_agent} (Linux)")
+                }))],
+                vec![],
+                vec![],
+            );
+            let error = session
+                .begin_thread("/tmp/worktree", &mut transport)
+                .unwrap_err();
+            assert_eq!(error, DriverError::UnsupportedVersion);
+            // Terminal: no retry, no turn, no completion filing.
+            assert_eq!(
+                session.begin_thread("/tmp/worktree", &mut transport),
+                Err(DriverError::AlreadyComplete)
+            );
+            assert_eq!(
+                session.turn("another", &mut transport),
+                Err(DriverError::AlreadyComplete)
+            );
+            assert_eq!(
+                session.request_completion("done"),
+                Err(DriverError::ContractMismatch)
+            );
+            // Exactly one Ready, one refusal diagnostic, tracker-replayable.
+            assert_eq!(
+                session
+                    .events()
+                    .iter()
+                    .filter(|e| matches!(e.payload(), RuntimeEventKind::Ready {}))
+                    .count(),
+                1
+            );
+            assert!(matches!(
+                session.run_summary().stopped,
+                Some(StopKind::TransportLost)
+            ));
+            replay_through_tracker(&session);
+        }
+    }
+
+    #[test]
+    fn malformed_thread_response_is_terminal_too() {
+        let mut session = session();
+        let mut transport = FixtureTransport::new(
+            vec![Ok(initialize_response()), Ok(serde_json::json!({}))],
+            vec![],
+            vec![],
+        );
+        let error = session
+            .begin_thread("/tmp/worktree", &mut transport)
+            .unwrap_err();
+        assert_eq!(error, DriverError::MalformedFrame);
+        assert_eq!(
+            session.begin_thread("/tmp/worktree", &mut transport),
+            Err(DriverError::AlreadyComplete)
+        );
+        replay_through_tracker(&session);
+    }
+
+    #[test]
     fn malformed_or_charset_violating_harness_ids_are_refused() {
         for bad_thread in [
             serde_json::json!({"thread": {"id": ""}}),
@@ -1503,7 +1615,7 @@ mod tests {
     #[test]
     fn notification_flood_is_bounded() {
         let mut session = session();
-        let flood: Vec<serde_json::Value> = (0..MAX_NOTIFICATIONS_PER_CALL * 16 + 1)
+        let flood: Vec<serde_json::Value> = (0..MAX_TURN_NOTIFICATION_FRAMES + 1)
             .map(|_| {
                 serde_json::json!({"method": "thread/status/changed",
                     "params": {"threadId": "thr-1", "status": "idle"}})
@@ -1515,7 +1627,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(error, DriverError::TransportFailed);
         // Event count stays bounded by the flood budget, not unbounded.
-        assert!(session.events().len() <= MAX_NOTIFICATIONS_PER_CALL * 16 + 8);
+        assert!(session.events().len() <= MAX_TURN_NOTIFICATION_FRAMES + 8);
     }
 
     #[test]

--- a/crates/symbiote-external-agent/src/lib.rs
+++ b/crates/symbiote-external-agent/src/lib.rs
@@ -546,16 +546,20 @@ impl ExternalSession {
                     // is invented. Recorded, never an approval.
                     ApprovalDecision::Unanswered
                 };
-                if decision != ApprovalDecision::Unanswered
-                    && let Err(error) = transport.refuse_server_request(&request, decision)
-                {
-                    self.stopped = Some(StopKind::TransportLost);
-                    self.record(RuntimeEventKind::Diagnostic {
-                        message: truncate_event_text(&format!(
-                            "refusal reply failed; run is terminal: {error}"
-                        )),
-                    })?;
-                    return Err(error);
+                if decision != ApprovalDecision::Unanswered {
+                    // Nested on purpose: let-chains are unstable on the
+                    // pinned MSRV (1.85) and clippy's collapse lint is
+                    // silenced here rather than relaxing it workspace-wide.
+                    #[allow(clippy::collapsible_if)]
+                    if let Err(error) = transport.refuse_server_request(&request, decision) {
+                        self.stopped = Some(StopKind::TransportLost);
+                        self.record(RuntimeEventKind::Diagnostic {
+                            message: truncate_event_text(&format!(
+                                "refusal reply failed; run is terminal: {error}"
+                            )),
+                        })?;
+                        return Err(error);
+                    }
                 }
                 // The harness escalated: it is alive and conversed with, so
                 // this interaction is not silence.

--- a/crates/symbiote-external-agent/src/lib.rs
+++ b/crates/symbiote-external-agent/src/lib.rs
@@ -34,6 +34,8 @@ use symbiote_runtime_sdk::events::{
     EventText, ObservationKind, RuntimeEvent, RuntimeEventKind, SessionBinding,
 };
 
+pub mod process;
+
 pub const EXTERNAL_LOOP_VERSION: u32 = 1;
 /// A single `call` may legally interleave this many notifications before its
 /// response; beyond it the harness is misbehaving. One observed turn may see
@@ -42,6 +44,10 @@ pub const EXTERNAL_LOOP_VERSION: u32 = 1;
 pub const MAX_NOTIFICATIONS_PER_CALL: usize = 64;
 /// How many notification reads one observed turn may span.
 pub const MAX_TURNS_NOTIFICATION_ROUNDS: usize = 16;
+/// Empty polls while waiting for harness frames. The production transport
+/// blocks on each poll, so this bounds a silent-but-alive harness (a long
+/// model turn) without falsely reporting a live run as lost.
+pub const MAX_EMPTY_NOTIFICATION_POLLS: usize = 4096;
 /// Notification text (agent messages, command output) is bounded by the SDK
 /// event contract; oversized text truncates on char boundaries with a marker.
 pub const MAX_EVENT_TEXT_BYTES: usize = symbiote_runtime_sdk::events::MAX_EVENT_TEXT_BYTES;
@@ -62,6 +68,10 @@ pub enum DriverError {
     MalformedFrame,
     /// A response correlated to a different request than the outstanding one.
     UnexpectedResponse,
+    /// The harness answered a request with a JSON-RPC error object.
+    RpcFailure,
+    /// The server did not report the pinned App Server version.
+    UnsupportedVersion,
     /// The harness answered the launch handshake with an unexpected state.
     ContractMismatch,
     /// Completion was already filed; the driver is finished.
@@ -75,34 +85,46 @@ impl std::fmt::Display for DriverError {
 }
 impl std::error::Error for DriverError {}
 
+/// One server-initiated request frame awaiting an answer. The `id` is kept
+/// verbatim (string or number) because the refusal response must echo it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerRequest {
+    pub id: serde_json::Value,
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
 /// The framed IPC boundary to the pinned App Server. Implementations translate
 /// a versionless request envelope into either a correlated response result or
 /// an error; notifications are surfaced separately. The production
-/// implementation wraps `JsonlTransport`; tests provide deterministic fixture
-/// servers.
+/// implementation wraps the sandboxed `JsonlTransport` process (see the
+/// `process` module); tests provide deterministic fixture servers.
 pub trait CodexTransport {
-    /// Send a request envelope (no `jsonrpc` field, string-or-number ids) and
-    /// return the matching response's `result` object. Interleaved server
-    /// notifications surface through [`Self::recv_notification`]; server
-    /// requests (approvals) surface through [`Self::recv_server_request`].
+    /// Send a request envelope (no `jsonrpc` field, number ids assigned by
+    /// the transport) and return the matching response's `result` object.
+    /// Interleaved server notifications and requests are buffered and
+    /// surfaced through [`Self::recv_notification`] and
+    /// [`Self::recv_server_request`].
     fn call(
         &mut self,
         method: &str,
         params: &serde_json::Value,
     ) -> Result<serde_json::Value, DriverError>;
-    /// Receive one server-initiated notification frame, or `None` at EOF.
+    /// Send a notification envelope (no id, no response expected).
+    fn notify(&mut self, method: &str, params: &serde_json::Value) -> Result<(), DriverError>;
+    /// Receive one server-initiated notification frame. `Ok(None)` means
+    /// nothing arrived within the transport's poll window — keep polling;
+    /// `Err` means the stream is closed or failed.
     fn recv_notification(&mut self) -> Result<Option<serde_json::Value>, DriverError>;
-    /// Receive one server-initiated request frame awaiting an answer, or
-    /// `None` when none is pending.
-    fn recv_server_request(&mut self) -> Result<Option<(String, serde_json::Value)>, DriverError>;
-    /// Refuse one pending server request. The refusal shape is per-method:
-    /// exec/patch/permissions requests take `decline`/`abort`, elicitation
-    /// takes `decline`, and a tool user-input question is answered with an
-    /// empty answer set. `Unanswered` refusals are never sent.
+    /// Receive one buffered server-initiated request frame, or `None` when
+    /// none is pending.
+    fn recv_server_request(&mut self) -> Result<Option<ServerRequest>, DriverError>;
+    /// Refuse one pending server request by echoing its id with a per-method
+    /// denial body from the pinned response schemas. `Unanswered` refusals
+    /// are never sent by the driver; implementations must not invent bodies.
     fn refuse_server_request(
         &mut self,
-        method: &str,
-        params: &serde_json::Value,
+        request: &ServerRequest,
         decision: ApprovalDecision,
     ) -> Result<(), DriverError>;
 }
@@ -123,11 +145,25 @@ pub enum ApprovalDecision {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ApprovalRefusal {
+    /// `execCommandApproval` — legacy exec approval; denied with `denied`.
     ExecCommand,
+    /// `applyPatchApproval` — legacy patch approval; denied with `denied`.
     ApplyPatch,
+    /// `item/commandExecution/requestApproval` — denied with `decline`.
+    CommandExecutionRequest,
+    /// `item/fileChange/requestApproval` — denied with `decline`.
+    FileChangeRequest,
+    /// `item/permissions/requestApproval` — denied with an empty granted
+    /// profile (grants nothing).
     PermissionsRequest,
-    ToolUserInput,
+    /// `mcpServer/elicitation/request` — declined with action `decline`.
     McpElicitation,
+    /// `item/tool/call` — a client-executed dynamic tool call; refused with
+    /// `success: false` and no content.
+    ToolCall,
+    /// `item/tool/requestUserInput` — no reply: the pinned answer shape must
+    /// match the question count, and inventing answers is worse than silence.
+    ToolUserInput,
     /// A server request method outside the pinned schema's known approvals.
     Unknown,
 }
@@ -137,11 +173,19 @@ impl ApprovalRefusal {
         match method {
             "execCommandApproval" => Self::ExecCommand,
             "applyPatchApproval" => Self::ApplyPatch,
+            "item/commandExecution/requestApproval" => Self::CommandExecutionRequest,
+            "item/fileChange/requestApproval" => Self::FileChangeRequest,
             "item/permissions/requestApproval" => Self::PermissionsRequest,
-            "item/tool/requestUserInput" => Self::ToolUserInput,
             "mcpServer/elicitation/request" => Self::McpElicitation,
+            "item/tool/call" => Self::ToolCall,
+            "item/tool/requestUserInput" => Self::ToolUserInput,
             _ => Self::Unknown,
         }
+    }
+    /// Whether the pinned response schemas give this refusal a well-defined
+    /// denial body the driver may send. Everything else stays unanswered.
+    fn has_shaped_denial(self) -> bool {
+        !matches!(self, Self::ToolUserInput | Self::Unknown)
     }
 }
 
@@ -293,10 +337,7 @@ impl ExternalSession {
     }
 
     /// Starts a harness thread bound to the task worktree and files the task
-    /// prompt as the first turn. `worktree` is the reserved worktree path the
-    /// Host authorized in the dispatch's root; the harness's sandbox policy is
-    /// pinned to read-only-plus-worktree here and can only be tightened, never
-    /// widened, by caller input.
+    /// prompt as the first turn: `begin_thread` + [`Self::turn`].
     pub fn start_turn(
         &mut self,
         task_prompt: &str,
@@ -309,11 +350,53 @@ impl ExternalSession {
         if task_prompt.trim().is_empty() || task_prompt.len() > 64 * 1024 {
             return Err(DriverError::InvalidInput);
         }
+        self.begin_thread(worktree, transport)?;
+        self.turn(task_prompt, transport)
+    }
+
+    /// Completes the pinned App Server handshake and starts the harness
+    /// thread bound to the task worktree. `worktree` is the reserved worktree
+    /// path the Host authorized in the dispatch's root; the harness's
+    /// internal sandbox policy is pinned to read-only and its approval
+    /// policy to never — the outer Host sandbox is the enforcement boundary.
+    /// No model turn starts here; the `codex_thread_smoke` proof stops after
+    /// this step.
+    pub fn begin_thread(
+        &mut self,
+        worktree: &str,
+        transport: &mut impl CodexTransport,
+    ) -> Result<(), DriverError> {
+        if self.completion_report.is_some() || self.stopped.is_some() {
+            return Err(DriverError::AlreadyComplete);
+        }
+        if self.harness_thread_id.is_some() {
+            return Err(DriverError::ContractMismatch);
+        }
         if worktree.is_empty() || worktree.len() > 4096 || !worktree.starts_with('/') {
             return Err(DriverError::InvalidInput);
         }
         // The SDK's session consumers require Ready before any other event.
         self.record(RuntimeEventKind::Ready {})?;
+        // Handshake first: initialize → pinned version check → initialized.
+        // The pin mirrors the #483 discovery probe exactly; a server that
+        // does not report the pinned version is refused before any thread,
+        // turn or account interaction happens.
+        let client_info = serde_json::json!({
+            "clientInfo": {"name": "symbiote", "version": "0.1.0", "title": "Symbiote"}
+        });
+        let initialized = transport.call("initialize", &client_info)?;
+        let user_agent = initialized
+            .get("userAgent")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(DriverError::MalformedFrame)?;
+        let expected = format!(
+            "symbiote/{}",
+            symbiote_runtime_discovery::codex::CODEX_VERSION
+        );
+        if user_agent.len() > 1024 || user_agent.split_whitespace().next() != Some(&expected) {
+            return Err(DriverError::UnsupportedVersion);
+        }
+        transport.notify("initialized", &serde_json::json!({}))?;
         // Thread identity is minted by the harness, not the driver. The
         // thread id is the correlation key for every later notification.
         let params = serde_json::json!({
@@ -332,7 +415,7 @@ impl ExternalSession {
             return Err(DriverError::MalformedFrame);
         }
         self.harness_thread_id = Some(thread_id);
-        self.turn(task_prompt, transport)
+        Ok(())
     }
 
     /// Files one turn and observes it to completion. All harness escalation
@@ -391,47 +474,73 @@ impl ExternalSession {
         transport: &mut impl CodexTransport,
     ) -> Result<(), DriverError> {
         let mut stop: Option<StopKind> = None;
-        let mut seen = 0usize;
+        let mut frames = 0usize;
+        let mut empty_polls = 0usize;
         while stop.is_none() {
-            seen += 1;
-            if seen > MAX_NOTIFICATIONS_PER_CALL * MAX_TURNS_NOTIFICATION_ROUNDS {
+            let notification = match transport.recv_notification() {
+                Ok(Some(notification)) => {
+                    empty_polls = 0;
+                    Some(notification)
+                }
+                Ok(None) => {
+                    // Nothing arrived within the poll window. A live harness
+                    // may think for a long time; only a bounded number of
+                    // silent polls reads as a lost transport.
+                    empty_polls += 1;
+                    if empty_polls > MAX_EMPTY_NOTIFICATION_POLLS {
+                        self.stopped = Some(StopKind::TransportLost);
+                        self.record(RuntimeEventKind::Diagnostic {
+                            message: truncate_event_text("harness silent beyond the poll budget"),
+                        })?;
+                        return Err(DriverError::TransportFailed);
+                    }
+                    None
+                }
+                Err(error) => {
+                    self.stopped = Some(StopKind::TransportLost);
+                    self.record(RuntimeEventKind::Diagnostic {
+                        message: truncate_event_text(&format!(
+                            "harness closed before turn completion: {error}"
+                        )),
+                    })?;
+                    return Err(error);
+                }
+            };
+            // Server requests surface through the same frame pump as
+            // notifications: drain everything that read surfaced before
+            // processing the notification itself, so a harness blocked on a
+            // pending approval is answered first.
+            while let Some(request) = transport.recv_server_request()? {
+                let refusal = ApprovalRefusal::from_method(&request.method);
+                self.approvals_refused += 1;
+                let decision = if refusal.has_shaped_denial() {
+                    ApprovalDecision::Denied
+                } else {
+                    // No pinned denial body exists for this shape; no reply
+                    // is invented. Recorded, never an approval.
+                    ApprovalDecision::Unanswered
+                };
+                if decision != ApprovalDecision::Unanswered {
+                    transport.refuse_server_request(&request, decision)?;
+                }
+                self.record(RuntimeEventKind::Diagnostic {
+                    message: truncate_event_text(&format!(
+                        "refused harness approval request: {:?} ({refusal:?}, {decision:?})",
+                        request.method
+                    )),
+                })?;
+            }
+            let Some(notification) = notification else {
+                continue;
+            };
+            frames += 1;
+            if frames > MAX_NOTIFICATIONS_PER_CALL * MAX_TURNS_NOTIFICATION_ROUNDS {
                 self.stopped = Some(StopKind::TransportLost);
                 self.record(RuntimeEventKind::Diagnostic {
                     message: truncate_event_text("notification budget exceeded"),
                 })?;
                 return Err(DriverError::TransportFailed);
             }
-            // Server requests are answered first: the pinned harness blocks a
-            // pending approval request while streaming notifications.
-            while let Some((method, params)) = transport.recv_server_request()? {
-                let refusal = ApprovalRefusal::from_method(&method);
-                self.approvals_refused += 1;
-                let decision = match refusal {
-                    // Known approval shapes get a shaped refusal the harness
-                    // understands; unknown methods get no reply at all, so no
-                    // unclaimed refusal body is invented for them.
-                    ApprovalRefusal::Unknown => ApprovalDecision::Unanswered,
-                    _ => ApprovalDecision::Denied,
-                };
-                if decision != ApprovalDecision::Unanswered {
-                    transport.refuse_server_request(&method, &params, decision)?;
-                }
-                self.record(RuntimeEventKind::Diagnostic {
-                    message: truncate_event_text(&format!(
-                        "refused harness approval request: {method:?} ({refusal:?}, {decision:?})"
-                    )),
-                })?;
-            }
-            let notification = match transport.recv_notification()? {
-                Some(notification) => notification,
-                None => {
-                    self.stopped = Some(StopKind::TransportLost);
-                    self.record(RuntimeEventKind::Diagnostic {
-                        message: truncate_event_text("harness closed before turn completion"),
-                    })?;
-                    return Err(DriverError::TransportFailed);
-                }
-            };
             let method = notification
                 .get("method")
                 .and_then(serde_json::Value::as_str)
@@ -691,23 +800,26 @@ mod tests {
     use std::collections::{BTreeSet, VecDeque};
 
     /// Deterministic offline fixture server: scripted frames consumed in
-    /// order. Refusal answers are recorded for assertions. Not a mock of
-    /// verification — the driver's real logic runs against it.
+    /// order. Calls, notifications and refusals are recorded for assertions.
+    /// Not a mock of verification — the driver's real logic runs against it.
     struct FixtureTransport {
         /// Response frames for `call`, keyed by arrival order.
         responses: Vec<Result<serde_json::Value, DriverError>>,
-        /// Frames surfaced by `recv_notification` (None = EOF).
+        /// Frames surfaced by `recv_notification` (None = end of script; the
+        /// driver treats prolonged silence as a lost transport).
         notifications: VecDeque<Option<serde_json::Value>>,
         /// Server requests awaiting refusal, surfaced by `recv_server_request`.
-        server_requests: VecDeque<(String, serde_json::Value)>,
+        server_requests: VecDeque<ServerRequest>,
         refusals: Vec<(String, ApprovalDecision)>,
+        /// (kind, method) of everything sent, in order.
+        sent: Vec<(&'static str, String)>,
         cursor: usize,
     }
     impl FixtureTransport {
         fn new(
             responses: Vec<Result<serde_json::Value, DriverError>>,
             notifications: Vec<serde_json::Value>,
-            server_requests: Vec<(String, serde_json::Value)>,
+            server_requests: Vec<ServerRequest>,
         ) -> Self {
             Self {
                 responses,
@@ -718,6 +830,7 @@ mod tests {
                     .collect(),
                 server_requests: server_requests.into(),
                 refusals: Vec::new(),
+                sent: Vec::new(),
                 cursor: 0,
             }
         }
@@ -725,9 +838,10 @@ mod tests {
     impl CodexTransport for FixtureTransport {
         fn call(
             &mut self,
-            _method: &str,
+            method: &str,
             _params: &serde_json::Value,
         ) -> Result<serde_json::Value, DriverError> {
+            self.sent.push(("request", method.to_owned()));
             let index = self.cursor;
             self.cursor += 1;
             self.responses
@@ -735,25 +849,44 @@ mod tests {
                 .cloned()
                 .unwrap_or(Err(DriverError::TransportFailed))
         }
+        fn notify(&mut self, method: &str, _params: &serde_json::Value) -> Result<(), DriverError> {
+            self.sent.push(("notification", method.to_owned()));
+            Ok(())
+        }
         fn recv_notification(&mut self) -> Result<Option<serde_json::Value>, DriverError> {
             Ok(self.notifications.pop_front().flatten())
         }
-        fn recv_server_request(
-            &mut self,
-        ) -> Result<Option<(String, serde_json::Value)>, DriverError> {
+        fn recv_server_request(&mut self) -> Result<Option<ServerRequest>, DriverError> {
             Ok(self.server_requests.pop_front())
         }
         fn refuse_server_request(
             &mut self,
-            method: &str,
-            _params: &serde_json::Value,
+            request: &ServerRequest,
             decision: ApprovalDecision,
         ) -> Result<(), DriverError> {
-            self.refusals.push((method.to_owned(), decision));
+            self.refusals.push((request.method.clone(), decision));
             Ok(())
         }
     }
 
+    fn server_request(
+        id: impl Into<serde_json::Value>,
+        method: &str,
+        params: serde_json::Value,
+    ) -> ServerRequest {
+        ServerRequest {
+            id: id.into(),
+            method: method.to_owned(),
+            params,
+        }
+    }
+
+    fn initialize_response() -> serde_json::Value {
+        serde_json::json!({"userAgent": format!(
+            "symbiote/{} (Linux)",
+            symbiote_runtime_discovery::codex::CODEX_VERSION
+        )})
+    }
     fn thread_start_response() -> serde_json::Value {
         serde_json::json!({"thread": {"id": "thr-1"}})
     }
@@ -898,7 +1031,11 @@ mod tests {
 
     fn transport_with(notifications: Vec<serde_json::Value>) -> FixtureTransport {
         FixtureTransport::new(
-            vec![Ok(thread_start_response()), Ok(turn_start_response())],
+            vec![
+                Ok(initialize_response()),
+                Ok(thread_start_response()),
+                Ok(turn_start_response()),
+            ],
             notifications,
             vec![],
         )
@@ -1149,30 +1286,39 @@ mod tests {
     fn every_approval_request_is_refused_and_counted() {
         let mut session = session();
         let mut transport = FixtureTransport::new(
-            vec![Ok(thread_start_response()), Ok(turn_start_response())],
+            vec![
+                Ok(initialize_response()),
+                Ok(thread_start_response()),
+                Ok(turn_start_response()),
+            ],
             vec![turn_completed("completed")],
             vec![
-                (
-                    "execCommandApproval".to_string(),
+                server_request(
+                    1,
+                    "execCommandApproval",
                     serde_json::json!({"callId": "c1", "conversationId": "thr-1",
                         "command": ["rm", "-rf"], "cwd": "/tmp/worktree", "parsedCmd": []}),
                 ),
-                (
-                    "applyPatchApproval".to_string(),
+                server_request(
+                    2,
+                    "applyPatchApproval",
                     serde_json::json!({"callId": "c2", "conversationId": "thr-1",
                         "fileChanges": {}}),
                 ),
-                (
-                    "item/permissions/requestApproval".to_string(),
+                server_request(
+                    "srv-3",
+                    "item/permissions/requestApproval",
                     serde_json::json!({"itemId": "i1", "threadId": "thr-1",
                         "turnId": "turn-1", "permissions": {}}),
                 ),
-                (
-                    "mcpServer/elicitation/request".to_string(),
+                server_request(
+                    "srv-4",
+                    "mcpServer/elicitation/request",
                     serde_json::json!({"serverName": "srv", "threadId": "thr-1"}),
                 ),
-                (
-                    "item/tool/requestUserInput".to_string(),
+                server_request(
+                    "srv-5",
+                    "item/tool/requestUserInput",
                     serde_json::json!({"itemId": "i2", "threadId": "thr-1",
                         "turnId": "turn-1", "questions": []}),
                 ),
@@ -1181,12 +1327,20 @@ mod tests {
         session
             .start_turn("fix the bug", "/tmp/worktree", &mut transport)
             .unwrap();
-        assert_eq!(transport.refusals.len(), 5);
+        // Four known shapes get a pinned denial reply; the user-input
+        // question gets none (no invented answers).
+        assert_eq!(transport.refusals.len(), 4);
         assert!(
             transport
                 .refusals
                 .iter()
                 .all(|(_, decision)| *decision == ApprovalDecision::Denied)
+        );
+        assert!(
+            !transport
+                .refusals
+                .iter()
+                .any(|(method, _)| method == "item/tool/requestUserInput")
         );
         let run = session.run_summary();
         assert_eq!(run.approvals_refused, 5);
@@ -1221,10 +1375,15 @@ mod tests {
     fn unknown_server_request_is_counted_but_never_answered() {
         let mut session = session();
         let mut transport = FixtureTransport::new(
-            vec![Ok(thread_start_response()), Ok(turn_start_response())],
+            vec![
+                Ok(initialize_response()),
+                Ok(thread_start_response()),
+                Ok(turn_start_response()),
+            ],
             vec![turn_completed("completed")],
-            vec![(
-                "account/chatgptAuthTokens/refresh".to_string(),
+            vec![server_request(
+                "srv-7",
+                "account/chatgptAuthTokens/refresh",
                 serde_json::json!({"reason": "test"}),
             )],
         );
@@ -1265,6 +1424,80 @@ mod tests {
         assert_eq!(run.stopped, Some(StopKind::TransportLost));
         // A lost transport never reads as a normal stop.
         assert_ne!(run.stopped, Some(StopKind::Completed));
+        // The silence budget fired, not a fabricated completion.
+        assert!(session.events().iter().any(
+            |e| matches!(e.payload(), RuntimeEventKind::Diagnostic { message }
+                    if message.as_str().contains("harness silent beyond the poll budget"))
+        ));
+        assert!(
+            !session
+                .events()
+                .iter()
+                .any(|e| matches!(e.payload(), RuntimeEventKind::Exit { .. }))
+        );
+    }
+
+    #[test]
+    fn driver_and_transport_work_end_to_end_over_a_real_subprocess() {
+        // The full driver against the real framed transport on a real
+        // process (pipes, EOF, deadlines) — scripted frames, no codex
+        // binary, no network, no credentials.
+        let mut session = session();
+        let mut transport = process::spawn_test_server(
+            "printf '%s\\n' \
+             '{\"id\":1,\"result\":{\"userAgent\":\"symbiote/0.118.0 (Linux)\"}}' \
+             '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thr-1\"}}}' \
+             '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}' \
+             '{\"method\":\"item/completed\",\"params\":{\"threadId\":\"thr-1\",\"turnId\":\"turn-1\",\"item\":{\"type\":\"agentMessage\",\"id\":\"i1\",\"text\":\"done\"}}}' \
+             '{\"method\":\"thread/tokenUsage/updated\",\"params\":{\"threadId\":\"thr-1\",\"turnId\":\"turn-1\",\"tokenUsage\":{\"last\":{},\"total\":{\"inputTokens\":11,\"outputTokens\":5,\"cachedInputTokens\":0,\"reasoningOutputTokens\":0,\"totalTokens\":16}}}}' \
+             '{\"method\":\"turn/completed\",\"params\":{\"threadId\":\"thr-1\",\"turnId\":\"turn-1\",\"turn\":{\"id\":\"turn-1\",\"status\":\"completed\",\"items\":[]}}}'; sleep 30",
+        );
+        session
+            .start_turn("fix the bug", "/tmp/worktree", &mut transport)
+            .unwrap();
+        let kinds: Vec<_> = session.events().iter().map(|e| e.payload()).collect();
+        assert!(matches!(kinds[0], RuntimeEventKind::Ready {}));
+        assert!(matches!(kinds[1], RuntimeEventKind::Message { .. }));
+        assert!(matches!(kinds[2], RuntimeEventKind::Usage { .. }));
+        assert!(matches!(kinds[3], RuntimeEventKind::Exit { code: Some(0) }));
+        let run = session.run_summary();
+        assert_eq!(run.stopped, Some(StopKind::Completed));
+        assert_eq!(run.usage_turns, 1);
+        replay_through_tracker(&session);
+    }
+
+    #[test]
+    fn silent_harness_never_reads_as_completion_or_hangs() {
+        // A harness that starts a turn and then goes quiet: the driver's
+        // poll budget must convert sustained silence into an explicit lost
+        // transport instead of spinning forever or inventing an outcome.
+        let mut session = session();
+        let mut transport = process::spawn_test_server(
+            "printf '%s\\n' \
+             '{\"id\":1,\"result\":{\"userAgent\":\"symbiote/0.118.0 (Linux)\"}}' \
+             '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thr-1\"}}}' \
+             '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'; sleep 1",
+        );
+        let error = session
+            .start_turn("fix the bug", "/tmp/worktree", &mut transport)
+            .unwrap_err();
+        assert_eq!(error, DriverError::TransportFailed);
+        assert_eq!(session.run_summary().stopped, Some(StopKind::TransportLost));
+        // The run recorded a transport diagnostic and never an Exit: silence
+        // produces no fabricated completion either way.
+        assert!(
+            session
+                .events()
+                .iter()
+                .any(|e| matches!(e.payload(), RuntimeEventKind::Diagnostic { .. }))
+        );
+        assert!(
+            !session
+                .events()
+                .iter()
+                .any(|e| matches!(e.payload(), RuntimeEventKind::Exit { .. }))
+        );
+        replay_through_tracker(&session);
     }
 
     #[test]

--- a/crates/symbiote-external-agent/src/process.rs
+++ b/crates/symbiote-external-agent/src/process.rs
@@ -141,6 +141,15 @@ fn classify(frame: Value) -> Result<Inbound, DriverError> {
             if id.is_null() {
                 return Err(DriverError::MalformedFrame);
             }
+            // A response carries exactly id + result xor id + error; any
+            // other key makes the frame out-of-shape even if the key is
+            // individually known to the protocol.
+            if object
+                .keys()
+                .any(|k| k != "id" && k != "result" && k != "error")
+            {
+                return Err(DriverError::MalformedFrame);
+            }
             match (object.get("result"), object.get("error")) {
                 (Some(result), None) => Ok(Inbound::Response {
                     id: id.clone(),
@@ -239,12 +248,14 @@ impl<T: FrameIo> CodexServerProcess<T> {
             .checked_add(self.frame_timeout)
             .ok_or(DriverError::TransportFailed)?;
         loop {
-            let remaining = deadline
+            let Some(remaining) = deadline
                 .checked_duration_since(std::time::Instant::now())
-                .ok_or(DriverError::TransportFailed)?;
-            if remaining.is_zero() {
+                .filter(|d| !d.is_zero())
+            else {
+                // Poll window over. Buffered frames surface through the
+                // queue on the next call; this is not a transport failure.
                 return Ok(None);
-            }
+            };
             match self.io.recv_frame(remaining)? {
                 Some(frame) => match classify(frame)? {
                     Inbound::Notification(notification) => return Ok(Some(notification)),
@@ -593,36 +604,5 @@ mod tests {
                 other => panic!("unexpected poll result: {other:?}"),
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod probe_timing {
-    use super::*;
-    use crate::CodexTransport;
-
-    #[test]
-    fn probe_zz_step_timing() {
-        let mut server = spawn_test_server(
-            "printf '%s\\n' \
-             '{\"id\":1,\"result\":{\"userAgent\":\"symbiote/0.118.0 (Linux)\"}}' \
-             '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thr-1\"}}}' \
-             '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'; sleep 30",
-        );
-        let t0 = std::time::Instant::now();
-        let r = server.call("initialize", &json!({}));
-        eprintln!("initialize: {:?} at {:?}", r.is_ok(), t0.elapsed());
-        let r = server.notify("initialized", &json!({}));
-        eprintln!("notify: {:?} at {:?}", r.is_ok(), t0.elapsed());
-        let r = server.call("thread/start", &json!({}));
-        eprintln!("thread/start: {:?} at {:?}", r.is_ok(), t0.elapsed());
-        let r = server.call("turn/start", &json!({}));
-        eprintln!("turn/start: {:?} at {:?}", r.is_ok(), t0.elapsed());
-        let r = server.recv_notification();
-        eprintln!(
-            "first notification poll: {:?} at {:?}",
-            r.is_ok(),
-            t0.elapsed()
-        );
     }
 }

--- a/crates/symbiote-external-agent/src/process.rs
+++ b/crates/symbiote-external-agent/src/process.rs
@@ -1,0 +1,628 @@
+//! The production transport for the pinned Codex App Server: versionless
+//! JSONL framing over a sandboxed process. The framing logic lives in
+//! [`CodexServerProcess`], generic over [`FrameIo`] so unit tests can drive
+//! it against a real subprocess through the shared `JsonlTransport` without
+//! bubblewrap, while the composed launcher ([`launch_sandboxed`]) runs the
+//! pinned binary inside the Host sandbox with a disposable HOME, no network
+//! and a read-only or worktree-writable reserved worktree (#211/#218).
+//!
+//! The transport owns exactly the wire facts: request-id assignment, frame
+//! classification (response / notification / server request), bounded
+//! buffering, strict envelope shapes, and the per-method denial bodies from
+//! the pinned response schemas. It grants nothing: there is no code path
+//! that sends an approval, an account operation or a credential.
+#[cfg(test)]
+use crate::CodexTransport;
+use crate::{ApprovalDecision, DriverError, ServerRequest};
+use serde_json::{Value, json};
+use std::collections::VecDeque;
+use std::path::Path;
+use std::time::Duration;
+use symbiote_domain::{HostId, RootId, Timestamp};
+use symbiote_runtime_transport::{TransportError, TransportLimits};
+
+/// Frames are bounded and duplicate-key-rejected by the shared transport.
+const MAX_BUFFERED_NOTIFICATIONS: usize = 1024;
+const MAX_BUFFERED_SERVER_REQUESTS: usize = 256;
+const MAX_METHOD_BYTES: usize = 256;
+const DEFAULT_FRAME_TIMEOUT: Duration = Duration::from_millis(250);
+/// How long `call` waits for its correlated response before failing.
+const DEFAULT_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The raw framed IO both transports provide: send one JSON value, receive
+/// one JSON value or `None` when nothing arrives within the timeout. `Err`
+/// means the stream is closed or failed (process exit, broken pipe, EOF).
+pub trait FrameIo {
+    fn send_frame(&mut self, frame: &Value, timeout: Duration) -> Result<(), DriverError>;
+    fn recv_frame(&mut self, timeout: Duration) -> Result<Option<Value>, DriverError>;
+}
+
+impl FrameIo for symbiote_sandbox::SandboxProcess {
+    fn send_frame(&mut self, frame: &Value, timeout: Duration) -> Result<(), DriverError> {
+        self.send(frame, timeout)
+            .map_err(|_| DriverError::TransportFailed)
+    }
+    fn recv_frame(&mut self, timeout: Duration) -> Result<Option<Value>, DriverError> {
+        match self.recv(timeout) {
+            Ok(frame) => Ok(Some(frame)),
+            Err(symbiote_sandbox::SandboxError::Transport(TransportError::DeadlineExceeded)) => {
+                Ok(None)
+            }
+            Err(_) => Err(DriverError::TransportFailed),
+        }
+    }
+}
+
+impl FrameIo for symbiote_runtime_transport::JsonlTransport {
+    fn send_frame(&mut self, frame: &Value, timeout: Duration) -> Result<(), DriverError> {
+        self.send(frame, timeout)
+            .map_err(|_| DriverError::TransportFailed)
+    }
+    fn recv_frame(&mut self, timeout: Duration) -> Result<Option<Value>, DriverError> {
+        match self.recv(timeout) {
+            Ok(frame) => Ok(Some(frame)),
+            Err(TransportError::DeadlineExceeded) => Ok(None),
+            Err(_) => Err(DriverError::TransportFailed),
+        }
+    }
+}
+
+/// The request envelope the transport sends. Versionless on purpose: the
+/// pinned App Server rejects `jsonrpc`-carrying envelopes, and #483's probe
+/// proved this exact shape against the installed binary.
+pub fn request_envelope(id: u64, method: &str, params: &Value) -> Value {
+    json!({"id": id, "method": method, "params": params})
+}
+
+pub fn notification_envelope(method: &str, params: &Value) -> Value {
+    json!({"method": method, "params": params})
+}
+
+/// Classifies one inbound frame. Mirrors the pinned protocol's three frame
+/// kinds; anything else is refused rather than guessed.
+enum Inbound {
+    Response {
+        id: Value,
+        result: Option<Value>,
+        error: bool,
+    },
+    Notification(Value),
+    ServerRequest(ServerRequest),
+}
+
+fn classify(frame: Value) -> Result<Inbound, DriverError> {
+    let Some(object) = frame.as_object() else {
+        return Err(DriverError::MalformedFrame);
+    };
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "id" | "method" | "params" | "result" | "error"
+        ) {
+            return Err(DriverError::MalformedFrame);
+        }
+    }
+    match (object.get("method"), object.get("id")) {
+        (Some(method), None) => {
+            let method = method.as_str().ok_or(DriverError::MalformedFrame)?;
+            if method.is_empty() || method.len() > MAX_METHOD_BYTES {
+                return Err(DriverError::MalformedFrame);
+            }
+            if object.keys().any(|k| k != "method" && k != "params") {
+                return Err(DriverError::MalformedFrame);
+            }
+            Ok(Inbound::Notification(json!({
+                "method": method,
+                "params": object.get("params").cloned().unwrap_or_else(|| json!({})),
+            })))
+        }
+        (Some(method), Some(id)) => {
+            let method = method.as_str().ok_or(DriverError::MalformedFrame)?;
+            if method.is_empty() || method.len() > MAX_METHOD_BYTES {
+                return Err(DriverError::MalformedFrame);
+            }
+            if object
+                .keys()
+                .any(|k| k != "method" && k != "params" && k != "id")
+            {
+                return Err(DriverError::MalformedFrame);
+            }
+            // Ids are echoed verbatim (string or number); null is not an id.
+            if id.is_null() {
+                return Err(DriverError::MalformedFrame);
+            }
+            Ok(Inbound::ServerRequest(ServerRequest {
+                id: id.clone(),
+                method: method.to_owned(),
+                params: object.get("params").cloned().unwrap_or_else(|| json!({})),
+            }))
+        }
+        (None, Some(id)) => {
+            if id.is_null() {
+                return Err(DriverError::MalformedFrame);
+            }
+            match (object.get("result"), object.get("error")) {
+                (Some(result), None) => Ok(Inbound::Response {
+                    id: id.clone(),
+                    result: Some(result.clone()),
+                    error: false,
+                }),
+                (None, Some(_)) => Ok(Inbound::Response {
+                    id: id.clone(),
+                    result: None,
+                    error: true,
+                }),
+                _ => Err(DriverError::MalformedFrame),
+            }
+        }
+        (None, None) => Err(DriverError::MalformedFrame),
+    }
+}
+
+/// The per-method denial body from the pinned response schemas. `None` means
+/// the pinned protocol defines no safe denial for this method and the driver
+/// leaves it unanswered. Every body here is a refusal: no variant grants.
+pub fn denial_body(method: &str) -> Option<Value> {
+    let body = match method {
+        // Legacy approvals answer with ReviewDecision "denied".
+        "execCommandApproval" | "applyPatchApproval" => json!({"decision": "denied"}),
+        // Current command/file approvals answer with "decline".
+        "item/commandExecution/requestApproval" | "item/fileChange/requestApproval" => {
+            json!({"decision": "decline"})
+        }
+        // An empty granted profile grants nothing.
+        "item/permissions/requestApproval" => json!({"permissions": {}, "scope": "turn"}),
+        // Elicitation is declined.
+        "mcpServer/elicitation/request" => json!({"action": "decline"}),
+        // A client-executed dynamic tool call is refused with failure.
+        "item/tool/call" => json!({"success": false, "contentItems": []}),
+        _ => return None,
+    };
+    Some(body)
+}
+
+/// The framed App Server process. One outstanding client request at a time;
+/// notifications and server requests that interleave a `call` are buffered
+/// (bounded) and surfaced in arrival order.
+pub struct CodexServerProcess<T: FrameIo> {
+    io: T,
+    notifications: VecDeque<Value>,
+    server_requests: VecDeque<ServerRequest>,
+    next_request_id: u64,
+    frame_timeout: Duration,
+    call_timeout: Duration,
+}
+
+impl<T: FrameIo> CodexServerProcess<T> {
+    pub fn new(io: T) -> Self {
+        Self {
+            io,
+            notifications: VecDeque::new(),
+            server_requests: VecDeque::new(),
+            next_request_id: 1,
+            frame_timeout: DEFAULT_FRAME_TIMEOUT,
+            call_timeout: DEFAULT_CALL_TIMEOUT,
+        }
+    }
+
+    pub fn io(&mut self) -> &mut T {
+        &mut self.io
+    }
+
+    /// Buffers one non-response inbound frame. A response outside an
+    /// outstanding `call` is a protocol violation, never buffered.
+    fn buffer(&mut self, inbound: Inbound) -> Result<(), DriverError> {
+        match inbound {
+            Inbound::Notification(notification) => {
+                if self.notifications.len() >= MAX_BUFFERED_NOTIFICATIONS {
+                    return Err(DriverError::MalformedFrame);
+                }
+                self.notifications.push_back(notification);
+                Ok(())
+            }
+            Inbound::ServerRequest(request) => {
+                if self.server_requests.len() >= MAX_BUFFERED_SERVER_REQUESTS {
+                    return Err(DriverError::MalformedFrame);
+                }
+                self.server_requests.push_back(request);
+                Ok(())
+            }
+            Inbound::Response { .. } => Err(DriverError::UnexpectedResponse),
+        }
+    }
+
+    fn recv_until_notification(&mut self) -> Result<Option<Value>, DriverError> {
+        if let Some(notification) = self.notifications.pop_front() {
+            return Ok(Some(notification));
+        }
+        let deadline = std::time::Instant::now()
+            .checked_add(self.frame_timeout)
+            .ok_or(DriverError::TransportFailed)?;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .ok_or(DriverError::TransportFailed)?;
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            match self.io.recv_frame(remaining)? {
+                Some(frame) => match classify(frame)? {
+                    Inbound::Notification(notification) => return Ok(Some(notification)),
+                    other => self.buffer(other)?,
+                },
+                None => return Ok(None),
+            }
+        }
+    }
+}
+
+/// The full refusal response envelope: the server request's id echoed
+/// verbatim with the per-method denial body. `None` when the pinned schemas
+/// define no safe denial body for the method (the driver leaves it
+/// unanswered and never calls the transport for it).
+pub fn refusal_envelope(request: &ServerRequest) -> Option<Value> {
+    denial_body(&request.method).map(|body| json!({"id": request.id, "result": body}))
+}
+
+impl<T: FrameIo> crate::CodexTransport for CodexServerProcess<T> {
+    fn call(&mut self, method: &str, params: &Value) -> Result<Value, DriverError> {
+        if method.is_empty() || method.len() > MAX_METHOD_BYTES {
+            return Err(DriverError::InvalidInput);
+        }
+        let id = self.next_request_id;
+        if id == u64::MAX {
+            return Err(DriverError::TransportFailed);
+        }
+        self.next_request_id += 1;
+        self.io
+            .send_frame(&request_envelope(id, method, params), self.call_timeout)?;
+        let deadline = std::time::Instant::now()
+            .checked_add(self.call_timeout)
+            .ok_or(DriverError::TransportFailed)?;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(std::time::Instant::now())
+                .ok_or(DriverError::TransportFailed)?;
+            let frame = self
+                .io
+                .recv_frame(remaining)?
+                .ok_or(DriverError::TransportFailed)?;
+            match classify(frame)? {
+                Inbound::Response {
+                    id: frame_id,
+                    result,
+                    error,
+                } => {
+                    if frame_id.as_u64() != Some(id) {
+                        return Err(DriverError::UnexpectedResponse);
+                    }
+                    if error {
+                        return Err(DriverError::RpcFailure);
+                    }
+                    return result.ok_or(DriverError::MalformedFrame);
+                }
+                other => {
+                    self.buffer(other)?;
+                }
+            }
+        }
+    }
+
+    fn notify(&mut self, method: &str, params: &Value) -> Result<(), DriverError> {
+        if method.is_empty() || method.len() > MAX_METHOD_BYTES {
+            return Err(DriverError::InvalidInput);
+        }
+        self.io
+            .send_frame(&notification_envelope(method, params), self.call_timeout)
+    }
+
+    fn recv_notification(&mut self) -> Result<Option<Value>, DriverError> {
+        self.recv_until_notification()
+    }
+
+    fn recv_server_request(&mut self) -> Result<Option<ServerRequest>, DriverError> {
+        Ok(self.server_requests.pop_front())
+    }
+
+    fn refuse_server_request(
+        &mut self,
+        request: &ServerRequest,
+        decision: ApprovalDecision,
+    ) -> Result<(), DriverError> {
+        // The only decision the driver may send: a per-method denial.
+        // Aborted and Unanswered are recorded by the driver; the transport
+        // sends nothing for them and must not be asked to.
+        if decision != ApprovalDecision::Denied {
+            return Err(DriverError::InvalidInput);
+        }
+        let envelope = refusal_envelope(request).ok_or(DriverError::InvalidInput)?;
+        self.io.send_frame(&envelope, self.call_timeout)
+    }
+}
+
+/// The command fingerprint for the pinned launch, matching the arguments
+/// [`launch_sandboxed`] uses. The caller must build their `ResourceSnapshot`
+/// (and the consent embedding it) with this fingerprint — the sandbox
+/// recomputes and compares it and refuses on any mismatch.
+pub fn codex_launch_fingerprint(
+    root_id: &RootId,
+    worktree: &Path,
+    profile: symbiote_sandbox::Profile,
+) -> Result<symbiote_trust::Fingerprint, DriverError> {
+    symbiote_sandbox::fingerprint_command(
+        root_id,
+        worktree,
+        profile,
+        "/usr/bin/codex",
+        &[
+            "app-server".to_owned(),
+            "--listen".to_owned(),
+            "stdio://".to_owned(),
+        ],
+    )
+    .map_err(|_| DriverError::InvalidContract)
+}
+
+/// Composed launch of the pinned binary inside the Host sandbox. The
+/// arguments and premises mirror the #483 discovery proof exactly: trusted
+/// helper, consented snapshot whose fingerprint covers the codex invocation,
+/// `/usr/bin/codex app-server --listen stdio://`, disposable HOME, isolated
+/// network. The caller supplies the reserved worktree; no credential
+/// directory is ever mounted.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_sandboxed(
+    helper_path: &Path,
+    consent: &symbiote_trust::ResourceConsent,
+    policy: &symbiote_domain::AccessSnapshot,
+    host: &HostId,
+    at: Timestamp,
+    root_id: &RootId,
+    worktree: &Path,
+    protected_paths: &[std::path::PathBuf],
+    profile: symbiote_sandbox::Profile,
+    limits: TransportLimits,
+) -> Result<CodexServerProcess<symbiote_sandbox::SandboxProcess>, DriverError> {
+    let process = symbiote_sandbox::launch(symbiote_sandbox::LaunchRequest {
+        helper_path,
+        consent,
+        snapshot: &consent.snapshot,
+        policy,
+        host,
+        at,
+        root_id,
+        worktree,
+        protected_paths,
+        profile,
+        program: "/usr/bin/codex",
+        args: &[
+            "app-server".to_owned(),
+            "--listen".to_owned(),
+            "stdio://".to_owned(),
+        ],
+        limits,
+    })
+    .map_err(|_| DriverError::TransportFailed)?;
+    Ok(CodexServerProcess::new(process))
+}
+
+/// Spawns an arbitrary process for transport framing tests: real subprocess,
+/// real pipes, no sandbox claims. Not a harness integration.
+#[cfg(test)]
+pub(crate) fn spawn_test_server(
+    script: &str,
+) -> CodexServerProcess<symbiote_runtime_transport::JsonlTransport> {
+    use std::collections::BTreeMap;
+    use symbiote_runtime_transport::SpawnSpec;
+    let transport = symbiote_runtime_transport::JsonlTransport::spawn(
+        SpawnSpec {
+            executable: "/usr/bin/sh".into(),
+            args: vec!["-c".into(), script.into()],
+            cwd: std::env::temp_dir(),
+            env: BTreeMap::new(),
+        },
+        TransportLimits::default(),
+    )
+    .expect("test server spawns");
+    CodexServerProcess::new(transport)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelopes_are_versionless_with_no_jsonrpc_field() {
+        let request = request_envelope(7, "thread/start", &json!({"cwd": "/w"}));
+        assert_eq!(
+            request,
+            json!({"id": 7, "method": "thread/start", "params": {"cwd": "/w"}})
+        );
+        assert!(request.get("jsonrpc").is_none());
+        let notification = notification_envelope("initialized", &json!({}));
+        assert_eq!(notification, json!({"method": "initialized", "params": {}}));
+        assert!(notification.get("id").is_none());
+        assert!(notification.get("jsonrpc").is_none());
+    }
+
+    #[test]
+    fn denial_bodies_match_the_pinned_response_schemas() {
+        assert_eq!(
+            denial_body("execCommandApproval"),
+            Some(json!({"decision": "denied"}))
+        );
+        assert_eq!(
+            denial_body("applyPatchApproval"),
+            Some(json!({"decision": "denied"}))
+        );
+        assert_eq!(
+            denial_body("item/commandExecution/requestApproval"),
+            Some(json!({"decision": "decline"}))
+        );
+        assert_eq!(
+            denial_body("item/fileChange/requestApproval"),
+            Some(json!({"decision": "decline"}))
+        );
+        assert_eq!(
+            denial_body("item/permissions/requestApproval"),
+            Some(json!({"permissions": {}, "scope": "turn"}))
+        );
+        assert_eq!(
+            denial_body("mcpServer/elicitation/request"),
+            Some(json!({"action": "decline"}))
+        );
+        assert_eq!(
+            denial_body("item/tool/call"),
+            Some(json!({"success": false, "contentItems": []}))
+        );
+        // No safe denial body exists for these; they stay unanswered.
+        assert_eq!(denial_body("item/tool/requestUserInput"), None);
+        assert_eq!(denial_body("account/chatgptAuthTokens/refresh"), None);
+        assert_eq!(denial_body("totally/unknown"), None);
+        // No body anywhere grants anything.
+        for method in [
+            "execCommandApproval",
+            "applyPatchApproval",
+            "item/commandExecution/requestApproval",
+            "item/fileChange/requestApproval",
+            "item/permissions/requestApproval",
+            "mcpServer/elicitation/request",
+            "item/tool/call",
+        ] {
+            let body = denial_body(method).unwrap().to_string();
+            assert!(!body.contains("accept"));
+            assert!(!body.contains("approved"));
+            assert!(!body.contains("\"success\":true"));
+        }
+    }
+
+    #[test]
+    fn refusal_envelopes_echo_the_server_request_id_verbatim() {
+        for id in [json!("server-1"), json!(42)] {
+            let request = ServerRequest {
+                id: id.clone(),
+                method: "execCommandApproval".into(),
+                params: json!({"callId": "c1"}),
+            };
+            let envelope = refusal_envelope(&request).unwrap();
+            assert_eq!(envelope["id"], id);
+            assert_eq!(envelope["result"], json!({"decision": "denied"}));
+            assert!(envelope.get("method").is_none());
+        }
+        // Methods without a pinned denial body produce no envelope at all.
+        let request = ServerRequest {
+            id: json!(1),
+            method: "item/tool/requestUserInput".into(),
+            params: json!({}),
+        };
+        assert!(refusal_envelope(&request).is_none());
+    }
+
+    #[test]
+    fn call_correlates_responses_and_buffers_interleaved_frames() {
+        // A real subprocess emits a notification and a server request
+        // between our two requests and their responses.
+        let mut server = spawn_test_server(
+            "printf '%s\\n' \
+             '{\"id\":1,\"result\":{\"userAgent\":\"symbiote/0.118.0\"}}' \
+             '{\"method\":\"thread/status/changed\",\"params\":{\"threadId\":\"t\"}}' \
+             '{\"id\":\"srv-9\",\"method\":\"execCommandApproval\",\"params\":{\"callId\":\"c\"}}' \
+             '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thr\"}}}'; sleep 30",
+        );
+        let result = server.call("initialize", &json!({})).unwrap();
+        assert_eq!(result["userAgent"], "symbiote/0.118.0");
+        // The interleaved notification surfaces next...
+        let notification = server.recv_notification().unwrap().unwrap();
+        assert_eq!(notification["method"], "thread/status/changed");
+        // The second call pumps through the interleaved server request (it
+        // is buffered, not dropped) and consumes its own response.
+        let thread = server.call("thread/start", &json!({})).unwrap();
+        assert_eq!(thread["thread"]["id"], "thr");
+        // The buffered server request now surfaces with its id verbatim.
+        let request = server.recv_server_request().unwrap().unwrap();
+        assert_eq!(request.method, "execCommandApproval");
+        assert_eq!(request.id, json!("srv-9"));
+        // Then the stream is quiet: a poll returns None, not an error.
+        assert!(server.recv_notification().unwrap().is_none());
+    }
+
+    #[test]
+    fn stray_and_malformed_frames_are_rejected() {
+        // Response with the wrong id is rejected even mid-call.
+        let mut server = spawn_test_server("printf '%s\\n' '{\"id\":99,\"result\":{}}'; sleep 30");
+        assert_eq!(
+            server.call("initialize", &json!({})),
+            Err(DriverError::UnexpectedResponse)
+        );
+        // Frames outside a call that look like responses are violations.
+        let mut server = spawn_test_server("printf '%s\\n' '{\"id\":1,\"result\":{}}'; sleep 30");
+        assert_eq!(
+            server.recv_notification(),
+            Err(DriverError::UnexpectedResponse)
+        );
+        // Unknown envelope fields are rejected.
+        let mut server = spawn_test_server(
+            "printf '%s\\n' '{\"method\":\"m\",\"params\":{},\"extra\":1}'; sleep 30",
+        );
+        assert_eq!(server.recv_notification(), Err(DriverError::MalformedFrame));
+    }
+
+    #[test]
+    fn rpc_error_responses_fail_the_call() {
+        let mut server = spawn_test_server(
+            "printf '%s\\n' '{\"id\":1,\"error\":{\"code\":-32000,\"message\":\"no\"}}'; sleep 30",
+        );
+        assert_eq!(
+            server.call("thread/start", &json!({})),
+            Err(DriverError::RpcFailure)
+        );
+    }
+
+    #[test]
+    fn process_exit_is_a_hard_failure_not_silence() {
+        let mut server = spawn_test_server("exit 0");
+        // Give the process a moment to exit, then the stream must report a
+        // closed transport rather than an indefinite silent poll.
+        let mut waited = 0;
+        loop {
+            match server.recv_notification() {
+                Err(DriverError::TransportFailed) => break,
+                Ok(None) => {
+                    waited += 1;
+                    assert!(waited < 200, "silent poll never resolved to closed");
+                }
+                other => panic!("unexpected poll result: {other:?}"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod probe_timing {
+    use super::*;
+    use crate::CodexTransport;
+
+    #[test]
+    fn probe_zz_step_timing() {
+        let mut server = spawn_test_server(
+            "printf '%s\\n' \
+             '{\"id\":1,\"result\":{\"userAgent\":\"symbiote/0.118.0 (Linux)\"}}' \
+             '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thr-1\"}}}' \
+             '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-1\"}}}'; sleep 30",
+        );
+        let t0 = std::time::Instant::now();
+        let r = server.call("initialize", &json!({}));
+        eprintln!("initialize: {:?} at {:?}", r.is_ok(), t0.elapsed());
+        let r = server.notify("initialized", &json!({}));
+        eprintln!("notify: {:?} at {:?}", r.is_ok(), t0.elapsed());
+        let r = server.call("thread/start", &json!({}));
+        eprintln!("thread/start: {:?} at {:?}", r.is_ok(), t0.elapsed());
+        let r = server.call("turn/start", &json!({}));
+        eprintln!("turn/start: {:?} at {:?}", r.is_ok(), t0.elapsed());
+        let r = server.recv_notification();
+        eprintln!(
+            "first notification poll: {:?} at {:?}",
+            r.is_ok(),
+            t0.elapsed()
+        );
+    }
+}

--- a/docs/contracts/external-agent-loop.md
+++ b/docs/contracts/external-agent-loop.md
@@ -38,7 +38,9 @@ thread/turn APIs) without experimental methods. The driver sends exactly:
 - `turn/start` with the task prompt as one text input on the recorded
   thread. Turn identity is minted by the harness.
 
-It never sends login/logout/account/config-write/fs/plugin/feedback/exec or
+The handshake precedes everything: `initialize` → pinned
+`symbiote/0.118.0` check → `initialized`. The driver never sends
+login/logout/account/config-write/fs/plugin/feedback/exec or
 fuzzyFileSearch requests. Notifications are correlated by `threadId` +
 `turnId`; foreign-turn notifications are absorbed but never stop the turn.
 
@@ -89,16 +91,35 @@ policy to hold.
   never follow a terminal `Exit`. Every completed turn's full event stream
   replays cleanly through the SDK `SessionTracker` (asserted in tests).
 
+## Production transport
+
+The `process` module owns the wire: versionless request envelopes (no
+`jsonrpc` field, transport-assigned numeric ids), strict frame
+classification (response / notification / server request; unknown fields,
+null ids and stray responses are violations, never guesses), bounded
+buffering, and the per-method denial bodies from the pinned response
+schemas. `launch_sandboxed` composes the Host sandbox (#218) with the
+pinned binary (`/usr/bin/codex app-server --listen stdio://`): trusted
+helper, consent whose fingerprint covers the exact invocation, disposable
+HOME, isolated network, reserved worktree (#211). The driver completes the
+real handshake (`initialize` → pinned `symbiote/0.118.0` check →
+`initialized`) before any thread or turn interaction; a server that does
+not report the pinned version is refused.
+
+The `codex_thread_smoke` example is the real-binary proof, mirroring the
+#483 discovery proof: sandboxed launch, real handshake, real `thread/start`,
+then cancellation — no turn, no model call, no credentials, no network. It
+runs locally and in CI (`Rust contracts`, stable toolchain).
+
 ## Honest non-claims
 
-This slice is offline-only: the 14 tests run against deterministic fixture
-transports and prove the driver's state machine, refusal behavior, event
-mapping and bounds. No live `codex` process was launched by these tests, no
-real App Server session was created, no model turn ran, no credential was
-read and no spending occurred. The concrete production transport (sandboxed
-`JsonlTransport` spawn of the pinned binary, #211/#218) is not implemented
-here; the discovery example (#483) remains the only real-binary proof, and
-it made no model turn. Durable session resume/reconnect (the SDK's
-Disconnected/Reconnected events), steering, interruption requests and
-multi-turn tool-result round trips are not implemented. #464/#465 remain
+Unit tests run against deterministic fixture transports; two tests drive
+the full driver over a real framed subprocess (scripted frames, no codex
+binary, no network, no credentials) to pin EOF, deadline and
+silent-harness behavior. The only live-binary evidence is the smoke
+proof's handshake + thread start: **no model turn ran** — with
+authentication `required` and no credentials in the sandbox, a turn would
+fail anyway, so execution proof still requires explicit user authorization
+for credentials and billing. No tool-result round trips, no
+steering/interrupt requests, no durable resume/reconnect. #464/#465 remain
 open.

--- a/docs/contracts/external-agent-loop.md
+++ b/docs/contracts/external-agent-loop.md
@@ -32,9 +32,12 @@ The tested release is `codex-cli 0.118.0`; shapes were checked against the
 installed executable's `app-server generate-json-schema` output (v2
 thread/turn APIs) without experimental methods. The driver sends exactly:
 
-- `thread/start` with the Host-authorized worktree as `cwd`, `sandbox`
-  pinned to `read-only` and `approvalPolicy` pinned to `never`. The thread
-  id is minted by the harness; the driver only records it.
+- `thread/start` with the worktree path **as visible to the harness
+  process** as `cwd` — through the sandboxed launcher the Host path is
+  mounted at `/workspace` and invisible by its host name, so composed
+  callers pass `/workspace` — `sandbox` pinned to `read-only` and
+  `approvalPolicy` pinned to `never`. The thread id is minted by the
+  harness; the driver only records it.
 - `turn/start` with the task prompt as one text input on the recorded
   thread. Turn identity is minted by the harness.
 
@@ -42,7 +45,8 @@ The handshake precedes everything: `initialize` → pinned
 `symbiote/0.118.0` check → `initialized`. The driver never sends
 login/logout/account/config-write/fs/plugin/feedback/exec or
 fuzzyFileSearch requests. Notifications are correlated by `threadId` +
-`turnId`; foreign-turn notifications are absorbed but never stop the turn.
+`turnId`; foreign-turn or unattributable notifications are ignored with a
+bounded diagnostic and never stop the turn or touch its accounting.
 
 ## Approval refusal is total
 
@@ -107,9 +111,14 @@ real handshake (`initialize` → pinned `symbiote/0.118.0` check →
 not report the pinned version is refused.
 
 The `codex_thread_smoke` example is the real-binary proof, mirroring the
-#483 discovery proof: sandboxed launch, real handshake, real `thread/start`,
-then cancellation — no turn, no model call, no credentials, no network. It
-runs locally and in CI (`Rust contracts`, stable toolchain).
+#483 discovery proof: sandboxed launch, the driver's own `begin_thread`
+against the production framing, then cancellation — no turn, no model
+call, no credentials, no network. It runs locally and in CI
+(`Rust contracts`, stable toolchain). Sizing note: the shared transport's
+default frame cap is 64 KiB; a real turn whose frames exceed that is
+rejected (`FrameTooLarge`) and reads as a lost transport, so production
+callers must size `TransportLimits` explicitly — event-text truncation
+only applies after framing.
 
 ## Honest non-claims
 


### PR DESCRIPTION
Continuation of the #465/#464 external-loop slice (PR #496 merged the driver). This PR closes the biggest honest non-claim from #496: the production transport.

## What exists now
- **Complete pinned protocol handshake**: the driver's `begin_thread` now performs `initialize` → pinned `symbiote/0.118.0` server-version check (single source of truth: the #483 discovery pin, imported from `symbiote-runtime-discovery`) → `initialized` notification → `thread/start`. A server reporting any other version is refused (`UnsupportedVersion`) before any thread, turn or account interaction. Tests assert the exact sent-method sequence and the refusal.
- **New `process` module — the production transport**: `CodexServerProcess<T: FrameIo>` frames versionless JSONL over any IO. Production IO is the sandboxed `SandboxProcess`; tests use the shared `JsonlTransport` over real subprocesses (scripted frames, no codex binary). Strict frame classification: responses must correlate to the outstanding request id (string-or-number echoed verbatim); notifications and server requests buffer with bounds; unknown envelope fields, null ids, stray responses and error responses are explicit violations (`MalformedFrame`/`UnexpectedResponse`/`RpcFailure`). Per-method denial bodies come from the pinned response schemas (`denied`/`decline`/empty-grant/`success:false`); bodyless methods (`item/tool/requestUserInput`, unknowns) stay unanswered — the transport structurally cannot send a grant.
- **`launch_sandboxed`** composes the Host sandbox (#218) with the pinned binary exactly like the #483 discovery proof: trusted helper, consent whose fingerprint covers the exact codex invocation, disposable HOME, isolated network, reserved worktree (#211), `/usr/bin/codex app-server --listen stdio://`.
- **Observation-loop fixes** (found by the first hung test run, then regression-pinned): the silent-poll budget's reset fired unconditionally (infinite loop on a silent harness) — now it only resets on received frames; server requests surface through the same frame pump as notifications and are drained before the notification is processed.
- **`codex_thread_smoke` example — the real-binary proof**: sandboxed launch, real handshake, real `thread/start`, cancellation. Ran locally against the installed `/usr/bin/codex 0.118.0` inside bubblewrap: `{"handshake":"initialize_initialized_ok","thread_started":true,"turn_started":false,"model_called":false,"credentials_mounted":false,"network":"denied_by_sandbox"}`. CI gains this proof alongside the discovery proof.

## Verification
- 28 crate tests (up from 18): fixtures + full driver-over-real-subprocess integration (handshake → thread → turn → events), EOF/process-exit pin, silent-harness pin, framing/violation matrix, denial-body matrix, id-echo envelope tests.
- Workspace: 345 tests pass; `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- Live evidence: local smoke run output above; CI repeats it on disposable runners with the SHA-512-verified pinned binary.

## Honest non-claims
- **No model turn ran** — with authentication `required` and no credentials in the sandbox, a turn would fail anyway; execution proof still requires explicit user authorization for credentials and billing. Surfaced, not attempted.
- No tool-result round trips, no steering/interrupt, no durable resume/reconnect, no Host-side wiring yet (dispatch → driver → RequestCompletion integration is the next slice).
- #464/#465 remain open.