### PR TITLE
fix(host): isolate parallel tests' reservation bases

### DIFF
--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -750,8 +750,10 @@ mod tests {
         let (store, task, _dispatch) =
             store_with_running_task("prov-wire", RuntimeKind::ExternalHarness);
         let host_id = HostId::new("unplaced-host").unwrap();
-        let reservation_base =
-            std::env::temp_dir().join(format!("symbiote-provwire-{}-base", std::process::id()));
+        let reservation_base = std::env::temp_dir().join(format!(
+            "symbiote-provwire-{}-base-nopl",
+            std::process::id()
+        ));
         let _ = std::fs::remove_dir_all(&reservation_base);
         std::fs::create_dir_all(&reservation_base).unwrap();
         let mut git = symbiote_repo::SystemGit::new();
@@ -813,7 +815,7 @@ mod tests {
         );
 
         let reservation_base =
-            std::env::temp_dir().join(format!("symbiote-provwire-{}-base", std::process::id()));
+            std::env::temp_dir().join(format!("symbiote-provwire-{}-base-mat", std::process::id()));
         let _ = std::fs::remove_dir_all(&reservation_base);
         std::fs::create_dir_all(&reservation_base).unwrap();
         let mut git = symbiote_repo::SystemGit::new();


### PR DESCRIPTION
Follow-up to PR #504: main's `cargo test --workspace` failed on `provision_worktree_materializes_from_store_records` with `Provisioning(Reservation)` — the two provisioning wiring tests shared one reservation_base directory name while running concurrently in the same test process, so one test's remove/recreate raced the other's reserve/verify. Each test now owns a uniquely named base.

The failure only manifests under the CI runner's scheduling (it passed locally before the merge); this branch makes the isolation structural. Cherry-pick of the fix from the merged-PR branch onto current main; `cargo test -p symbiote-host --lib` 14/14 green locally.