### PR TITLE
feat(host): wire started dispatches to both worker loops with evidence-only completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,11 +388,17 @@ name = "symbiote-host"
 version = "0.1.0"
 dependencies = [
  "nix",
+ "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "symbiote-domain",
+ "symbiote-external-agent",
  "symbiote-host-inventory",
+ "symbiote-native-agent",
  "symbiote-protocol",
+ "symbiote-runtime-discovery",
+ "symbiote-runtime-sdk",
  "symbiote-store",
  "symbiote-workforce",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,6 @@ name = "symbiote-host"
 version = "0.1.0"
 dependencies = [
  "nix",
- "rusqlite",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/symbiote-host/Cargo.toml
+++ b/crates/symbiote-host/Cargo.toml
@@ -11,6 +11,12 @@ symbiote-host-inventory = { path = "../symbiote-host-inventory" }
 symbiote-domain = { path = "../symbiote-domain" }
 symbiote-protocol = { path = "../symbiote-protocol" }
 symbiote-store = { path = "../symbiote-store" }
+symbiote-native-agent = { path = "../symbiote-native-agent" }
+symbiote-external-agent = { path = "../symbiote-external-agent" }
+symbiote-runtime-sdk = { path = "../symbiote-runtime-sdk" }
+symbiote-runtime-discovery = { path = "../symbiote-runtime-discovery" }
+schemars.workspace = true
+rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
 serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "fs"] }

--- a/crates/symbiote-host/Cargo.toml
+++ b/crates/symbiote-host/Cargo.toml
@@ -16,7 +16,6 @@ symbiote-external-agent = { path = "../symbiote-external-agent" }
 symbiote-runtime-sdk = { path = "../symbiote-runtime-sdk" }
 symbiote-runtime-discovery = { path = "../symbiote-runtime-discovery" }
 schemars.workspace = true
-rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled"] }
 serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "fs"] }

--- a/crates/symbiote-host/src/lib.rs
+++ b/crates/symbiote-host/src/lib.rs
@@ -6,6 +6,7 @@ compile_error!(
 
 mod identity;
 mod inventory;
+pub mod runner;
 mod service;
 pub mod transport;
 

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -47,7 +47,7 @@ pub struct WorkerOutcome {
     pub completion_filed: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RunnerError {
     /// The dispatch's runtime kind does not match the loop being run.
     RuntimeMismatch,
@@ -55,12 +55,17 @@ pub enum RunnerError {
     NotRunning,
     /// The dispatch contract no longer validates at the run time.
     InvalidContract,
-    /// The loop halted without a completed turn; nothing was filed.
-    LoopFailed,
+    /// The loop halted without a completed turn; nothing was filed. The
+    /// payload is the loop's own halt/error identity, so a caller-sequence
+    /// bug (`invalid_input`, `already_complete`, `unknown_tool`) is never
+    /// misread as a retryable transient failure.
+    LoopFailed(&'static str),
     /// The loop completed but produced no reportable final message.
     NoReport,
-    /// The store refused the completion (illegal transition, CAS, etc.).
-    Store,
+    /// The store refused the filing. The payload names the store's own
+    /// error (display form) so an idempotency collision is distinguishable
+    /// from a state move.
+    Store(String),
 }
 
 impl std::fmt::Display for RunnerError {
@@ -81,7 +86,9 @@ fn check_runnable(
     if dispatch.contract().profile().runtime != expected {
         return Err(RunnerError::RuntimeMismatch);
     }
-    let task = store.task(task_id).map_err(|_| RunnerError::Store)?;
+    let task = store
+        .task(task_id)
+        .map_err(|error| RunnerError::Store(error.to_string()))?;
     if task.state() != &TaskState::Running {
         return Err(RunnerError::NotRunning);
     }
@@ -100,10 +107,21 @@ fn file_completion(
     report: &str,
     at: Timestamp,
 ) -> Result<(), RunnerError> {
-    let task = store.task(task_id).map_err(|_| RunnerError::Store)?;
+    let task = store
+        .task(task_id)
+        .map_err(|error| RunnerError::Store(error.to_string()))?;
+    // The command id carries the dispatch id and the filing time: a Host
+    // retry of the SAME observed run replays honestly (byte-identical
+    // request), while a NEW run of the task gets a fresh id and can never
+    // be silently swallowed by the old receipt.
+    let id = CommandId::new(format!(
+        "worker-completion-{}-{}",
+        dispatch.id().as_str(),
+        at.0
+    ))
+    .map_err(|error| RunnerError::Store(error.to_string()))?;
     let command = TaskCommand {
-        id: CommandId::new(format!("worker-completion-{}", task_id.as_str()))
-            .map_err(|_| RunnerError::Store)?,
+        id,
         expected_revision: task.revision(),
         actor: Actor::Worker(dispatch.id().clone()),
         at,
@@ -115,11 +133,12 @@ fn file_completion(
     store
         .apply_task(task_id, command)
         .map_err(|error: symbiote_store::StoreError| {
-            // An illegal transition here means the state moved under us
-            // (lease expiry, concurrent edit, replay). The loop's evidence
-            // stays in the run summary; the Host decides the retry.
-            let _ = error;
-            RunnerError::Store
+            // Surfaced, never swallowed: an illegal transition means the
+            // state moved under us (lease expiry, concurrent edit); an
+            // idempotency conflict means a different command already used
+            // this id. The loop's evidence stays with the caller; the Host
+            // decides the retry.
+            RunnerError::Store(error.to_string())
         })?;
     Ok(())
 }
@@ -142,11 +161,24 @@ pub fn run_native(
     // keyed by the contract's profile model — never from loop input.
     let model = store
         .model_descriptor(&dispatch.contract().profile().model)
-        .map_err(|_| RunnerError::Store)?;
+        .map_err(|error| RunnerError::Store(error.to_string()))?;
     let mut session = NativeSession::new(dispatch, model, at).map_err(native_error)?;
     let summary = session.run(task_prompt, transport).map_err(native_error)?;
-    if summary.halted != Some(symbiote_native_agent::HaltReason::Stop) {
-        return Err(RunnerError::LoopFailed);
+    // Only a model-finished turn is a clean stop. The native loop maps
+    // FinishReason::Cancelled to the same HaltReason::Stop as a normal
+    // finish, so a cancelled turn is recognized by its terminal event: it
+    // records CancelAcknowledged, not Exit(0). Filing a cancelled turn
+    // would make an unfinished turn look worker-complete.
+    let cancelled = session
+        .events()
+        .iter()
+        .any(|event| matches!(event.payload(), RuntimeEventKind::CancelAcknowledged {}));
+    if cancelled || summary.halted != Some(symbiote_native_agent::HaltReason::Stop) {
+        let reason = match summary.halted {
+            Some(halt) => halt_name(halt),
+            None => "none",
+        };
+        return Err(RunnerError::LoopFailed(reason));
     }
     // The final assistant message is the worker's report; it is recorded in
     // the event stream as the last Message before Exit.
@@ -170,7 +202,36 @@ pub fn run_native(
 fn native_error(error: LoopError) -> RunnerError {
     match error {
         LoopError::InvalidContract => RunnerError::InvalidContract,
-        _ => RunnerError::LoopFailed,
+        other => RunnerError::LoopFailed(native_error_name(other)),
+    }
+}
+
+/// The loop error's own identity, so caller-sequencing bugs
+/// (`invalid_input`, `already_complete`) are never misread as retryable
+/// transient failures like `provider_failed`.
+fn native_error_name(error: LoopError) -> &'static str {
+    match error {
+        LoopError::InvalidContract => "invalid_contract",
+        LoopError::BudgetExhausted => "budget_exhausted",
+        LoopError::TurnCapReached => "turn_cap_reached",
+        LoopError::ProviderFailed => "provider_failed",
+        LoopError::EnvelopeMismatch => "envelope_mismatch",
+        LoopError::UnknownTool => "unknown_tool",
+        LoopError::AlreadyComplete => "already_complete",
+        LoopError::InvalidInput => "invalid_input",
+    }
+}
+
+fn halt_name(halt: symbiote_native_agent::HaltReason) -> &'static str {
+    match halt {
+        symbiote_native_agent::HaltReason::Stop => "stop",
+        symbiote_native_agent::HaltReason::Length => "length",
+        symbiote_native_agent::HaltReason::BudgetExhausted => "budget_exhausted",
+        symbiote_native_agent::HaltReason::TurnCapReached => "turn_cap_reached",
+        symbiote_native_agent::HaltReason::ProviderFailed => "provider_failed",
+        symbiote_native_agent::HaltReason::EnvelopeMismatch => "envelope_mismatch",
+        symbiote_native_agent::HaltReason::UnknownTool => "unknown_tool",
+        symbiote_native_agent::HaltReason::OutputBackstop => "output_backstop",
     }
 }
 
@@ -188,18 +249,23 @@ pub fn run_external(
     at: Timestamp,
 ) -> Result<WorkerOutcome, RunnerError> {
     check_runnable(store, task_id, dispatch, RuntimeKind::ExternalHarness)?;
-    let mut session = ExternalSession::new(dispatch, at).map_err(|error| match error {
-        symbiote_external_agent::DriverError::InvalidContract => RunnerError::InvalidContract,
-        _ => RunnerError::LoopFailed,
-    })?;
+    let mut session = ExternalSession::new(dispatch, at).map_err(external_error)?;
     session
         .begin_thread(worktree_cwd, transport)
         .map_err(external_error)?;
     session
         .turn(task_prompt, transport)
         .map_err(external_error)?;
-    if session.run_summary().stopped != Some(StopKind::Completed) {
-        return Err(RunnerError::LoopFailed);
+    let stopped = session.run_summary().stopped;
+    if stopped != Some(StopKind::Completed) {
+        let name = match stopped {
+            Some(StopKind::Completed) => "completed",
+            Some(StopKind::Failed) => "failed",
+            Some(StopKind::Interrupted) => "interrupted",
+            Some(StopKind::TransportLost) => "transport_lost",
+            None => "none",
+        };
+        return Err(RunnerError::LoopFailed(name));
     }
     let report = session
         .events()
@@ -219,18 +285,27 @@ pub fn run_external(
 }
 
 fn external_error(error: symbiote_external_agent::DriverError) -> RunnerError {
+    use symbiote_external_agent::DriverError;
     match error {
-        symbiote_external_agent::DriverError::InvalidContract => RunnerError::InvalidContract,
-        _ => RunnerError::LoopFailed,
+        DriverError::InvalidContract => RunnerError::InvalidContract,
+        other => RunnerError::LoopFailed(external_error_name(other)),
     }
 }
 
-/// Domain-law re-asserted for tests and callers: the runner's filing is
-/// bounded by the same domain transition the protocol operation uses. Exposed
-/// here so the contract doc's claim ("cannot pass CompletionRequested") is
-/// checkable against the actual transition table, not folklore.
-pub fn completion_requires_running(state: &TaskState) -> bool {
-    matches!(state, TaskState::Running)
+fn external_error_name(error: symbiote_external_agent::DriverError) -> &'static str {
+    use symbiote_external_agent::DriverError;
+    match error {
+        DriverError::InvalidContract => "invalid_contract",
+        DriverError::NotExternalHarness => "not_external_harness",
+        DriverError::InvalidInput => "invalid_input",
+        DriverError::TransportFailed => "transport_failed",
+        DriverError::MalformedFrame => "malformed_frame",
+        DriverError::UnexpectedResponse => "unexpected_response",
+        DriverError::RpcFailure => "rpc_failure",
+        DriverError::UnsupportedVersion => "unsupported_version",
+        DriverError::ContractMismatch => "contract_mismatch",
+        DriverError::AlreadyComplete => "already_complete",
+    }
 }
 
 #[cfg(test)]
@@ -274,7 +349,7 @@ mod tests {
         let task_record = store.task(&task).unwrap();
         let role = fixture::role(&store, tag);
         let dispatch = fixture::dispatch(tag, &task_record, &role, &binding, &host);
-        store
+        let (_, started) = store
             .start_prepared_task(
                 fixture::command(tag, "start"),
                 task.clone(),
@@ -285,6 +360,11 @@ mod tests {
                 Timestamp(50),
             )
             .unwrap();
+        // Fidelity pin: the store re-reads the role/binding from its own
+        // tables and compiles its own dispatch. If the fixture's hand-built
+        // inputs ever diverged from registered state, this identity check
+        // fails loudly instead of testing against a phantom dispatch.
+        assert_eq!(started.id(), dispatch.id());
         (store, task, dispatch)
     }
 
@@ -390,7 +470,7 @@ mod tests {
                 &mut transport,
                 Timestamp(60)
             ),
-            Err(RunnerError::LoopFailed)
+            Err(RunnerError::LoopFailed("provider_failed"))
         );
         assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
         // External: a failed turn files nothing either.
@@ -407,7 +487,7 @@ mod tests {
                 &mut transport,
                 Timestamp(60)
             ),
-            Err(RunnerError::LoopFailed)
+            Err(RunnerError::LoopFailed("failed"))
         );
         assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
     }
@@ -448,6 +528,90 @@ mod tests {
             store.task(&task).unwrap().state(),
             &TaskState::CompletionRequested
         );
+    }
+
+    #[test]
+    fn external_completed_turn_without_message_files_nothing() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("no-report", RuntimeKind::ExternalHarness);
+        // A completed turn whose only item is a commandExecution: the
+        // NoReport path fires instead of filing an empty report the domain
+        // would reject.
+        let mut transport = fixture::ScriptedCodex::new(
+            vec![
+                Ok(serde_json::json!({"userAgent": format!(
+                    "symbiote/{} (Linux)",
+                    symbiote_runtime_discovery::codex::CODEX_VERSION
+                )})),
+                Ok(serde_json::json!({"thread": {"id": "thr-fixture"}})),
+                Ok(serde_json::json!({"turn": {"id": "turn-fixture"}})),
+            ],
+            vec![
+                serde_json::json!({
+                    "method": "item/completed",
+                    "params": {"threadId": "thr-fixture", "turnId": "turn-fixture",
+                        "item": {"type": "commandExecution", "id": "c1",
+                            "command": "cargo test", "status": "completed"}}
+                }),
+                fixture::codex_completed("completed"),
+            ],
+            Vec::new(),
+        );
+        assert_eq!(
+            run_external(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                "/workspace",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::NoReport)
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn external_interrupted_turn_files_nothing() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("interrupted-run", RuntimeKind::ExternalHarness);
+        let mut transport = fixture::codex_transport_with_status("interrupted");
+        assert_eq!(
+            run_external(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                "/workspace",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::LoopFailed("interrupted"))
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn native_cancelled_turn_files_nothing() {
+        // The native loop maps FinishReason::Cancelled to HaltReason::Stop;
+        // the runner must look at the terminal event, not just the halt
+        // reason, so a cancelled turn is never filed as worker-complete.
+        let (mut store, task, dispatch) =
+            store_with_running_task("cancelled-run", RuntimeKind::NativeSymbiote);
+        let mut transport = fixture::CancelledTransport;
+        assert_eq!(
+            run_native(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::LoopFailed("stop"))
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
     }
 
     /// Test fixtures for the store wiring. Mirrors the store's own
@@ -833,6 +997,12 @@ mod tests {
         }
 
         pub fn role(store: &Store, tag: &str) -> Role {
+            // The domain Role is reconstructed here; its fidelity is pinned
+            // by the start step below: the store's start_prepared_task
+            // re-reads the role from the roles table and compiles its own
+            // dispatch, and the test asserts the store's started dispatch
+            // id equals this fixture's dispatch id — a mismatched role
+            // (lineage mismatch) would fail that start loudly.
             let _ = store;
             Role {
                 id: RoleId::new(format!("worker-{tag}")).unwrap(),
@@ -951,7 +1121,53 @@ mod tests {
             )
         }
 
-        fn codex_completed(status: &str) -> serde_json::Value {
+        pub fn codex_transport_with_status(
+            status: &str,
+        ) -> impl symbiote_external_agent::CodexTransport {
+            ScriptedCodex::new(
+                vec![
+                    Ok(serde_json::json!({"userAgent": format!(
+                        "symbiote/{} (Linux)",
+                        symbiote_runtime_discovery::codex::CODEX_VERSION
+                    )})),
+                    Ok(serde_json::json!({"thread": {"id": "thr-fixture"}})),
+                    Ok(serde_json::json!({"turn": {"id": "turn-fixture"}})),
+                ],
+                vec![codex_completed(status)],
+                Vec::new(),
+            )
+        }
+
+        /// A native "provider" that reports a mid-turn cancellation.
+        pub struct CancelledTransport;
+        impl symbiote_native_agent::InferenceTransport for CancelledTransport {
+            fn request(
+                &mut self,
+                request: &symbiote_runtime_sdk::provider::ProviderRequest,
+                _model: &symbiote_runtime_sdk::provider::ModelDescriptor,
+            ) -> Result<
+                symbiote_runtime_sdk::provider::ProviderResponse,
+                symbiote_runtime_sdk::provider::ProviderError,
+            > {
+                Ok(symbiote_runtime_sdk::provider::ProviderResponse {
+                    schema_version: symbiote_runtime_sdk::provider::PROVIDER_CONTRACT_VERSION,
+                    request_id: request.request_id.clone(),
+                    provider_id: request.provider_id.clone(),
+                    model_id: request.model_id.clone(),
+                    text: "I'll continue implementing...".into(),
+                    tool_calls: Vec::new(),
+                    finish_reason: symbiote_runtime_sdk::provider::FinishReason::Cancelled,
+                    usage: symbiote_runtime_sdk::provider::TokenUsage::Known {
+                        input_tokens: 1,
+                        output_tokens: 1,
+                        cached_input_tokens: None,
+                        reasoning_tokens: None,
+                    },
+                })
+            }
+        }
+
+        pub fn codex_completed(status: &str) -> serde_json::Value {
             serde_json::json!({
                 "method": "turn/completed",
                 "params": {"threadId": "thr-fixture", "turnId": "turn-fixture",
@@ -960,14 +1176,14 @@ mod tests {
         }
 
         /// Minimal scripted Codex transport for runner wiring tests.
-        struct ScriptedCodex {
+        pub struct ScriptedCodex {
             responses: Vec<Result<serde_json::Value, symbiote_external_agent::DriverError>>,
             notifications: VecDeque<Option<serde_json::Value>>,
             server_requests: VecDeque<symbiote_external_agent::ServerRequest>,
             cursor: usize,
         }
         impl ScriptedCodex {
-            fn new(
+            pub fn new(
                 responses: Vec<Result<serde_json::Value, symbiote_external_agent::DriverError>>,
                 notifications: Vec<serde_json::Value>,
                 server_requests: Vec<symbiote_external_agent::ServerRequest>,

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -1,0 +1,1030 @@
+//! Host-side worker runner: the composition point where a started dispatch
+//! is actually executed by one of the two worker loops (#465), and where the
+//! loop's completion report is filed as canonical `RequestCompletion`
+//! evidence. The runner owns no loop logic — native turns come from
+//! `symbiote-native-agent`, external turns from `symbiote-external-agent`,
+//! selected strictly by the dispatch contract's runtime kind. It owns the
+//! wiring facts:
+//!
+//! - the dispatch is re-validated by the loop session at creation time (the
+//!   loop refuses expired or foreign contracts), and the runner refuses a
+//!   dispatch whose runtime kind does not match the loop it is about to run;
+//! - the task must still be `Running` under the started dispatch before the
+//!   run begins, and the completion report is applied as the `Worker` actor
+//!   through the store's journaled `apply_task`, exactly like the protocol
+//!   operation — so it can only move the task to `CompletionRequested`;
+//!   Host verification and independent review remain the completion gates;
+//! - a loop that halts without a completed turn files nothing: the task
+//!   stays `Running` and the failure is returned for Host retry policy.
+//!
+//! Transports are injected. Tests use deterministic scripted transports; the
+//! live native Responses-API client and the live external Codex turn each
+//! require explicit user authorization for credentials and billing and are
+//! not implemented here. No silent native-billing fallback for external work
+//! exists and none may be added: the runtime kind decides the loop, and the
+//! runner refuses mismatches.
+use symbiote_domain::{
+    Actor, CommandId, Dispatch, RuntimeKind, TaskAction, TaskCommand, TaskId, TaskState, Timestamp,
+};
+use symbiote_external_agent::{ExternalSession, StopKind};
+use symbiote_native_agent::{LoopError, NativeSession};
+use symbiote_runtime_sdk::events::RuntimeEventKind;
+use symbiote_store::Store;
+
+/// One wired worker run: the loop's own durable summary plus the journaled
+/// completion evidence, if a completed turn produced a report.
+#[derive(
+    Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerOutcome {
+    /// The dispatch the loop ran against.
+    pub dispatch_id: symbiote_domain::DispatchId,
+    pub task_id: TaskId,
+    /// Completion evidence filed with the store, if the run completed a turn.
+    /// The task can only be `CompletionRequested` after this; verification is
+    /// a separate Host gate.
+    pub completion_filed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunnerError {
+    /// The dispatch's runtime kind does not match the loop being run.
+    RuntimeMismatch,
+    /// The task is not in the Running state under this dispatch.
+    NotRunning,
+    /// The dispatch contract no longer validates at the run time.
+    InvalidContract,
+    /// The loop halted without a completed turn; nothing was filed.
+    LoopFailed,
+    /// The loop completed but produced no reportable final message.
+    NoReport,
+    /// The store refused the completion (illegal transition, CAS, etc.).
+    Store,
+}
+
+impl std::fmt::Display for RunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "worker runner: {self:?}")
+    }
+}
+impl std::error::Error for RunnerError {}
+
+/// Preconditions every runner shares: the task is Running under this exact
+/// dispatch and the loop's runtime kind matches the contract.
+fn check_runnable(
+    store: &Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    expected: RuntimeKind,
+) -> Result<(), RunnerError> {
+    if dispatch.contract().profile().runtime != expected {
+        return Err(RunnerError::RuntimeMismatch);
+    }
+    let task = store.task(task_id).map_err(|_| RunnerError::Store)?;
+    if task.state() != &TaskState::Running {
+        return Err(RunnerError::NotRunning);
+    }
+    match task.current_dispatch() {
+        Some(current) if current.id() == dispatch.id() => {}
+        _ => return Err(RunnerError::NotRunning),
+    }
+    Ok(())
+}
+
+/// Files the loop's completion report through the store as Worker evidence.
+fn file_completion(
+    store: &mut Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    report: &str,
+    at: Timestamp,
+) -> Result<(), RunnerError> {
+    let task = store.task(task_id).map_err(|_| RunnerError::Store)?;
+    let command = TaskCommand {
+        id: CommandId::new(format!("worker-completion-{}", task_id.as_str()))
+            .map_err(|_| RunnerError::Store)?,
+        expected_revision: task.revision(),
+        actor: Actor::Worker(dispatch.id().clone()),
+        at,
+        action: TaskAction::RequestCompletion {
+            dispatch_id: dispatch.id().clone(),
+            report: report.to_owned(),
+        },
+    };
+    store
+        .apply_task(task_id, command)
+        .map_err(|error: symbiote_store::StoreError| {
+            // An illegal transition here means the state moved under us
+            // (lease expiry, concurrent edit, replay). The loop's evidence
+            // stays in the run summary; the Host decides the retry.
+            let _ = error;
+            RunnerError::Store
+        })?;
+    Ok(())
+}
+
+/// Runs the native loop (#465 native side) against an already-started
+/// dispatch and files the completion evidence on a clean stop. The final
+/// agent message is the report: it is what the model offered as its
+/// summary, and it routes through the same Worker-evidence gate as the
+/// protocol operation.
+pub fn run_native(
+    store: &mut Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    task_prompt: &str,
+    transport: &mut impl symbiote_native_agent::InferenceTransport,
+    at: Timestamp,
+) -> Result<WorkerOutcome, RunnerError> {
+    check_runnable(store, task_id, dispatch, RuntimeKind::NativeSymbiote)?;
+    // The model envelope comes from the Host's provider registry (#464),
+    // keyed by the contract's profile model — never from loop input.
+    let model = store
+        .model_descriptor(&dispatch.contract().profile().model)
+        .map_err(|_| RunnerError::Store)?;
+    let mut session = NativeSession::new(dispatch, model, at).map_err(native_error)?;
+    let summary = session.run(task_prompt, transport).map_err(native_error)?;
+    if summary.halted != Some(symbiote_native_agent::HaltReason::Stop) {
+        return Err(RunnerError::LoopFailed);
+    }
+    // The final assistant message is the worker's report; it is recorded in
+    // the event stream as the last Message before Exit.
+    let report = session
+        .events()
+        .iter()
+        .rev()
+        .find_map(|event| match event.payload() {
+            RuntimeEventKind::Message { text } => Some(text.as_str().to_owned()),
+            _ => None,
+        })
+        .ok_or(RunnerError::NoReport)?;
+    file_completion(store, task_id, dispatch, &report, at)?;
+    Ok(WorkerOutcome {
+        dispatch_id: dispatch.id().clone(),
+        task_id: task_id.clone(),
+        completion_filed: true,
+    })
+}
+
+fn native_error(error: LoopError) -> RunnerError {
+    match error {
+        LoopError::InvalidContract => RunnerError::InvalidContract,
+        _ => RunnerError::LoopFailed,
+    }
+}
+
+/// Runs the external loop (#465 external side) against an already-started
+/// dispatch and files the completion evidence on a completed turn. The
+/// final harness agent message is the report. Any other stop kind — failed,
+/// interrupted, transport lost — files nothing.
+pub fn run_external(
+    store: &mut Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    task_prompt: &str,
+    worktree_cwd: &str,
+    transport: &mut impl symbiote_external_agent::CodexTransport,
+    at: Timestamp,
+) -> Result<WorkerOutcome, RunnerError> {
+    check_runnable(store, task_id, dispatch, RuntimeKind::ExternalHarness)?;
+    let mut session = ExternalSession::new(dispatch, at).map_err(|error| match error {
+        symbiote_external_agent::DriverError::InvalidContract => RunnerError::InvalidContract,
+        _ => RunnerError::LoopFailed,
+    })?;
+    session
+        .begin_thread(worktree_cwd, transport)
+        .map_err(external_error)?;
+    session
+        .turn(task_prompt, transport)
+        .map_err(external_error)?;
+    if session.run_summary().stopped != Some(StopKind::Completed) {
+        return Err(RunnerError::LoopFailed);
+    }
+    let report = session
+        .events()
+        .iter()
+        .rev()
+        .find_map(|event| match event.payload() {
+            RuntimeEventKind::Message { text } => Some(text.as_str().to_owned()),
+            _ => None,
+        })
+        .ok_or(RunnerError::NoReport)?;
+    file_completion(store, task_id, dispatch, &report, at)?;
+    Ok(WorkerOutcome {
+        dispatch_id: dispatch.id().clone(),
+        task_id: task_id.clone(),
+        completion_filed: true,
+    })
+}
+
+fn external_error(error: symbiote_external_agent::DriverError) -> RunnerError {
+    match error {
+        symbiote_external_agent::DriverError::InvalidContract => RunnerError::InvalidContract,
+        _ => RunnerError::LoopFailed,
+    }
+}
+
+/// Domain-law re-asserted for tests and callers: the runner's filing is
+/// bounded by the same domain transition the protocol operation uses. Exposed
+/// here so the contract doc's claim ("cannot pass CompletionRequested") is
+/// checkable against the actual transition table, not folklore.
+pub fn completion_requires_running(state: &TaskState) -> bool {
+    matches!(state, TaskState::Running)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{BTreeSet, VecDeque};
+
+    fn store_with_running_task(tag: &str, runtime: RuntimeKind) -> (Store, TaskId, Dispatch) {
+        let mut store = Store::memory().unwrap();
+        let (project, task) = fixture::full_fixture(&mut store, tag, runtime);
+        let task_role = store.task(&task).unwrap().role_id().clone();
+        let request = symbiote_workforce::RouteRequest {
+            project_id: project.clone(),
+            work_id: fixture::work_id(tag),
+            requested: Some(task_role.clone()),
+            domains: BTreeSet::new(),
+        };
+        let decision =
+            symbiote_workforce::resolve_route(&store.get_team(&project).unwrap(), &request)
+                .unwrap();
+        store
+            .record_route(
+                fixture::command(tag, "route"),
+                decision,
+                fixture::user(),
+                Timestamp(20),
+            )
+            .unwrap();
+        store
+            .prepare_dispatch(
+                fixture::command(tag, "prepare"),
+                task.clone(),
+                fixture::user(),
+                Timestamp(30),
+            )
+            .unwrap();
+        let preparation = store.dispatch_preparation(&task).unwrap();
+        assert_eq!(preparation.outcome, fixture::ready_outcome());
+        let host = fixture::host(tag);
+        let binding = fixture::binding(&store, &project, tag);
+        let task_record = store.task(&task).unwrap();
+        let role = fixture::role(&store, tag);
+        let dispatch = fixture::dispatch(tag, &task_record, &role, &binding, &host);
+        store
+            .start_prepared_task(
+                fixture::command(tag, "start"),
+                task.clone(),
+                dispatch.id().clone(),
+                fixture::contract(tag, "start"),
+                &host,
+                fixture::user(),
+                Timestamp(50),
+            )
+            .unwrap();
+        (store, task, dispatch)
+    }
+
+    #[test]
+    fn native_runner_files_completion_evidence() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("native-run", RuntimeKind::NativeSymbiote);
+        let mut transport = fixture::EchoTransport {
+            text: "implemented the change".into(),
+        };
+        let outcome = run_native(
+            &mut store,
+            &task,
+            &dispatch,
+            "do the work",
+            &mut transport,
+            Timestamp(60),
+        )
+        .unwrap();
+        assert!(outcome.completion_filed);
+        assert_eq!(
+            store.task(&task).unwrap().state(),
+            &TaskState::CompletionRequested
+        );
+        // Evidence is not completion: no Verified transition happened.
+        assert_ne!(store.task(&task).unwrap().state(), &TaskState::Completed);
+    }
+
+    #[test]
+    fn external_runner_files_completion_evidence() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("external-run", RuntimeKind::ExternalHarness);
+        let mut transport = fixture::codex_transport();
+        let outcome = run_external(
+            &mut store,
+            &task,
+            &dispatch,
+            "do the work",
+            "/workspace",
+            &mut transport,
+            Timestamp(60),
+        )
+        .unwrap();
+        assert!(outcome.completion_filed);
+        assert_eq!(
+            store.task(&task).unwrap().state(),
+            &TaskState::CompletionRequested
+        );
+        assert_ne!(store.task(&task).unwrap().state(), &TaskState::Completed);
+    }
+
+    #[test]
+    fn runners_refuse_foreign_runtime_kinds() {
+        let (store, task, dispatch) =
+            store_with_running_task("mismatch-native", RuntimeKind::NativeSymbiote);
+        let mut store = store;
+        let mut external_transport = fixture::codex_transport();
+        assert_eq!(
+            run_external(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                "/workspace",
+                &mut external_transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::RuntimeMismatch)
+        );
+        // The task is still Running; nothing was filed.
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+        let (store, task, dispatch) =
+            store_with_running_task("mismatch-external", RuntimeKind::ExternalHarness);
+        let mut store = store;
+        let mut native_transport = fixture::native_transport(vec![]);
+        assert_eq!(
+            run_native(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                &mut native_transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::RuntimeMismatch)
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn failed_loop_files_nothing_and_task_stays_running() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("native-fail", RuntimeKind::NativeSymbiote);
+        let mut transport = fixture::native_transport(vec![Err(
+            symbiote_runtime_sdk::provider::ProviderError::Unavailable,
+        )]);
+        assert_eq!(
+            run_native(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::LoopFailed)
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+        // External: a failed turn files nothing either.
+        let (mut store, task, dispatch) =
+            store_with_running_task("external-fail", RuntimeKind::ExternalHarness);
+        let mut transport = fixture::codex_transport_failed();
+        assert_eq!(
+            run_external(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                "/workspace",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::LoopFailed)
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn a_task_not_running_is_refused_before_any_loop() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("not-running", RuntimeKind::NativeSymbiote);
+        // File a completion directly (as the worker would) to leave the task
+        // in CompletionRequested; a second run must be refused.
+        let task_record = store.task(&task).unwrap();
+        let command = TaskCommand {
+            id: fixture::command("not-running", "manual-completion"),
+            expected_revision: task_record.revision(),
+            actor: Actor::Worker(dispatch.id().clone()),
+            at: Timestamp(55),
+            action: TaskAction::RequestCompletion {
+                dispatch_id: dispatch.id().clone(),
+                report: "first run".into(),
+            },
+        };
+        store.apply_task(&task, command).unwrap();
+        let mut transport = fixture::EchoTransport {
+            text: "second".into(),
+        };
+        assert_eq!(
+            run_native(
+                &mut store,
+                &task,
+                &dispatch,
+                "do the work",
+                &mut transport,
+                Timestamp(60)
+            ),
+            Err(RunnerError::NotRunning)
+        );
+        assert_eq!(
+            store.task(&task).unwrap().state(),
+            &TaskState::CompletionRequested
+        );
+    }
+
+    /// Test fixtures for the store wiring. Mirrors the store's own
+    /// preparation_tests fixture: a full project/team/binding/provider
+    /// composition whose profile carries the requested runtime kind.
+    mod fixture {
+        use super::*;
+        use std::collections::BTreeMap;
+        use symbiote_domain::*;
+
+        pub fn user() -> symbiote_domain::UserId {
+            symbiote_domain::UserId::new("owner").unwrap()
+        }
+        pub fn command(tag: &str, name: &str) -> CommandId {
+            CommandId::new(format!("{tag}-{name}")).unwrap()
+        }
+        pub fn contract(tag: &str, name: &str) -> RuntimeContractId {
+            RuntimeContractId::new(format!("{tag}-{name}")).unwrap()
+        }
+        pub fn work_id(tag: &str) -> WorkId {
+            WorkId::Objective(
+                symbiote_domain::ObjectiveId::new(format!("objective-{tag}")).unwrap(),
+            )
+        }
+        pub fn sha(c: char) -> symbiote_domain::CommitSha {
+            let hex: String = std::iter::repeat_n(c, 40).collect();
+            symbiote_domain::CommitSha::new(hex).unwrap()
+        }
+        pub fn ready_outcome() -> PreparationOutcome {
+            PreparationOutcome::Ready
+        }
+
+        /// Builds the full store fixture with the requested runtime kind on
+        /// the binding's profile. Mirrors the store's own preparation_tests
+        /// fixture composition (project/team/binding/provider/task/origin).
+        pub fn full_fixture(
+            store: &mut Store,
+            tag: &str,
+            runtime: RuntimeKind,
+        ) -> (ProjectId, TaskId) {
+            let project_id = ProjectId::new(format!("project-{tag}")).unwrap();
+            let root_id = RootId::new(format!("root-{tag}")).unwrap();
+            let lead_id = RoleId::new(format!("lead-{tag}")).unwrap();
+            let worker_id = RoleId::new(format!("worker-{tag}")).unwrap();
+            let project = Project {
+                id: project_id.clone(),
+                revision: Revision(0),
+                name: format!("Project {tag}"),
+                owner: user(),
+                roots: BTreeSet::from([root_id.clone()]),
+                lead: lead_id.clone(),
+                disposition: symbiote_domain::RecordDisposition::Active,
+                provenance: Provenance {
+                    created_at: Timestamp(10),
+                    updated_at: Timestamp(10),
+                    actor: Actor::User(user()),
+                    external_references: vec![],
+                },
+            };
+            let root = Root {
+                id: root_id.clone(),
+                project_id: project_id.clone(),
+                revision: Revision(0),
+                repository: None,
+                host_paths: BTreeMap::new(),
+            };
+            let roles = vec![
+                Role {
+                    id: lead_id.clone(),
+                    project_id: project_id.clone(),
+                    revision: Revision(0),
+                    name: "Lead".into(),
+                    operating_contract: VersionedRoleContract {
+                        id: RoleContractId::new(format!("lead-contract-{tag}")).unwrap(),
+                        revision: Revision(1),
+                    },
+                },
+                Role {
+                    id: worker_id.clone(),
+                    project_id: project_id.clone(),
+                    revision: Revision(0),
+                    name: "Engineer".into(),
+                    operating_contract: VersionedRoleContract {
+                        id: RoleContractId::new(format!("worker-contract-{tag}")).unwrap(),
+                        revision: Revision(1),
+                    },
+                },
+            ];
+            store
+                .register_project(
+                    command(tag, "register"),
+                    project.clone(),
+                    vec![root],
+                    roles.clone(),
+                )
+                .unwrap();
+            let access = AccessSnapshot {
+                project_id: project.id.clone(),
+                roots: project.roots.clone(),
+                grants: BTreeSet::from([Permission::ReadRoot, Permission::ExecuteProcess]),
+                policy_revision: Revision(1),
+            };
+            let lead_policy = symbiote_domain::RolePolicy {
+                role_id: lead_id.clone(),
+                function: symbiote_domain::RoleFunction::LeadOrchestrator,
+                responsibilities: vec!["Plan".into()],
+                task_domains: BTreeSet::from(["coordination".into()]),
+                access: access.clone(),
+                context_policy_ref: "context".into(),
+                tool_policy_ref: "tools".into(),
+                skill_policy_ref: "skills".into(),
+                execution_policy_ref: "execution".into(),
+                independent_reviewers: BTreeSet::from([worker_id.clone()]),
+                fallbacks: vec![],
+            };
+            let mut worker_access = access.clone();
+            worker_access.grants = BTreeSet::from([
+                Permission::ReadRoot,
+                Permission::ExecuteProcess,
+                Permission::MutateStream,
+            ]);
+            let worker_access_for_binding = worker_access.clone();
+            let worker_policy = symbiote_domain::RolePolicy {
+                role_id: worker_id.clone(),
+                function: symbiote_domain::RoleFunction::GeneralExecution,
+                responsibilities: vec!["Implement".into()],
+                task_domains: BTreeSet::from(["coding".into()]),
+                access: worker_access.clone(),
+                context_policy_ref: "context".into(),
+                tool_policy_ref: "tools".into(),
+                skill_policy_ref: "skills".into(),
+                execution_policy_ref: "execution".into(),
+                independent_reviewers: BTreeSet::from([lead_id.clone()]),
+                fallbacks: vec![],
+            };
+            let mut ceiling = access.clone();
+            ceiling.grants.insert(Permission::MutateStream);
+            let team = symbiote_domain::TeamConfiguration {
+                schema_version: 1,
+                project_id: project.id.clone(),
+                revision: Revision(0),
+                lead_role_id: lead_id.clone(),
+                access_ceiling: ceiling,
+                members: vec![lead_policy, worker_policy],
+            };
+            store
+                .replace_team(
+                    command(tag, "team"),
+                    None,
+                    team.clone(),
+                    user(),
+                    Timestamp(10),
+                )
+                .unwrap();
+            let connection = ProviderConnection {
+                id: ProviderConnectionId::new(format!("provider-{tag}")).unwrap(),
+                adapter: InferenceProviderAdapterId::new("adapter").unwrap(),
+                endpoint_reference: "https://api.openai.example/v1".into(),
+                authentication: AuthenticationKind::ApiCredential,
+            };
+            store
+                .replace_provider_connection(
+                    command(tag, "provider"),
+                    project.id.clone(),
+                    connection,
+                    user(),
+                    Timestamp(11),
+                )
+                .unwrap();
+            // The model descriptor the native loop reads from the registry
+            // (only meaningful for native runs; harmless for external).
+            store
+                .replace_model_descriptor(
+                    command(tag, "model"),
+                    project.id.clone(),
+                    symbiote_runtime_sdk::provider::ModelDescriptor {
+                        schema_version: symbiote_runtime_sdk::provider::PROVIDER_CONTRACT_VERSION,
+                        id: ModelId::new(format!("model-{tag}")).unwrap(),
+                        provider_id: ProviderConnectionId::new(format!("provider-{tag}")).unwrap(),
+                        context_window_tokens: 8192,
+                        max_output_tokens: 4096,
+                        capabilities: symbiote_runtime_sdk::provider::ModelCapabilities {
+                            reasoning_efforts: BTreeSet::new(),
+                            tools: true,
+                            images: false,
+                            streaming: false,
+                        },
+                    },
+                    user(),
+                    Timestamp(11),
+                )
+                .unwrap();
+            let profile = RuntimeProfile {
+                id: RuntimeProfileId::new(format!("profile-{tag}")).unwrap(),
+                revision: Revision(0),
+                runtime,
+                adapter: AgentRuntimeAdapterId::new("adapter").unwrap(),
+                // An external-harness profile must pin its installation.
+                installation: if runtime == RuntimeKind::ExternalHarness {
+                    Some(InstallationId::new("codex-0-118-0").unwrap())
+                } else {
+                    None
+                },
+                provider: ProviderConnectionId::new(format!("provider-{tag}")).unwrap(),
+                credential: CredentialReferenceId::new("credential").unwrap(),
+                billing_entitlement: BillingEntitlementId::new(format!("ent-{tag}")).unwrap(),
+                model: ModelId::new(format!("model-{tag}")).unwrap(),
+                eligible_hosts: BTreeSet::from([HostId::new(format!("host-{tag}")).unwrap()]),
+            };
+            let primary = symbiote_workforce::StaffingCandidate {
+                profile: profile.clone(),
+                config_identity: "fixture".into(),
+                access: worker_access.clone(),
+                tools: BTreeSet::new(),
+                skills: BTreeSet::new(),
+                secret_scopes: BTreeSet::new(),
+                context: ContextPolicy {
+                    bundle: ContextBundleId::new("context").unwrap(),
+                    revision: Revision(1),
+                    max_input_tokens: 4096,
+                    reserved_output_tokens: 2048,
+                },
+                limits: symbiote_workforce::ResourceLimits {
+                    max_total_tokens: 100_000,
+                    max_wall_time_ms: 60_000,
+                    max_concurrency: 1,
+                    max_memory_bytes: 1 << 20,
+                },
+            };
+            let policy = || symbiote_workforce::PolicyReference {
+                id: "policy".into(),
+                revision: Revision(0),
+            };
+            let configuration = symbiote_workforce::BindingConfiguration {
+                schema_version: symbiote_workforce::BINDING_VERSION,
+                binding: WorkforceBinding {
+                    id: BindingId::new(format!("binding-{tag}")).unwrap(),
+                    revision: Revision(0),
+                    project_id: project.id.clone(),
+                    role_id: worker_id.clone(),
+                    profile_id: profile.id.clone(),
+                    profile_revision: profile.revision,
+                    protocol: VersionedProtocol {
+                        id: ProtocolId::new("protocol").unwrap(),
+                        revision: Revision(1),
+                    },
+                    access: worker_access_for_binding,
+                    required_controls: BTreeSet::from([Control::Filesystem]),
+                    context: primary.context.clone(),
+                    required_tools: BTreeSet::new(),
+                    required_skills: BTreeSet::new(),
+                    escalation: EscalationPolicy::StopAndRequestHuman,
+                },
+                team_revision: team.revision,
+                primary,
+                fallbacks: vec![],
+                policies: symbiote_workforce::WorkforcePolicies {
+                    environment: policy(),
+                    worktree: policy(),
+                    verification: policy(),
+                    documentation: policy(),
+                    artifacts: policy(),
+                    mcp: policy(),
+                    escalation: policy(),
+                    root_effort: symbiote_workforce::RootEffort::Medium,
+                    local_children: symbiote_workforce::LocalChildPolicy::default(),
+                    fallback_consent: FallbackConsent::ExplicitRequired,
+                    minimum_enforcement: [
+                        Control::Filesystem,
+                        Control::Cancellation,
+                        Control::CompletionAuthority,
+                        Control::Process,
+                    ]
+                    .into_iter()
+                    .map(|c| (c, EnforcementStrength::HostEnforced))
+                    .collect(),
+                    required_capabilities: BTreeSet::new(),
+                },
+            };
+            store
+                .replace_binding(
+                    command(tag, "binding"),
+                    None,
+                    configuration,
+                    user(),
+                    Timestamp(12),
+                )
+                .unwrap();
+            // Classified objective origin: legacy unclassified tasks cannot
+            // start, so the fixture owns its task through an Objective.
+            let work = WorkId::Objective(
+                symbiote_domain::ObjectiveId::new(format!("objective-{tag}")).unwrap(),
+            );
+            let spec = WorkSpec {
+                id: work.clone(),
+                project_id: project.id.clone(),
+                role_id: worker_id.clone(),
+                title: format!("Objective {tag}"),
+                description: format!("Owns task {tag}"),
+                utterance: None,
+                objective_class: Some(ObjectiveClass::Maintenance),
+                parent: None,
+                dependencies: BTreeSet::new(),
+                requirements: vec![],
+                constraints: vec![],
+                risks: vec![],
+                acceptance: vec![],
+                priority: 1,
+                budget: None,
+                external_references: vec![],
+            };
+            let origin = TaskOrigin::Objective(spec.reference());
+            let item = WorkItem::new(spec, user(), Timestamp(10)).unwrap();
+            store.create_work_item(command(tag, "work"), item).unwrap();
+            let task = Task::new(
+                TaskId::new(format!("task-{tag}")).unwrap(),
+                project.id.clone(),
+                root_id.clone(),
+                worker_id.clone(),
+                ChangeStreamId::new(format!("stream-{tag}")).unwrap(),
+                VersionedTaskContract {
+                    id: TaskContractId::new(format!("contract-{tag}")).unwrap(),
+                    revision: Revision(1),
+                },
+            );
+            let stream = ChangeStream::new(NewChangeStream {
+                id: ChangeStreamId::new(format!("stream-{tag}")).unwrap(),
+                project_id: project.id.clone(),
+                root_id: root_id.clone(),
+                tasks: BTreeSet::from([task.id().clone()]),
+                originating_chat: ChatId::new(format!("chat-{tag}")).unwrap(),
+                worktree: WorktreeId::new(format!("worktree-{tag}")).unwrap(),
+                branch: "fixture-branch".into(),
+                lineage: StreamLineage::Independent,
+                base: sha('a'),
+                target: sha('b'),
+            })
+            .unwrap();
+            store
+                .create_task(command(tag, "task"), task.clone(), stream, origin)
+                .unwrap();
+            (project.id, task.id().clone())
+        }
+
+        pub fn host(tag: &str) -> Host {
+            Host {
+                id: HostId::new(format!("host-{tag}")).unwrap(),
+                revision: Revision(0),
+                device: DeviceId::new(format!("device-{tag}")).unwrap(),
+                fabric: None,
+                supported_runtimes: vec![RuntimeKind::NativeSymbiote, RuntimeKind::ExternalHarness],
+                controls: [
+                    Control::Filesystem,
+                    Control::Cancellation,
+                    Control::CompletionAuthority,
+                    Control::Process,
+                ]
+                .into_iter()
+                .map(|c| {
+                    (
+                        c,
+                        EnforcementClaim {
+                            strength: EnforcementStrength::HostEnforced,
+                            evidence: EvidenceId::new("proof").unwrap(),
+                            verified_at: Timestamp(1),
+                            expires_at: Timestamp(1_000_000),
+                        },
+                    )
+                })
+                .collect(),
+            }
+        }
+
+        pub fn binding(
+            store: &Store,
+            project: &ProjectId,
+            tag: &str,
+        ) -> symbiote_workforce::BindingConfiguration {
+            // The fixture's binding id is deterministic; the store's public
+            // accessor is the only bridge (its connection is private).
+            let binding_id = BindingId::new(format!("binding-{tag}")).unwrap();
+            store.get_binding(project, &binding_id).unwrap()
+        }
+
+        pub fn role(store: &Store, tag: &str) -> Role {
+            let _ = store;
+            Role {
+                id: RoleId::new(format!("worker-{tag}")).unwrap(),
+                project_id: ProjectId::new(format!("project-{tag}")).unwrap(),
+                revision: Revision(0),
+                name: "Engineer".into(),
+                operating_contract: VersionedRoleContract {
+                    id: RoleContractId::new(format!("worker-contract-{tag}")).unwrap(),
+                    revision: Revision(1),
+                },
+            }
+        }
+
+        pub fn dispatch(
+            tag: &str,
+            task: &Task,
+            role: &Role,
+            binding: &symbiote_workforce::BindingConfiguration,
+            host: &Host,
+        ) -> Dispatch {
+            Dispatch::compile(
+                DispatchId::new(format!("dispatch-{tag}")).unwrap(),
+                contract(tag, "dispatch"),
+                DispatchInputs {
+                    task,
+                    role,
+                    binding: &binding.binding,
+                    profile: &binding.primary.profile,
+                    host,
+                    now: Timestamp(40),
+                },
+            )
+            .unwrap()
+        }
+
+        /// An echo transport: whatever request the loop builds, the
+        /// "provider" answers with a Stop response carrying `text` and the
+        /// request's own identities (what a real provider must preserve).
+        pub struct EchoTransport {
+            pub text: String,
+        }
+        impl symbiote_native_agent::InferenceTransport for EchoTransport {
+            fn request(
+                &mut self,
+                request: &symbiote_runtime_sdk::provider::ProviderRequest,
+                _model: &symbiote_runtime_sdk::provider::ModelDescriptor,
+            ) -> Result<
+                symbiote_runtime_sdk::provider::ProviderResponse,
+                symbiote_runtime_sdk::provider::ProviderError,
+            > {
+                Ok(symbiote_runtime_sdk::provider::ProviderResponse {
+                    schema_version: symbiote_runtime_sdk::provider::PROVIDER_CONTRACT_VERSION,
+                    request_id: request.request_id.clone(),
+                    provider_id: request.provider_id.clone(),
+                    model_id: request.model_id.clone(),
+                    text: self.text.clone(),
+                    tool_calls: Vec::new(),
+                    finish_reason: symbiote_runtime_sdk::provider::FinishReason::Stop,
+                    usage: symbiote_runtime_sdk::provider::TokenUsage::Known {
+                        input_tokens: 1,
+                        output_tokens: 1,
+                        cached_input_tokens: None,
+                        reasoning_tokens: None,
+                    },
+                })
+            }
+        }
+
+        pub fn native_transport(
+            responses: Vec<
+                Result<
+                    symbiote_runtime_sdk::provider::ProviderResponse,
+                    symbiote_runtime_sdk::provider::ProviderError,
+                >,
+            >,
+        ) -> symbiote_native_agent::ScriptedTransport {
+            symbiote_native_agent::ScriptedTransport::new(responses)
+        }
+
+        /// A scripted Codex transport producing one complete turn.
+        pub fn codex_transport() -> impl symbiote_external_agent::CodexTransport {
+            ScriptedCodex::new(
+                vec![
+                    Ok(serde_json::json!({"userAgent": format!(
+                        "symbiote/{} (Linux)",
+                        symbiote_runtime_discovery::codex::CODEX_VERSION
+                    )})),
+                    Ok(serde_json::json!({"thread": {"id": "thr-fixture"}})),
+                    Ok(serde_json::json!({"turn": {"id": "turn-fixture"}})),
+                ],
+                vec![
+                    serde_json::json!({
+                        "method": "item/completed",
+                        "params": {"threadId": "thr-fixture", "turnId": "turn-fixture",
+                            "item": {"type": "agentMessage", "id": "i1",
+                                "text": "implemented the change"}}
+                    }),
+                    codex_completed("completed"),
+                ],
+                Vec::new(),
+            )
+        }
+
+        pub fn codex_transport_failed() -> impl symbiote_external_agent::CodexTransport {
+            ScriptedCodex::new(
+                vec![
+                    Ok(serde_json::json!({"userAgent": format!(
+                        "symbiote/{} (Linux)",
+                        symbiote_runtime_discovery::codex::CODEX_VERSION
+                    )})),
+                    Ok(serde_json::json!({"thread": {"id": "thr-fixture"}})),
+                    Ok(serde_json::json!({"turn": {"id": "turn-fixture"}})),
+                ],
+                vec![codex_completed("failed")],
+                Vec::new(),
+            )
+        }
+
+        fn codex_completed(status: &str) -> serde_json::Value {
+            serde_json::json!({
+                "method": "turn/completed",
+                "params": {"threadId": "thr-fixture", "turnId": "turn-fixture",
+                    "turn": {"id": "turn-fixture", "status": status, "items": []}}
+            })
+        }
+
+        /// Minimal scripted Codex transport for runner wiring tests.
+        struct ScriptedCodex {
+            responses: Vec<Result<serde_json::Value, symbiote_external_agent::DriverError>>,
+            notifications: VecDeque<Option<serde_json::Value>>,
+            server_requests: VecDeque<symbiote_external_agent::ServerRequest>,
+            cursor: usize,
+        }
+        impl ScriptedCodex {
+            fn new(
+                responses: Vec<Result<serde_json::Value, symbiote_external_agent::DriverError>>,
+                notifications: Vec<serde_json::Value>,
+                server_requests: Vec<symbiote_external_agent::ServerRequest>,
+            ) -> Self {
+                Self {
+                    responses,
+                    notifications: notifications
+                        .into_iter()
+                        .map(Some)
+                        .chain(std::iter::once(None))
+                        .collect(),
+                    server_requests: server_requests.into(),
+                    cursor: 0,
+                }
+            }
+        }
+        impl symbiote_external_agent::CodexTransport for ScriptedCodex {
+            fn call(
+                &mut self,
+                _method: &str,
+                _params: &serde_json::Value,
+            ) -> Result<serde_json::Value, symbiote_external_agent::DriverError> {
+                let index = self.cursor;
+                self.cursor += 1;
+                self.responses
+                    .get(index)
+                    .cloned()
+                    .unwrap_or(Err(symbiote_external_agent::DriverError::TransportFailed))
+            }
+            fn notify(
+                &mut self,
+                _method: &str,
+                _params: &serde_json::Value,
+            ) -> Result<(), symbiote_external_agent::DriverError> {
+                Ok(())
+            }
+            fn recv_notification(
+                &mut self,
+            ) -> Result<Option<serde_json::Value>, symbiote_external_agent::DriverError>
+            {
+                Ok(self.notifications.pop_front().flatten())
+            }
+            fn recv_server_request(
+                &mut self,
+            ) -> Result<
+                Option<symbiote_external_agent::ServerRequest>,
+                symbiote_external_agent::DriverError,
+            > {
+                Ok(self.server_requests.pop_front())
+            }
+            fn refuse_server_request(
+                &mut self,
+                _request: &symbiote_external_agent::ServerRequest,
+                _decision: symbiote_external_agent::ApprovalDecision,
+            ) -> Result<(), symbiote_external_agent::DriverError> {
+                Ok(())
+            }
+        }
+    }
+}

--- a/docs/contracts/worker-completion-wiring.md
+++ b/docs/contracts/worker-completion-wiring.md
@@ -19,19 +19,31 @@ pending item that `dispatch-preparation.md` tracked for both runtimes.
   under this exact dispatch (per the store's journaled state) before the
   loop runs; the loop session re-validates the dispatch contract at run
   time, refusing expired enforcement windows or foreign identities.
-- **Completion is evidence.** On a clean stop (`HaltReason::Stop` native;
-  `StopKind::Completed` external), the final agent message is filed through
-  the store's journaled `apply_task` as `Actor::Worker(dispatch)` with
+- **Completion is evidence.** On a genuinely finished turn — native: the
+  loop's halt reason is `Stop` AND the stream's terminal event is `Exit(0)`
+  with no `CancelAcknowledged` (the native loop maps a provider
+  `Cancelled` finish to the same `HaltReason::Stop` as a normal finish, so
+  the runner checks the event, not just the reason); external:
+  `StopKind::Completed` — the final agent message is filed through the
+  store's journaled `apply_task` as `Actor::Worker(dispatch)` with
   `TaskAction::RequestCompletion` — the same transition the protocol's
   `request_task_completion` uses. The domain law holds structurally: a task
   can only reach `CompletionRequested` this way. Host verification and
   independent review remain the completion gates; the runner has no code
   path to `Complete`, `BeginVerification`, or any other transition.
-- **Failure files nothing.** A halted, failed, interrupted, or
-  transport-lost loop leaves the task `Running` and returns
-  `RunnerError::LoopFailed`; retry policy is the Host's, decided outside
-  the loop. The run summary (loop events, usage, stop kind) is available
-  from the session for journaling by the caller.
+- **The filing command id is per-run** (`worker-completion-{dispatch}-{at}`):
+  a Host retry of the same observed run replays byte-identically, but a new
+  run's filing can never be silently swallowed by an older receipt.
+- **Failure files nothing, with named causes.** A halted, failed,
+  interrupted, or transport-lost loop leaves the task `Running` and returns
+  `RunnerError::LoopFailed(reason)` carrying the loop's own halt/error
+  identity — caller-sequencing bugs (`invalid_input`, `already_complete`)
+  are never misread as retryable transient failures
+  (`provider_failed`). Store refusals return `RunnerError::Store(cause)`
+  with the store's error preserved, so an idempotency collision is
+  distinguishable from a state move. A finished turn with no reportable
+  message returns `NoReport` rather than filing an empty report the domain
+  would reject. Retry policy is the Host's, decided outside the loop.
 
 ## Verification
 

--- a/docs/contracts/worker-completion-wiring.md
+++ b/docs/contracts/worker-completion-wiring.md
@@ -1,0 +1,56 @@
+# Worker completion wiring — Host-side runner (#465/#205 integration slice)
+
+`symbiote-host::runner` is the composition point where a started dispatch is
+executed by one of the two worker loops and where the loop's completion
+report is filed as canonical evidence. It closes the "completion wiring"
+pending item that `dispatch-preparation.md` tracked for both runtimes.
+
+## What it does
+
+- **Runtime selection is the contract's, not the caller's.** `run_native`
+  refuses a dispatch whose profile is not `NativeSymbiote`;
+  `run_external` refuses one that is not `ExternalHarness`. There is no
+  fallback loop: native work never uses the harness, external work never
+  uses the native inference path, and neither loop can be pointed at the
+  other's billing route. (The native model envelope is read from the #464
+  provider registry keyed by the contract's profile model, never from loop
+  input.)
+- **Preconditions are re-checked, not trusted.** The task must be `Running`
+  under this exact dispatch (per the store's journaled state) before the
+  loop runs; the loop session re-validates the dispatch contract at run
+  time, refusing expired enforcement windows or foreign identities.
+- **Completion is evidence.** On a clean stop (`HaltReason::Stop` native;
+  `StopKind::Completed` external), the final agent message is filed through
+  the store's journaled `apply_task` as `Actor::Worker(dispatch)` with
+  `TaskAction::RequestCompletion` — the same transition the protocol's
+  `request_task_completion` uses. The domain law holds structurally: a task
+  can only reach `CompletionRequested` this way. Host verification and
+  independent review remain the completion gates; the runner has no code
+  path to `Complete`, `BeginVerification`, or any other transition.
+- **Failure files nothing.** A halted, failed, interrupted, or
+  transport-lost loop leaves the task `Running` and returns
+  `RunnerError::LoopFailed`; retry policy is the Host's, decided outside
+  the loop. The run summary (loop events, usage, stop kind) is available
+  from the session for journaling by the caller.
+
+## Verification
+
+Tests run against an in-process `Store::memory()` with the full composition
+fixture (project, Team, provider registry entry, model descriptor, workforce
+binding, classified Objective origin, task, route, preparation, start) —
+the same composition the store's own preparation tests prove — with scripted
+native and external transports. Covered: both runtimes file evidence and the
+task reaches `CompletionRequested` (never `Completed`); foreign-runtime
+refusals leave the task `Running`; a failed loop files nothing; a task no
+longer `Running` is refused before any loop runs.
+
+## Honest non-claims
+
+The transports are deterministic fixtures; no live OpenAI Responses API
+call, no live Codex turn, no credential read, no spending. The live native
+transport and the live external turn each require explicit user
+authorization for credentials and billing. The runner is a library
+composition point; the daemon does not yet expose a worker-activation
+endpoint and nothing schedules runs automatically. Durable session
+resume/reconnect, tool execution, and multi-turn tool-result round trips
+remain pending (#465/#464 stay open).


### PR DESCRIPTION
Closes nothing — an integration slice of #465/#205, which stay open.

## What exists now
- New `symbiote-host::runner`: the composition point where a started dispatch is executed by one of the two worker loops (#465) and the loop's completion report is filed as canonical evidence. This closes the "completion wiring" pending item that `docs/contracts/dispatch-preparation.md` tracked for both runtimes.
- **Runtime selection is the contract's, not the caller's**: `run_native` refuses a dispatch whose profile is not `NativeSymbiote`; `run_external` refuses one that is not `ExternalHarness`. No fallback loop exists — native work never touches the harness, external work never touches the native inference path, and neither loop can be pointed at the other's billing route. The native model envelope is read from the #464 provider registry keyed by the contract's profile model, never from loop input.
- **Preconditions re-checked, not trusted**: the task must be `Running` under this exact dispatch per the journaled store before the loop runs; each loop session re-validates the dispatch contract at run time (expired enforcement windows and foreign identities are refused).
- **Completion is evidence, structurally**: on a clean stop the final agent message is filed through the store's journaled `apply_task` as `Actor::Worker(dispatch)` with `TaskAction::RequestCompletion` — the same domain transition the protocol's `request_task_completion` uses. The task can only reach `CompletionRequested`; the runner has no code path to `Complete` or `BeginVerification`. Host verification and independent review remain the completion gates.
- **Failure files nothing**: halted/failed/interrupted/transport-lost loops leave the task `Running` and return `LoopFailed`; retry policy stays with the Host.
- Tests run against an in-process store with the full composition fixture (project, Team, provider registry entry + model descriptor, workforce binding, classified Objective origin, task, route, preparation, start) and scripted transports for both runtimes: evidence filing on both paths (task reaches `CompletionRequested`, never `Completed`), foreign-runtime refusals leave `Running`, failed-loop no-ops, not-Running refusal before any loop.
- Contract: `docs/contracts/worker-completion-wiring.md`.

## Verification
- Workspace: 351 tests pass; `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- Offline only: fixtures prove the wiring; no live API call, no credential read, no spending.

## Honest non-claims
- The transports are deterministic fixtures; live native Responses-API and live Codex model turns each require explicit user authorization for credentials and billing (surfaced, not attempted).
- The runner is a library composition point: the daemon does not yet expose a worker-activation endpoint and nothing schedules runs automatically. Durable session resume, tool execution, and multi-turn tool-result round trips remain pending.
- #464/#465 remain open.