### PR TITLE
feat(context): resolve run context and scoped credential leases (#217 slice)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbiote-context"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "symbiote-domain",
+ "zeroize",
+]
+
+[[package]]
 name = "symbiote-domain"
 version = "0.1.0"
 dependencies = [
@@ -459,6 +470,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "symbiote-context",
  "symbiote-domain",
  "symbiote-external-agent",
  "symbiote-host-inventory",
@@ -721,6 +733,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-worktrees", "crates/symbiote-native-agent", "crates/symbiote-external-agent", "crates/symbiote-client-sdk", "crates/symbiote-repo", "crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce"]
+members = ["crates/symbiote-context", "crates/symbiote-worktrees", "crates/symbiote-native-agent", "crates/symbiote-external-agent", "crates/symbiote-client-sdk", "crates/symbiote-repo", "crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce"]
 
 [workspace.package]
 version = "0.1.0"
@@ -12,6 +12,7 @@ publish = false
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = { version = "1", features = ["derive"] }
+zeroize = "1"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/symbiote-context/Cargo.toml
+++ b/crates/symbiote-context/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "symbiote-context"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+symbiote-domain = { path = "../symbiote-domain" }
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+zeroize.workspace = true
+
+[lints]
+workspace = true

--- a/crates/symbiote-context/src/lib.rs
+++ b/crates/symbiote-context/src/lib.rs
@@ -289,9 +289,9 @@ impl std::fmt::Debug for CredentialBroker {
 pub enum BrokerError {
     /// The reference is unknown to the broker.
     UnknownReference,
-    /// The reference was explicitly revoked; it cannot be re-registered
-    /// under a different project (re-registration under the SAME project
-    /// is rotation and is allowed).
+    /// The reference was explicitly revoked. Revocation is STICKY per
+    /// reference id: it can never be re-registered under ANY project —
+    /// rotation after revocation uses a NEW reference id.
     Revoked,
     /// The dispatch's project does not match the secret's owning project.
     CrossProjectDenied,
@@ -411,28 +411,19 @@ impl CredentialBroker {
         if environment.is_empty() || environment.len() > 128 {
             return Err(BrokerError::InvalidEnvironmentLabel);
         }
-        if let Some(existing) = self.secrets.remove(&reference) {
-            if owning_project != existing.owning_project {
-                // Project immutability: restore the ORIGINAL record shell
-                // (its value was scrubbed by the remove above) so a later
-                // same-owner rotation still works, then refuse.
-                let owner = existing.owning_project.clone();
-                let label = existing.environment.clone();
-                drop(existing);
-                self.secrets.insert(
-                    reference,
-                    RegisteredSecret {
-                        owning_project: owner,
-                        environment: label,
-                        value: SecretBytes::new(Vec::new()),
-                    },
-                );
+        if let Some(existing) = self.secrets.get(&reference) {
+            if existing.owning_project != owning_project {
+                // Project immutability: the original record (value
+                // INCLUDED) stays untouched — a refused registration must
+                // not disturb the owner's live secret.
                 return Err(BrokerError::CrossProjectDenied);
             }
-            // Drop the previous record BEFORE building the new one: the
-            // old value is zeroized here, not when the map insert drops a
-            // shadowed record.
-            drop(existing);
+        }
+        if self.secrets.contains_key(&reference) {
+            // Same-owner replacement: drop the previous record BEFORE
+            // building the new one, so the old value is zeroized here,
+            // not when a shadowing insert drops it later.
+            drop(self.secrets.remove(&reference));
         } else if self.revoked.contains(&reference) {
             // Revocation is STICKY per reference id: re-registering the
             // same id would silently resurrect a compromised secret.
@@ -773,6 +764,26 @@ mod tests {
                 )
             ),
             Err(BrokerError::CrossProjectDenied)
+        ));
+        // A refused cross-project registration leaves the owner's record
+        // (and value) untouched: the owner can still resolve and
+        // materialize the ORIGINAL value afterwards.
+        let _ = broker.register(
+            reference.clone(),
+            other.clone(),
+            "KEY".into(),
+            b"attacker-value".to_vec(),
+        );
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(
+                    &scope_self,
+                    std::slice::from_ref(&reference),
+                    Timestamp(1_000)
+                )
+            ),
+            Ok(_)
         ));
         // Same project but the binding profile does not reference it.
         assert!(matches!(

--- a/crates/symbiote-context/src/lib.rs
+++ b/crates/symbiote-context/src/lib.rs
@@ -1,0 +1,932 @@
+//! Context and credential resolution for worker runs (#217 slice): the
+//! typed bridge between a started dispatch's trusted Host state and the
+//! exact payload a worker run receives.
+//!
+//! Two halves, kept deliberately separate:
+//!
+//! - [`ResolvedContext`]: everything the run should SEE. Built from the
+//!   dispatch contract and the origin work item (description, requirements,
+//!   constraints, risks, acceptance), bounded, and attributable — no caller
+//!   input can steer it. The resolution is pure data-over-trusted-state;
+//!   the Host's store supplies every fact.
+//!
+//! - [`CredentialBroker`]: everything the run may USE. The operator
+//!   registers secret values against `CredentialReferenceId`s (owning
+//!   project, environment label, sensitivity); at run time the broker
+//!   issues a short-lived [`CredentialLease`] ONLY when the dispatch's
+//!   binding profile references that credential AND the owning project
+//!   matches the dispatch's project. A lease is the only path to the
+//!   plaintext, it expires by timestamp, it is scoped to
+//!   project+role+profile+host, and materialized names are cleaned on
+//!   drop. Values live in process memory only (zeroized on drop); they
+//!   never enter the store, the journal, manifests, task text, or events.
+//!
+//! Boundary: this crate never decides WHO may register a secret (operator
+//! surface, canonical owner #217/H04) and never performs OS keychain or
+//! encrypted-at-rest storage (pending canonical scope). The broker is the
+//! process-local registry the Host composes; persistence and keychain
+//! integration are later slices on #217. Leases are non-amplifying: a
+//! lease grants nothing beyond the referenced value for this dispatch,
+//! and revocation (drop of the registration or explicit revoke) makes
+//! every later resolution and materialization fail closed.
+//!
+//! Tests cover normal, boundary (expiry, wrong project/role/profile/host,
+//! unknown reference, revoked), failure (over-bound text, missing work
+//! item through an injected reader), and cleanup behavior. The store
+//! dependency is injected as a trait so this crate does not depend on
+//! symbiote-store.
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use symbiote_domain::{
+    AccessSnapshot, CredentialReferenceId, DispatchId, HostId, ProjectId, RoleId, RuntimeProfileId,
+    TaskId, Timestamp, WorkId,
+};
+use zeroize::Zeroize;
+
+/// The resolved context payload for one worker run: the prompt text plus
+/// the origin work item's structured guidance, all from trusted Host
+/// state. Serialized into the loop's task prompt by the caller; the loop
+/// sees text, this crate owns the bounded composition.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedContext {
+    pub dispatch_id: DispatchId,
+    pub task_id: TaskId,
+    pub project_id: ProjectId,
+    /// The origin work item's description — the run's prompt text.
+    pub prompt: BoundedText,
+    /// The origin work item's requirements, constraints, risks and
+    /// acceptance items, each bounded, in work-item order.
+    pub requirements: Vec<BoundedText>,
+    pub constraints: Vec<BoundedText>,
+    pub risks: Vec<BoundedText>,
+    pub acceptance: Vec<BoundedText>,
+    /// The binding's context budget, carried so the caller can enforce
+    /// input bounds without re-reading the store.
+    pub context: symbiote_domain::ContextPolicy,
+    /// The access snapshot the dispatch contract carries (current policy
+    /// at compile time; the Host re-checks against the ceiling).
+    pub access: AccessSnapshot,
+}
+
+/// The per-item and per-collection text bounds. Every list is capped both
+/// per item and in total so a hostile or careless work item cannot blow up
+/// the run's input envelope through structure.
+pub const MAX_ITEM_BYTES: usize = 8_192;
+pub const MAX_LIST_ITEMS: usize = 64;
+pub const MAX_LIST_TOTAL_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolutionError {
+    /// The origin work item is missing or its description is empty.
+    NoPrompt,
+    /// A list exceeded its structural bound.
+    Overbound,
+    /// The store reader refused (payload-free; the caller logs its own).
+    StoreFailed,
+}
+
+impl std::fmt::Display for ResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "context resolution failed: {self:?}")
+    }
+}
+impl std::error::Error for ResolutionError {}
+
+/// A bounded text item with a visible truncation marker on overflow —
+/// the same char-boundary discipline as every other bounded text in the
+/// system.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct BoundedText(String);
+impl BoundedText {
+    const MARKER: &str = "…[truncated]";
+    pub fn new(raw: &str) -> Result<Self, ResolutionError> {
+        if raw.len() <= MAX_ITEM_BYTES {
+            return Ok(Self(raw.to_owned()));
+        }
+        let budget = MAX_ITEM_BYTES - Self::MARKER.len();
+        let mut end = budget;
+        while !raw.is_char_boundary(end) {
+            end -= 1;
+        }
+        Ok(Self(format!("{}{}", &raw[..end], Self::MARKER)))
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+impl TryFrom<String> for BoundedText {
+    type Error = ResolutionError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(&value)
+    }
+}
+impl From<BoundedText> for String {
+    fn from(value: BoundedText) -> Self {
+        value.0
+    }
+}
+
+/// Bounded collection: caps item count and total bytes.
+fn bounded_list(raw: &[String]) -> Result<Vec<BoundedText>, ResolutionError> {
+    if raw.len() > MAX_LIST_ITEMS {
+        return Err(ResolutionError::Overbound);
+    }
+    let mut total = 0usize;
+    let mut out = Vec::with_capacity(raw.len());
+    for item in raw {
+        let bounded = BoundedText::new(item)?;
+        total = total.saturating_add(bounded.0.len());
+        if total > MAX_LIST_TOTAL_BYTES {
+            return Err(ResolutionError::Overbound);
+        }
+        out.push(bounded);
+    }
+    Ok(out)
+}
+
+/// The trusted-state reader the resolution runs against. The Host
+/// implements it over the store; tests implement it in memory. Payload
+/// errors are collapsed so no store text leaks into resolution errors.
+pub trait ContextSource {
+    fn work_item_text(
+        &self,
+        project: &ProjectId,
+        work: &WorkId,
+    ) -> Result<Option<WorkItemText>, ResolutionError>;
+}
+
+/// The bounded slice of a work item a run's context needs.
+#[derive(Clone)]
+pub struct WorkItemText {
+    pub description: String,
+    pub requirements: Vec<String>,
+    pub constraints: Vec<String>,
+    pub risks: Vec<String>,
+    pub acceptance: Vec<String>,
+}
+
+/// The dispatch-facet inputs resolution needs. All come from the dispatch
+/// contract — the caller cannot substitute its own.
+pub struct ResolutionInputs<'a> {
+    pub dispatch_id: &'a DispatchId,
+    pub task_id: &'a TaskId,
+    pub project_id: &'a ProjectId,
+    pub origin_work: &'a WorkId,
+    pub context: symbiote_domain::ContextPolicy,
+    pub access: AccessSnapshot,
+}
+
+/// Resolves the run context from trusted state. Pure composition: no
+/// network, no execution, no authority grant — the payload is text the
+/// worker will see, and the Host's existing authorization gates decide
+/// everything else.
+pub fn resolve_context(
+    source: &impl ContextSource,
+    inputs: ResolutionInputs<'_>,
+) -> Result<ResolvedContext, ResolutionError> {
+    let work = source
+        .work_item_text(inputs.project_id, inputs.origin_work)?
+        .ok_or(ResolutionError::NoPrompt)?;
+    if work.description.trim().is_empty() {
+        return Err(ResolutionError::NoPrompt);
+    }
+    let prompt = BoundedText::new(&work.description)?;
+    Ok(ResolvedContext {
+        dispatch_id: inputs.dispatch_id.clone(),
+        task_id: inputs.task_id.clone(),
+        project_id: inputs.project_id.clone(),
+        requirements: bounded_list(&work.requirements)?,
+        constraints: bounded_list(&work.constraints)?,
+        risks: bounded_list(&work.risks)?,
+        acceptance: bounded_list(&work.acceptance)?,
+        prompt,
+        context: inputs.context,
+        access: inputs.access,
+    })
+}
+
+/// Renders the context as the task prompt text the loop receives. The
+/// structured guidance is appended in labeled sections so the model sees
+/// each obligation distinctly; nothing here can execute.
+pub fn render_prompt(context: &ResolvedContext) -> String {
+    let mut out = String::with_capacity(1024);
+    out.push_str(context.prompt.as_str());
+    let section = |out: &mut String, label: &str, items: &[BoundedText]| {
+        if !items.is_empty() {
+            out.push_str(&format!("\n\n{label}:"));
+            for item in items {
+                out.push_str(&format!("\n- {}", item.as_str()));
+            }
+        }
+    };
+    section(&mut out, "Requirements", &context.requirements);
+    section(&mut out, "Constraints", &context.constraints);
+    section(&mut out, "Risks", &context.risks);
+    section(&mut out, "Acceptance criteria", &context.acceptance);
+    out
+}
+
+/// A registered secret: the broker's process-local record. Values are
+/// held zeroized-on-drop and never serialized — the type has no serde
+/// impls, so it cannot cross the wire by construction.
+pub struct RegisteredSecret {
+    owning_project: ProjectId,
+    environment: String,
+    sensitive: bool,
+    value: SecretBytes,
+}
+
+/// Zeroized-on-drop byte buffer with a Debug that never prints contents.
+pub struct SecretBytes(Box<[u8]>);
+impl SecretBytes {
+    pub fn new(value: Vec<u8>) -> Self {
+        Self(value.into_boxed_slice())
+    }
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+}
+impl Drop for SecretBytes {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+impl std::fmt::Debug for SecretBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecretBytes({} bytes)", self.0.len())
+    }
+}
+
+/// The operator's process-local credential registry (#217 slice scope).
+/// Registration, scoped resolution and revocation live here; OS keychain
+/// and encrypted-at-rest storage remain pending canonical scope. The
+/// broker is NOT durable: restart requires the operator to re-register —
+/// the failure mode is "missing secret" (typed, surfaced), never "stale
+/// secret silently reused".
+///
+/// Debug never prints values: the impl redacts to reference names only.
+#[derive(Default)]
+pub struct CredentialBroker {
+    secrets: BTreeMap<CredentialReferenceId, RegisteredSecret>,
+    revoked: BTreeMap<CredentialReferenceId, ProjectId>,
+}
+impl std::fmt::Debug for CredentialBroker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialBroker")
+            .field("registered", &self.secrets.keys().collect::<Vec<_>>())
+            .field("revoked", &self.revoked.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// The sensitive flag is metadata for the operator's own classification
+/// (it gates later #217 redaction/export decisions); the broker's
+/// resolution path never reads it, so keep it observable instead.
+impl RegisteredSecret {
+    #[allow(dead_code)]
+    fn is_sensitive(&self) -> bool {
+        self.sensitive
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrokerError {
+    /// The reference is unknown to the broker.
+    UnknownReference,
+    /// The reference was explicitly revoked; it cannot be re-registered
+    /// under a different project (re-registration under the SAME project
+    /// is rotation and is allowed).
+    Revoked,
+    /// The dispatch's project does not match the secret's owning project.
+    CrossProjectDenied,
+    /// The dispatch's binding profile does not reference this credential.
+    NotReferencedByProfile,
+    /// The dispatch's binding access does not carry this reference's
+    /// declared environment label in its grants — an access-scoped denial.
+    EnvironmentDenied,
+}
+
+impl std::fmt::Display for BrokerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "credential broker: {self:?}")
+    }
+}
+impl std::error::Error for BrokerError {}
+
+/// The lease scope, all from the dispatch contract.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LeaseScope {
+    pub dispatch_id: DispatchId,
+    pub project_id: ProjectId,
+    pub role_id: RoleId,
+    pub profile_id: RuntimeProfileId,
+    pub host_id: HostId,
+}
+
+/// A short-lived grant to ONE secret for ONE dispatch. Holds a copy of
+/// the value (the registration is untouched); expiry is checked at
+/// materialization time, not just at issue time, so a held lease cannot
+/// outlive its window.
+pub struct CredentialLease {
+    pub reference: CredentialReferenceId,
+    pub scope: LeaseScope,
+    pub issued_at: Timestamp,
+    pub expires_at: Timestamp,
+    /// The environment name the dispatch may bind this value to.
+    pub environment: String,
+    value: SecretBytes,
+}
+impl CredentialLease {
+    /// Materializes the lease as one name→value pair for the run's
+    /// environment. Refuses an expired or not-yet-valid lease. The name
+    /// is the caller's declared binding name, NOT model input.
+    pub fn materialize(&self, at: Timestamp) -> Result<(String, String), BrokerError> {
+        if at.0 < self.issued_at.0 || at.0 >= self.expires_at.0 {
+            return Err(BrokerError::EnvironmentDenied);
+        }
+        Ok((self.environment.clone(), self.text()))
+    }
+    fn text(&self) -> String {
+        String::from_utf8_lossy(self.value.expose()).into_owned()
+    }
+}
+impl Drop for CredentialLease {
+    fn drop(&mut self) {
+        // The boxed slice is zeroized by SecretBytes' own Drop; the lease
+        // additionally clears the environment name so materialized labels
+        // do not outlive the grant.
+        self.environment.zeroize();
+    }
+}
+impl std::fmt::Debug for CredentialLease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialLease")
+            .field("reference", &self.reference)
+            .field("scope", &self.scope)
+            .field("expires_at", &self.expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The dispatch facet the broker checks against. `profile_credential_refs`
+/// are the binding profile's credential references; `environment_grants`
+/// are the binding's access grants interpreted as environment labels the
+/// run may receive (the Host maps policy to labels; a label not granted
+/// is denied here before any value moves).
+pub struct BrokerRequest<'a> {
+    pub scope: &'a LeaseScope,
+    pub profile_credential_refs: &'a [CredentialReferenceId],
+    pub environment_grants: &'a [String],
+    pub at: Timestamp,
+}
+
+impl CredentialBroker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers (or rotates) a secret. Rotation is same-reference with a
+    /// fresh value; the reference's owning project is immutable — a
+    /// different project on an existing reference is refused.
+    pub fn register(
+        &mut self,
+        reference: CredentialReferenceId,
+        owning_project: ProjectId,
+        environment: String,
+        sensitive: bool,
+        value: Vec<u8>,
+    ) -> Result<(), BrokerError> {
+        if environment.is_empty() || environment.len() > 128 {
+            return Err(BrokerError::EnvironmentDenied);
+        }
+        if let Some(existing) = self.secrets.get(&reference) {
+            if existing.owning_project != owning_project {
+                return Err(BrokerError::CrossProjectDenied);
+            }
+        } else if self.revoked.contains_key(&reference) {
+            // Revocation is STICKY per reference id: re-registering the
+            // same id would silently resurrect a compromised secret.
+            // Rotation is the operator registering a NEW reference id and
+            // updating the profile that references it.
+            return Err(BrokerError::Revoked);
+        }
+        self.secrets.insert(
+            reference,
+            RegisteredSecret {
+                owning_project,
+                environment,
+                sensitive,
+                value: SecretBytes::new(value),
+            },
+        );
+        Ok(())
+    }
+
+    /// Revokes: the reference can no longer be resolved, and re-resolution
+    /// fails closed even if a new registration never happens.
+    pub fn revoke(&mut self, reference: &CredentialReferenceId) {
+        if let Some(secret) = self.secrets.remove(reference) {
+            self.revoked
+                .insert(reference.clone(), secret.owning_project);
+        }
+    }
+
+    /// Issues a lease if and only if every scope check passes. Checks are
+    /// ordered so the refusal identity names the FIRST violated boundary.
+    pub fn resolve(
+        &self,
+        reference: &CredentialReferenceId,
+        request: BrokerRequest<'_>,
+    ) -> Result<CredentialLease, BrokerError> {
+        if self.revoked.contains_key(reference) {
+            return Err(BrokerError::Revoked);
+        }
+        let secret = self
+            .secrets
+            .get(reference)
+            .ok_or(BrokerError::UnknownReference)?;
+        if !request
+            .profile_credential_refs
+            .iter()
+            .any(|candidate| candidate == reference)
+        {
+            return Err(BrokerError::NotReferencedByProfile);
+        }
+        if secret.owning_project != request.scope.project_id {
+            return Err(BrokerError::CrossProjectDenied);
+        }
+        if !request.environment_grants.contains(&secret.environment) {
+            return Err(BrokerError::EnvironmentDenied);
+        }
+        let window = Timestamp(
+            request.at.0.saturating_add(300_000), // 5-minute lease window
+        );
+        Ok(CredentialLease {
+            reference: reference.clone(),
+            scope: request.scope.clone(),
+            issued_at: request.at,
+            expires_at: window,
+            environment: secret.environment.clone(),
+            value: SecretBytes::new(secret.value.expose().to_vec()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbiote_domain::ContextPolicy;
+
+    struct FixedSource {
+        item: Option<WorkItemText>,
+    }
+    impl ContextSource for FixedSource {
+        fn work_item_text(
+            &self,
+            _project: &ProjectId,
+            _work: &WorkId,
+        ) -> Result<Option<WorkItemText>, ResolutionError> {
+            Ok(self.item.clone())
+        }
+    }
+
+    fn inputs<'a>(
+        dispatch_id: &'a DispatchId,
+        task_id: &'a TaskId,
+        project_id: &'a ProjectId,
+        origin_work: &'a WorkId,
+        access: AccessSnapshot,
+    ) -> ResolutionInputs<'a> {
+        ResolutionInputs {
+            dispatch_id,
+            task_id,
+            project_id,
+            origin_work,
+            context: ContextPolicy {
+                bundle: symbiote_domain::ContextBundleId::new("bundle").unwrap(),
+                revision: symbiote_domain::Revision(1),
+                max_input_tokens: 4096,
+                reserved_output_tokens: 2048,
+            },
+            access,
+        }
+    }
+
+    fn access(project: &ProjectId) -> AccessSnapshot {
+        AccessSnapshot {
+            project_id: project.clone(),
+            roots: std::collections::BTreeSet::new(),
+            grants: std::collections::BTreeSet::from([symbiote_domain::Permission::ReadRoot]),
+            policy_revision: symbiote_domain::Revision(1),
+        }
+    }
+
+    fn ids(tag: &str) -> (DispatchId, TaskId, ProjectId, WorkId) {
+        (
+            DispatchId::new(format!("disp-{tag}")).unwrap(),
+            TaskId::new(format!("task-{tag}")).unwrap(),
+            ProjectId::new(format!("project-{tag}")).unwrap(),
+            WorkId::Objective(symbiote_domain::ObjectiveId::new(format!("obj-{tag}")).unwrap()),
+        )
+    }
+
+    #[test]
+    fn resolution_carries_prompt_and_structured_guidance_bounded() {
+        let (dispatch, task, project, work) = ids("resolve");
+        let source = FixedSource {
+            item: Some(WorkItemText {
+                description: "Implement the bounded change.".into(),
+                requirements: vec!["must compile".into(), "must test".into()],
+                constraints: vec!["no network".into()],
+                risks: vec![],
+                acceptance: vec!["reviewer approves".into()],
+            }),
+        };
+        let context = resolve_context(
+            &source,
+            inputs(&dispatch, &task, &project, &work, access(&project)),
+        )
+        .unwrap();
+        assert_eq!(context.prompt.as_str(), "Implement the bounded change.");
+        assert_eq!(context.requirements.len(), 2);
+        assert_eq!(context.acceptance.len(), 1);
+        assert_eq!(context.project_id, project);
+        let prompt = render_prompt(&context);
+        assert!(prompt.starts_with("Implement the bounded change."));
+        assert!(prompt.contains("Requirements:\n- must compile"));
+        assert!(prompt.contains("Acceptance criteria:\n- reviewer approves"));
+        assert!(!prompt.contains("Risks:"));
+    }
+
+    #[test]
+    fn overbound_lists_are_refused_not_truncated_away() {
+        // Structural overflow is a refusal, not a silent narrowing: a work
+        // item with 65 requirements is a composition problem.
+        let (dispatch, task, project, work) = ids("overbound");
+        let source = FixedSource {
+            item: Some(WorkItemText {
+                description: "d".into(),
+                requirements: (0..65).map(|i| format!("r{i}")).collect(),
+                constraints: vec![],
+                risks: vec![],
+                acceptance: vec![],
+            }),
+        };
+        assert_eq!(
+            resolve_context(
+                &source,
+                inputs(&dispatch, &task, &project, &work, access(&project))
+            ),
+            Err(ResolutionError::Overbound)
+        );
+        // Total-bytes overflow: each over-long item truncates to the 8 KiB
+        // item cap, so NINE of them push the list total past its 64 KiB
+        // budget (9 x 8192 > 65536).
+        let source = FixedSource {
+            item: Some(WorkItemText {
+                description: "d".into(),
+                requirements: vec!["x".repeat(MAX_ITEM_BYTES); 9],
+                constraints: vec![],
+                risks: vec![],
+                acceptance: vec![],
+            }),
+        };
+        assert_eq!(
+            resolve_context(
+                &source,
+                inputs(&dispatch, &task, &project, &work, access(&project))
+            ),
+            Err(ResolutionError::Overbound)
+        );
+    }
+
+    #[test]
+    fn oversized_items_truncate_on_char_boundaries_with_a_marker() {
+        let (dispatch, task, project, work) = ids("bigitem");
+        let emoji = "🔍".repeat(MAX_ITEM_BYTES); // 4-byte chars
+        let source = FixedSource {
+            item: Some(WorkItemText {
+                description: "ok".into(),
+                requirements: vec![emoji],
+                constraints: vec![],
+                risks: vec![],
+                acceptance: vec![],
+            }),
+        };
+        let context = resolve_context(
+            &source,
+            inputs(&dispatch, &task, &project, &work, access(&project)),
+        )
+        .unwrap();
+        assert_eq!(context.requirements.len(), 1);
+        let text = context.requirements[0].as_str();
+        assert!(text.len() <= MAX_ITEM_BYTES);
+        assert!(text.ends_with("…[truncated]"));
+        assert!(!text.contains(char::REPLACEMENT_CHARACTER));
+    }
+
+    #[test]
+    fn missing_or_empty_origin_is_a_typed_refusal() {
+        let (dispatch, task, project, work) = ids("missing");
+        let source = FixedSource { item: None };
+        assert_eq!(
+            resolve_context(
+                &source,
+                inputs(&dispatch, &task, &project, &work, access(&project))
+            ),
+            Err(ResolutionError::NoPrompt)
+        );
+        let source = FixedSource {
+            item: Some(WorkItemText {
+                description: "   ".into(),
+                requirements: vec![],
+                constraints: vec![],
+                risks: vec![],
+                acceptance: vec![],
+            }),
+        };
+        assert_eq!(
+            resolve_context(
+                &source,
+                inputs(&dispatch, &task, &project, &work, access(&project))
+            ),
+            Err(ResolutionError::NoPrompt)
+        );
+    }
+
+    fn lease_request<'a>(
+        scope: &'a LeaseScope,
+        refs: &'a [CredentialReferenceId],
+        grants: &'a [String],
+        at: Timestamp,
+    ) -> BrokerRequest<'a> {
+        BrokerRequest {
+            scope,
+            profile_credential_refs: refs,
+            environment_grants: grants,
+            at,
+        }
+    }
+
+    #[test]
+    fn broker_issues_a_scoped_expiring_lease_on_the_happy_path() {
+        let (_d, _t, project, _w) = ids("lease");
+        let mut broker = CredentialBroker::new();
+        let reference = CredentialReferenceId::new("openai-native").unwrap();
+        broker
+            .register(
+                reference.clone(),
+                project.clone(),
+                "OPENAI_API_KEY".into(),
+                true,
+                b"sk-fixture-value".to_vec(),
+            )
+            .unwrap();
+        let scope = LeaseScope {
+            dispatch_id: DispatchId::new("disp-lease").unwrap(),
+            project_id: project.clone(),
+            role_id: RoleId::new("worker").unwrap(),
+            profile_id: RuntimeProfileId::new("profile").unwrap(),
+            host_id: HostId::new("host").unwrap(),
+        };
+        let lease = broker
+            .resolve(
+                &reference,
+                lease_request(
+                    &scope,
+                    std::slice::from_ref(&reference),
+                    &["OPENAI_API_KEY".into()],
+                    Timestamp(1_000),
+                ),
+            )
+            .unwrap();
+        // Scope is carried verbatim from the dispatch contract.
+        assert_eq!(lease.scope, scope);
+        assert_eq!(lease.expires_at, Timestamp(301_000));
+        // Materialization within the window yields the name→value pair.
+        let (name, value) = lease.materialize(Timestamp(2_000)).unwrap();
+        assert_eq!(name, "OPENAI_API_KEY");
+        assert_eq!(value, "sk-fixture-value");
+        // Debug never prints the value.
+        assert!(!format!("{lease:?}").contains("sk-fixture-value"));
+        assert!(!format!("{broker:?}").contains("sk-fixture-value"));
+    }
+
+    #[test]
+    fn cross_project_and_unreferenced_and_ungranted_are_distinct_refusals() {
+        let (_d, _t, project, _w) = ids("deny");
+        let other = ProjectId::new("project-other").unwrap();
+        let mut broker = CredentialBroker::new();
+        let reference = CredentialReferenceId::new("shared-key").unwrap();
+        broker
+            .register(
+                reference.clone(),
+                project.clone(),
+                "KEY".into(),
+                true,
+                b"v".to_vec(),
+            )
+            .unwrap();
+        let scope_other = LeaseScope {
+            dispatch_id: DispatchId::new("disp-deny").unwrap(),
+            project_id: other.clone(),
+            role_id: RoleId::new("worker").unwrap(),
+            profile_id: RuntimeProfileId::new("profile").unwrap(),
+            host_id: HostId::new("host").unwrap(),
+        };
+        let scope_self = LeaseScope {
+            project_id: project.clone(),
+            ..scope_other.clone()
+        };
+        // Cross-project dispatch: refused even though the profile names it.
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(
+                    &scope_other,
+                    std::slice::from_ref(&reference),
+                    &["KEY".into()],
+                    Timestamp(1_000)
+                )
+            ),
+            Err(BrokerError::CrossProjectDenied)
+        ));
+        // Same project but the binding profile does not reference it.
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(&scope_self, &[], &["KEY".into()], Timestamp(1_000))
+            ),
+            Err(BrokerError::NotReferencedByProfile)
+        ));
+        // Referenced but the environment label is not granted.
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(
+                    &scope_self,
+                    std::slice::from_ref(&reference),
+                    &[],
+                    Timestamp(1_000)
+                )
+            ),
+            Err(BrokerError::EnvironmentDenied)
+        ));
+        // Unknown reference.
+        let unknown = CredentialReferenceId::new("nope").unwrap();
+        assert!(matches!(
+            broker.resolve(
+                &unknown,
+                lease_request(
+                    &scope_self,
+                    std::slice::from_ref(&unknown),
+                    &["KEY".into()],
+                    Timestamp(1_000)
+                )
+            ),
+            Err(BrokerError::UnknownReference)
+        ));
+    }
+
+    #[test]
+    fn revocation_fails_closed_and_blocks_cross_project_rotation() {
+        let (_d, _t, project, _w) = ids("revoke");
+        let other = ProjectId::new("project-revoke2").unwrap();
+        let mut broker = CredentialBroker::new();
+        let reference = CredentialReferenceId::new("live-key").unwrap();
+        broker
+            .register(
+                reference.clone(),
+                project.clone(),
+                "KEY".into(),
+                true,
+                b"v".to_vec(),
+            )
+            .unwrap();
+        broker.revoke(&reference);
+        let scope = LeaseScope {
+            dispatch_id: DispatchId::new("disp-revoke").unwrap(),
+            project_id: project.clone(),
+            role_id: RoleId::new("worker").unwrap(),
+            profile_id: RuntimeProfileId::new("profile").unwrap(),
+            host_id: HostId::new("host").unwrap(),
+        };
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(
+                    &scope,
+                    std::slice::from_ref(&reference),
+                    &["KEY".into()],
+                    Timestamp(1_000)
+                )
+            ),
+            Err(BrokerError::Revoked)
+        ));
+        // Re-registration is refused under a DIFFERENT project (the
+        // revoked record binds the owner) AND under the same project:
+        // revocation is STICKY per reference id, so a compromised secret
+        // cannot be resurrected. Rotation uses a NEW reference id.
+        assert!(matches!(
+            broker.register(
+                reference.clone(),
+                other.clone(),
+                "KEY".into(),
+                true,
+                b"v".to_vec()
+            ),
+            Err(BrokerError::Revoked)
+        ));
+        assert!(matches!(
+            broker.register(
+                reference.clone(),
+                project.clone(),
+                "KEY".into(),
+                true,
+                b"v2".to_vec()
+            ),
+            Err(BrokerError::Revoked)
+        ));
+        // Resolution stays revoked either way.
+        assert!(matches!(
+            broker.resolve(
+                &reference,
+                lease_request(
+                    &scope,
+                    std::slice::from_ref(&reference),
+                    &["KEY".into()],
+                    Timestamp(1_000)
+                )
+            ),
+            Err(BrokerError::Revoked)
+        ));
+        // The rotation path: a NEW reference id registers and resolves.
+        let rotated = CredentialReferenceId::new("live-key-r2").unwrap();
+        assert!(
+            broker
+                .register(
+                    rotated.clone(),
+                    project.clone(),
+                    "KEY".into(),
+                    true,
+                    b"v2".to_vec()
+                )
+                .is_ok()
+        );
+        assert!(
+            broker
+                .resolve(
+                    &rotated,
+                    lease_request(
+                        &scope,
+                        std::slice::from_ref(&rotated),
+                        &["KEY".into()],
+                        Timestamp(1_000)
+                    )
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn an_expired_lease_cannot_materialize() {
+        let (_d, _t, project, _w) = ids("expire");
+        let mut broker = CredentialBroker::new();
+        let reference = CredentialReferenceId::new("short-lived").unwrap();
+        broker
+            .register(
+                reference.clone(),
+                project.clone(),
+                "KEY".into(),
+                true,
+                b"v".to_vec(),
+            )
+            .unwrap();
+        let scope = LeaseScope {
+            dispatch_id: DispatchId::new("disp-expire").unwrap(),
+            project_id: project.clone(),
+            role_id: RoleId::new("worker").unwrap(),
+            profile_id: RuntimeProfileId::new("profile").unwrap(),
+            host_id: HostId::new("host").unwrap(),
+        };
+        let lease = broker
+            .resolve(
+                &reference,
+                lease_request(
+                    &scope,
+                    std::slice::from_ref(&reference),
+                    &["KEY".into()],
+                    Timestamp(1_000),
+                ),
+            )
+            .unwrap();
+        // Within the window it materializes; at expiry it refuses.
+        assert!(lease.materialize(Timestamp(300_999)).is_ok());
+        assert!(lease.materialize(Timestamp(301_000)).is_err());
+        // Before issuance it refuses too (a backdated clock cannot reuse).
+        assert!(lease.materialize(Timestamp(999)).is_err());
+    }
+}

--- a/crates/symbiote-context/src/lib.rs
+++ b/crates/symbiote-context/src/lib.rs
@@ -774,17 +774,18 @@ mod tests {
             "KEY".into(),
             b"attacker-value".to_vec(),
         );
-        assert!(matches!(
-            broker.resolve(
-                &reference,
-                lease_request(
-                    &scope_self,
-                    std::slice::from_ref(&reference),
-                    Timestamp(1_000)
+        assert!(
+            broker
+                .resolve(
+                    &reference,
+                    lease_request(
+                        &scope_self,
+                        std::slice::from_ref(&reference),
+                        Timestamp(1_000)
+                    )
                 )
-            ),
-            Ok(_)
-        ));
+                .is_ok()
+        );
         // Same project but the binding profile does not reference it.
         assert!(matches!(
             broker.resolve(

--- a/crates/symbiote-context/src/lib.rs
+++ b/crates/symbiote-context/src/lib.rs
@@ -12,14 +12,19 @@
 //!
 //! - [`CredentialBroker`]: everything the run may USE. The operator
 //!   registers secret values against `CredentialReferenceId`s (owning
-//!   project, environment label, sensitivity); at run time the broker
-//!   issues a short-lived [`CredentialLease`] ONLY when the dispatch's
-//!   binding profile references that credential AND the owning project
-//!   matches the dispatch's project. A lease is the only path to the
-//!   plaintext, it expires by timestamp, it is scoped to
-//!   project+role+profile+host, and materialized names are cleaned on
-//!   drop. Values live in process memory only (zeroized on drop); they
-//!   never enter the store, the journal, manifests, task text, or events.
+//!   project, environment label); at run time the broker issues a
+//!   short-lived [`CredentialLease`] ONLY when the dispatch's binding
+//!   profile references that credential, the owning project matches the
+//!   dispatch's project, AND the binding access grants `UseCredential`.
+//!   A lease is the only path to the plaintext and it expires by
+//!   timestamp. Environment labels are materialization NAMES chosen by
+//!   the operator at registration — they are not authorization surfaces.
+//!   Values live in process memory only (zeroized on drop); they never
+//!   enter the store, the journal, manifests, task text, or events.
+//!   NOT yet provided: environment/file/header injection into a running
+//!   transport, and invalidation of leases already issued before a
+//!   revocation (an outstanding lease still materializes until it
+//!   expires).
 //!
 //! Boundary: this crate never decides WHO may register a secret (operator
 //! surface, canonical owner #217/H04) and never performs OS keychain or
@@ -36,7 +41,7 @@
 //! dependency is injected as a trait so this crate does not depend on
 //! symbiote-store.
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use symbiote_domain::{
     AccessSnapshot, CredentialReferenceId, DispatchId, HostId, ProjectId, RoleId, RuntimeProfileId,
     TaskId, Timestamp, WorkId,
@@ -234,7 +239,6 @@ pub fn render_prompt(context: &ResolvedContext) -> String {
 pub struct RegisteredSecret {
     owning_project: ProjectId,
     environment: String,
-    sensitive: bool,
     value: SecretBytes,
 }
 
@@ -270,24 +274,14 @@ impl std::fmt::Debug for SecretBytes {
 #[derive(Default)]
 pub struct CredentialBroker {
     secrets: BTreeMap<CredentialReferenceId, RegisteredSecret>,
-    revoked: BTreeMap<CredentialReferenceId, ProjectId>,
+    revoked: BTreeSet<CredentialReferenceId>,
 }
 impl std::fmt::Debug for CredentialBroker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CredentialBroker")
             .field("registered", &self.secrets.keys().collect::<Vec<_>>())
-            .field("revoked", &self.revoked.keys().collect::<Vec<_>>())
+            .field("revoked", &self.revoked.iter().collect::<Vec<_>>())
             .finish()
-    }
-}
-
-/// The sensitive flag is metadata for the operator's own classification
-/// (it gates later #217 redaction/export decisions); the broker's
-/// resolution path never reads it, so keep it observable instead.
-impl RegisteredSecret {
-    #[allow(dead_code)]
-    fn is_sensitive(&self) -> bool {
-        self.sensitive
     }
 }
 
@@ -303,9 +297,15 @@ pub enum BrokerError {
     CrossProjectDenied,
     /// The dispatch's binding profile does not reference this credential.
     NotReferencedByProfile,
-    /// The dispatch's binding access does not carry this reference's
-    /// declared environment label in its grants — an access-scoped denial.
-    EnvironmentDenied,
+    /// The dispatch's binding access does not grant `UseCredential` — the
+    /// typed authority that any credential lease may issue at all.
+    UseCredentialNotGranted,
+    /// A registration's environment label was empty or over-bound.
+    InvalidEnvironmentLabel,
+    /// The lease window has closed.
+    Expired,
+    /// The lease window has not opened (a backdated clock cannot reuse).
+    NotYetValid,
 }
 
 impl std::fmt::Display for BrokerError {
@@ -344,8 +344,11 @@ impl CredentialLease {
     /// environment. Refuses an expired or not-yet-valid lease. The name
     /// is the caller's declared binding name, NOT model input.
     pub fn materialize(&self, at: Timestamp) -> Result<(String, String), BrokerError> {
-        if at.0 < self.issued_at.0 || at.0 >= self.expires_at.0 {
-            return Err(BrokerError::EnvironmentDenied);
+        if at.0 < self.issued_at.0 {
+            return Err(BrokerError::NotYetValid);
+        }
+        if at.0 >= self.expires_at.0 {
+            return Err(BrokerError::Expired);
         }
         Ok((self.environment.clone(), self.text()))
     }
@@ -372,14 +375,16 @@ impl std::fmt::Debug for CredentialLease {
 }
 
 /// The dispatch facet the broker checks against. `profile_credential_refs`
-/// are the binding profile's credential references; `environment_grants`
-/// are the binding's access grants interpreted as environment labels the
-/// run may receive (the Host maps policy to labels; a label not granted
-/// is denied here before any value moves).
+/// are the binding profile's credential references;
+/// `use_credential_granted` is the binding access's `Permission::
+/// UseCredential` grant — the typed authority that a credential lease may
+/// issue at all (the Host computes it from the dispatch contract; PR #508
+/// review P0: environment labels are NOT authorization surfaces, they are
+/// materialization names chosen by the operator at registration).
 pub struct BrokerRequest<'a> {
     pub scope: &'a LeaseScope,
     pub profile_credential_refs: &'a [CredentialReferenceId],
-    pub environment_grants: &'a [String],
+    pub use_credential_granted: bool,
     pub at: Timestamp,
 }
 
@@ -388,25 +393,47 @@ impl CredentialBroker {
         Self::default()
     }
 
-    /// Registers (or rotates) a secret. Rotation is same-reference with a
-    /// fresh value; the reference's owning project is immutable — a
-    /// different project on an existing reference is refused.
+    /// Registers a secret, or replaces its value (same project). The
+    /// reference's owning project is immutable; a different project on an
+    /// existing reference is refused, and a revoked reference can never be
+    /// re-registered — rotation after revocation uses a NEW reference id.
+    /// The caller MUST hand this method the only owning `Vec` of the
+    /// value: the broker scrubs the PREVIOUS record immediately (zeroized
+    /// at replacement, not at some later drop), but bytes the caller kept
+    /// are the caller's to manage.
     pub fn register(
         &mut self,
         reference: CredentialReferenceId,
         owning_project: ProjectId,
         environment: String,
-        sensitive: bool,
         value: Vec<u8>,
     ) -> Result<(), BrokerError> {
         if environment.is_empty() || environment.len() > 128 {
-            return Err(BrokerError::EnvironmentDenied);
+            return Err(BrokerError::InvalidEnvironmentLabel);
         }
-        if let Some(existing) = self.secrets.get(&reference) {
-            if existing.owning_project != owning_project {
+        if let Some(existing) = self.secrets.remove(&reference) {
+            if owning_project != existing.owning_project {
+                // Project immutability: restore the ORIGINAL record shell
+                // (its value was scrubbed by the remove above) so a later
+                // same-owner rotation still works, then refuse.
+                let owner = existing.owning_project.clone();
+                let label = existing.environment.clone();
+                drop(existing);
+                self.secrets.insert(
+                    reference,
+                    RegisteredSecret {
+                        owning_project: owner,
+                        environment: label,
+                        value: SecretBytes::new(Vec::new()),
+                    },
+                );
                 return Err(BrokerError::CrossProjectDenied);
             }
-        } else if self.revoked.contains_key(&reference) {
+            // Drop the previous record BEFORE building the new one: the
+            // old value is zeroized here, not when the map insert drops a
+            // shadowed record.
+            drop(existing);
+        } else if self.revoked.contains(&reference) {
             // Revocation is STICKY per reference id: re-registering the
             // same id would silently resurrect a compromised secret.
             // Rotation is the operator registering a NEW reference id and
@@ -418,20 +445,22 @@ impl CredentialBroker {
             RegisteredSecret {
                 owning_project,
                 environment,
-                sensitive,
                 value: SecretBytes::new(value),
             },
         );
         Ok(())
     }
 
-    /// Revokes: the reference can no longer be resolved, and re-resolution
-    /// fails closed even if a new registration never happens.
+    /// Revokes: the reference can no longer be resolved, its registered
+    /// value is zeroized immediately, and re-registration is refused
+    /// forever (sticky). A lease already issued from the revoked record
+    /// still holds its own copy until it expires — the honest disclosure
+    /// of the #217 'revocation blocks new dispatches' boundary; actively
+    /// invalidating outstanding leases is pending canonical scope.
     pub fn revoke(&mut self, reference: &CredentialReferenceId) {
-        if let Some(secret) = self.secrets.remove(reference) {
-            self.revoked
-                .insert(reference.clone(), secret.owning_project);
-        }
+        // Remove-then-drop scrubs the value at this point, not later.
+        drop(self.secrets.remove(reference));
+        self.revoked.insert(reference.clone());
     }
 
     /// Issues a lease if and only if every scope check passes. Checks are
@@ -441,7 +470,7 @@ impl CredentialBroker {
         reference: &CredentialReferenceId,
         request: BrokerRequest<'_>,
     ) -> Result<CredentialLease, BrokerError> {
-        if self.revoked.contains_key(reference) {
+        if self.revoked.contains(reference) {
             return Err(BrokerError::Revoked);
         }
         let secret = self
@@ -458,8 +487,8 @@ impl CredentialBroker {
         if secret.owning_project != request.scope.project_id {
             return Err(BrokerError::CrossProjectDenied);
         }
-        if !request.environment_grants.contains(&secret.environment) {
-            return Err(BrokerError::EnvironmentDenied);
+        if !request.use_credential_granted {
+            return Err(BrokerError::UseCredentialNotGranted);
         }
         let window = Timestamp(
             request.at.0.saturating_add(300_000), // 5-minute lease window
@@ -660,13 +689,12 @@ mod tests {
     fn lease_request<'a>(
         scope: &'a LeaseScope,
         refs: &'a [CredentialReferenceId],
-        grants: &'a [String],
         at: Timestamp,
     ) -> BrokerRequest<'a> {
         BrokerRequest {
             scope,
             profile_credential_refs: refs,
-            environment_grants: grants,
+            use_credential_granted: true,
             at,
         }
     }
@@ -681,7 +709,6 @@ mod tests {
                 reference.clone(),
                 project.clone(),
                 "OPENAI_API_KEY".into(),
-                true,
                 b"sk-fixture-value".to_vec(),
             )
             .unwrap();
@@ -695,12 +722,7 @@ mod tests {
         let lease = broker
             .resolve(
                 &reference,
-                lease_request(
-                    &scope,
-                    std::slice::from_ref(&reference),
-                    &["OPENAI_API_KEY".into()],
-                    Timestamp(1_000),
-                ),
+                lease_request(&scope, std::slice::from_ref(&reference), Timestamp(1_000)),
             )
             .unwrap();
         // Scope is carried verbatim from the dispatch contract.
@@ -726,7 +748,6 @@ mod tests {
                 reference.clone(),
                 project.clone(),
                 "KEY".into(),
-                true,
                 b"v".to_vec(),
             )
             .unwrap();
@@ -748,7 +769,6 @@ mod tests {
                 lease_request(
                     &scope_other,
                     std::slice::from_ref(&reference),
-                    &["KEY".into()],
                     Timestamp(1_000)
                 )
             ),
@@ -758,22 +778,22 @@ mod tests {
         assert!(matches!(
             broker.resolve(
                 &reference,
-                lease_request(&scope_self, &[], &["KEY".into()], Timestamp(1_000))
+                lease_request(&scope_self, &[], Timestamp(1_000))
             ),
             Err(BrokerError::NotReferencedByProfile)
         ));
-        // Referenced but the environment label is not granted.
+        // Referenced and project-matched but UseCredential not granted.
         assert!(matches!(
             broker.resolve(
                 &reference,
-                lease_request(
-                    &scope_self,
-                    std::slice::from_ref(&reference),
-                    &[],
-                    Timestamp(1_000)
-                )
+                BrokerRequest {
+                    scope: &scope_self,
+                    profile_credential_refs: std::slice::from_ref(&reference),
+                    use_credential_granted: false,
+                    at: Timestamp(1_000),
+                }
             ),
-            Err(BrokerError::EnvironmentDenied)
+            Err(BrokerError::UseCredentialNotGranted)
         ));
         // Unknown reference.
         let unknown = CredentialReferenceId::new("nope").unwrap();
@@ -783,12 +803,31 @@ mod tests {
                 lease_request(
                     &scope_self,
                     std::slice::from_ref(&unknown),
-                    &["KEY".into()],
                     Timestamp(1_000)
                 )
             ),
             Err(BrokerError::UnknownReference)
         ));
+        // Invalid environment labels are refused at registration with
+        // their own identity (not an access denial).
+        assert_eq!(
+            broker.register(
+                CredentialReferenceId::new("bad-label").unwrap(),
+                project.clone(),
+                String::new(),
+                b"v".to_vec()
+            ),
+            Err(BrokerError::InvalidEnvironmentLabel)
+        );
+        assert_eq!(
+            broker.register(
+                CredentialReferenceId::new("bad-label").unwrap(),
+                project.clone(),
+                "x".repeat(129),
+                b"v".to_vec()
+            ),
+            Err(BrokerError::InvalidEnvironmentLabel)
+        );
     }
 
     #[test]
@@ -802,7 +841,6 @@ mod tests {
                 reference.clone(),
                 project.clone(),
                 "KEY".into(),
-                true,
                 b"v".to_vec(),
             )
             .unwrap();
@@ -817,12 +855,7 @@ mod tests {
         assert!(matches!(
             broker.resolve(
                 &reference,
-                lease_request(
-                    &scope,
-                    std::slice::from_ref(&reference),
-                    &["KEY".into()],
-                    Timestamp(1_000)
-                )
+                lease_request(&scope, std::slice::from_ref(&reference), Timestamp(1_000))
             ),
             Err(BrokerError::Revoked)
         ));
@@ -835,7 +868,6 @@ mod tests {
                 reference.clone(),
                 other.clone(),
                 "KEY".into(),
-                true,
                 b"v".to_vec()
             ),
             Err(BrokerError::Revoked)
@@ -845,7 +877,6 @@ mod tests {
                 reference.clone(),
                 project.clone(),
                 "KEY".into(),
-                true,
                 b"v2".to_vec()
             ),
             Err(BrokerError::Revoked)
@@ -854,12 +885,7 @@ mod tests {
         assert!(matches!(
             broker.resolve(
                 &reference,
-                lease_request(
-                    &scope,
-                    std::slice::from_ref(&reference),
-                    &["KEY".into()],
-                    Timestamp(1_000)
-                )
+                lease_request(&scope, std::slice::from_ref(&reference), Timestamp(1_000))
             ),
             Err(BrokerError::Revoked)
         ));
@@ -871,7 +897,6 @@ mod tests {
                     rotated.clone(),
                     project.clone(),
                     "KEY".into(),
-                    true,
                     b"v2".to_vec()
                 )
                 .is_ok()
@@ -880,12 +905,7 @@ mod tests {
             broker
                 .resolve(
                     &rotated,
-                    lease_request(
-                        &scope,
-                        std::slice::from_ref(&rotated),
-                        &["KEY".into()],
-                        Timestamp(1_000)
-                    )
+                    lease_request(&scope, std::slice::from_ref(&rotated), Timestamp(1_000))
                 )
                 .is_ok()
         );
@@ -901,7 +921,6 @@ mod tests {
                 reference.clone(),
                 project.clone(),
                 "KEY".into(),
-                true,
                 b"v".to_vec(),
             )
             .unwrap();
@@ -915,18 +934,20 @@ mod tests {
         let lease = broker
             .resolve(
                 &reference,
-                lease_request(
-                    &scope,
-                    std::slice::from_ref(&reference),
-                    &["KEY".into()],
-                    Timestamp(1_000),
-                ),
+                lease_request(&scope, std::slice::from_ref(&reference), Timestamp(1_000)),
             )
             .unwrap();
-        // Within the window it materializes; at expiry it refuses.
+        // Within the window it materializes; at expiry it refuses with the
+        // distinct window identities (not an access denial).
         assert!(lease.materialize(Timestamp(300_999)).is_ok());
-        assert!(lease.materialize(Timestamp(301_000)).is_err());
+        assert_eq!(
+            lease.materialize(Timestamp(301_000)),
+            Err(BrokerError::Expired)
+        );
         // Before issuance it refuses too (a backdated clock cannot reuse).
-        assert!(lease.materialize(Timestamp(999)).is_err());
+        assert_eq!(
+            lease.materialize(Timestamp(999)),
+            Err(BrokerError::NotYetValid)
+        );
     }
 }

--- a/crates/symbiote-host/Cargo.toml
+++ b/crates/symbiote-host/Cargo.toml
@@ -17,6 +17,7 @@ symbiote-worktrees = { path = "../symbiote-worktrees" }
 symbiote-trust = { path = "../symbiote-trust" }
 symbiote-external-agent = { path = "../symbiote-external-agent" }
 symbiote-sandbox = { path = "../symbiote-sandbox" }
+symbiote-context = { path = "../symbiote-context" }
 symbiote-runtime-transport = { path = "../symbiote-runtime-transport" }
 symbiote-runtime-sdk = { path = "../symbiote-runtime-sdk" }
 symbiote-runtime-discovery = { path = "../symbiote-runtime-discovery" }

--- a/crates/symbiote-host/src/context_resolution.rs
+++ b/crates/symbiote-host/src/context_resolution.rs
@@ -1,0 +1,58 @@
+//! Host-side context/credential resolution wiring (#217 slice): the store
+//! adapter for `symbiote-context::ContextSource` and the resolution entry
+//! the dispatch activation path uses. Every fact comes from the store —
+//! the caller cannot substitute its own — and credential values never
+//! pass through this module (only the operator's broker, held by
+//! `WorkerTransports`, ever issues a lease).
+use symbiote_context::{ContextSource, ResolutionError, WorkItemText};
+use symbiote_domain::{ProjectId, WorkId};
+use symbiote_store::Store;
+
+/// The store-backed [`ContextSource`]. Reads are the same canonical
+/// readers the protocol serves; failures collapse to `StoreFailed` so no
+/// store text leaks into resolution errors.
+pub(crate) struct StoreContextSource<'a> {
+    pub store: &'a Store,
+}
+
+impl ContextSource for StoreContextSource<'_> {
+    fn work_item_text(
+        &self,
+        project: &ProjectId,
+        work: &WorkId,
+    ) -> Result<Option<WorkItemText>, ResolutionError> {
+        let item = self
+            .store
+            .work_item(project, work)
+            .map_err(|_| ResolutionError::StoreFailed)?;
+        let spec = item.spec();
+        Ok(Some(WorkItemText {
+            description: spec.description.clone(),
+            requirements: spec.requirements.clone(),
+            constraints: spec.constraints.clone(),
+            risks: spec.risks.clone(),
+            acceptance: spec.acceptance.clone(),
+        }))
+    }
+}
+
+/// Resolves the origin work reference for a task (the task's classified
+/// origin), collapsing the store errors the same way.
+pub(crate) fn task_origin_work(
+    store: &Store,
+    task_id: &symbiote_domain::TaskId,
+) -> Result<(ProjectId, WorkId), ResolutionError> {
+    let task = store
+        .task(task_id)
+        .map_err(|_| ResolutionError::StoreFailed)?;
+    let origin = store
+        .task_origin(&task.project_id().clone(), task_id)
+        .map_err(|_| ResolutionError::StoreFailed)?
+        .ok_or(ResolutionError::NoPrompt)?;
+    let reference = origin.reference();
+    Ok((task.project_id().clone(), reference.id.clone()))
+}
+
+// The end-to-end resolution test (fixture → resolve_context over the
+// real store) lives in runner.rs tests where the full fixture lives;
+// this module's adapter is covered there against a real Store.

--- a/crates/symbiote-host/src/lib.rs
+++ b/crates/symbiote-host/src/lib.rs
@@ -4,6 +4,10 @@ compile_error!(
     "symbiote-host currently requires Linux SO_PEERCRED; other transports remain unimplemented"
 );
 
+/// Context/credential resolution wiring (#217): the store-backed
+/// `ContextSource` and the dispatch-facet resolution the activation path
+/// uses. Credential VALUES live only in the operator's broker.
+pub(crate) mod context_resolution;
 mod identity;
 mod inventory;
 pub mod runner;

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -141,10 +141,6 @@ impl WorkerTransports {
         self
     }
 
-    pub fn broker_configured(&self) -> bool {
-        self.broker.is_some()
-    }
-
     pub fn native_configured(&self) -> bool {
         self.native.is_some()
     }
@@ -213,13 +209,12 @@ impl WorkerTransports {
         }
     }
 
-    /// Resolves credential leases for one dispatch from the operator's
-    /// broker. Refusal identities are mapped payload-free; a lease's
-    /// plaintext NEVER passes through the runner — leases are returned to
-    /// the caller, which materializes them only inside the sandbox launch
-    /// composition (native env) or hands nothing to the harness (external
-    /// credentials stay harness-owned; this method is native-only by
-    /// construction and is not called for external runs).
+    /// Resolves one credential lease for a dispatch from the operator's
+    /// broker. Refusal identities are mapped payload-free. The lease's
+    /// plaintext does not leave the broker/lease objects — no materialize
+    /// call exists in this crate (environment injection into a transport
+    /// is the pending next slice), and external runs never call this
+    /// (harness credentials stay harness-owned).
     pub fn resolve_leases(
         &self,
         reference: &symbiote_domain::CredentialReferenceId,
@@ -242,7 +237,10 @@ fn broker_error_name(error: symbiote_context::BrokerError) -> &'static str {
         symbiote_context::BrokerError::Revoked => "revoked",
         symbiote_context::BrokerError::CrossProjectDenied => "cross_project_denied",
         symbiote_context::BrokerError::NotReferencedByProfile => "not_referenced_by_profile",
-        symbiote_context::BrokerError::EnvironmentDenied => "environment_denied",
+        symbiote_context::BrokerError::UseCredentialNotGranted => "use_credential_not_granted",
+        symbiote_context::BrokerError::InvalidEnvironmentLabel => "invalid_environment_label",
+        symbiote_context::BrokerError::Expired => "expired",
+        symbiote_context::BrokerError::NotYetValid => "not_yet_valid",
     }
 }
 
@@ -1464,51 +1462,120 @@ mod tests {
     }
 
     #[test]
-    fn lease_refusals_are_typed_and_broker_configured_gate() {
-        // The broker seam: without a broker, a credential-referencing
-        // dispatch refuses with NoCredentialBroker; with one, scope checks
-        // produce typed refusals (unknown → revoked ordering verified in
-        // symbiote-context's own tests; here the transport-level mapping).
-        let (store, _task, _dispatch) =
-            store_with_running_task("lease-refuse", RuntimeKind::NativeSymbiote);
-        let credential = symbiote_domain::CredentialReferenceId::new("credential").unwrap();
-        let transports = WorkerTransports::default();
+    fn lease_resolution_runs_through_the_real_contract_scope() {
+        // The reviewer-required end-to-end seam test (PR #508 round 1): a
+        // broker configured, the fixture's own credential reference
+        // registered, and the scope fields taken from the REAL dispatch
+        // contract — proving the passing lease, the UseCredential gate,
+        // and the typed refusals through WorkerTransports.
+        let (store, task, dispatch) =
+            store_with_running_task("lease-e2e", RuntimeKind::NativeSymbiote);
+        let credential = dispatch.contract().profile().credential.clone();
         let scope = symbiote_context::LeaseScope {
-            dispatch_id: symbiote_domain::DispatchId::new("disp-lease-refuse").unwrap(),
-            project_id: symbiote_domain::ProjectId::new("project-lease-refuse").unwrap(),
-            role_id: symbiote_domain::RoleId::new("worker-lease-refuse").unwrap(),
-            profile_id: symbiote_domain::RuntimeProfileId::new("profile-lease-refuse").unwrap(),
-            host_id: symbiote_domain::HostId::new("host-lease-refuse").unwrap(),
+            dispatch_id: dispatch.id().clone(),
+            project_id: store.task(&task).unwrap().project_id().clone(),
+            role_id: dispatch.contract().binding().role_id.clone(),
+            profile_id: dispatch.contract().profile().id.clone(),
+            host_id: symbiote_domain::HostId::new("host-lease-e2e").unwrap(),
         };
+        // No broker: the typed daemon gate.
+        let empty = WorkerTransports::default();
         assert!(matches!(
-            transports.resolve_leases(
+            empty.resolve_leases(
                 &credential,
                 symbiote_context::BrokerRequest {
                     scope: &scope,
                     profile_credential_refs: std::slice::from_ref(&credential),
-                    environment_grants: &[],
+                    use_credential_granted: true,
                     at: Timestamp(60),
                 },
             ),
             Err(RunnerError::NoCredentialBroker)
         ));
-        // With a broker configured but no registration: UnknownReference.
-        let with_broker = WorkerTransports::default().with_credential_broker(std::rc::Rc::new(
+        // Broker without a registration: UnknownReference.
+        let bare_broker = WorkerTransports::default().with_credential_broker(std::rc::Rc::new(
             std::cell::RefCell::new(symbiote_context::CredentialBroker::new()),
         ));
         assert!(matches!(
-            with_broker.resolve_leases(
+            bare_broker.resolve_leases(
                 &credential,
                 symbiote_context::BrokerRequest {
                     scope: &scope,
                     profile_credential_refs: std::slice::from_ref(&credential),
-                    environment_grants: &[],
+                    use_credential_granted: true,
                     at: Timestamp(60),
                 },
             ),
             Err(RunnerError::CredentialRefused("unknown_reference"))
         ));
-        assert_eq!(store.task(&_task).unwrap().state(), &TaskState::Running);
+        // Registered under the dispatch's project: the lease issues and
+        // its scope matches the contract verbatim.
+        let broker = std::rc::Rc::new(std::cell::RefCell::new(
+            symbiote_context::CredentialBroker::new(),
+        ));
+        broker
+            .borrow_mut()
+            .register(
+                credential.clone(),
+                scope.project_id.clone(),
+                "OPENAI_API_KEY".into(),
+                b"sk-fixture-lease-e2e".to_vec(),
+            )
+            .unwrap();
+        let configured = WorkerTransports::default().with_credential_broker(broker.clone());
+        let lease = configured
+            .resolve_leases(
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &scope,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    use_credential_granted: dispatch
+                        .contract()
+                        .binding()
+                        .access
+                        .grants
+                        .contains(&symbiote_domain::Permission::UseCredential),
+                    at: Timestamp(60),
+                },
+            )
+            .unwrap()
+            .expect("the fixture grants UseCredential");
+        assert_eq!(lease.scope, scope);
+        let (label, value) = lease.materialize(Timestamp(61)).unwrap();
+        assert_eq!(label, "OPENAI_API_KEY");
+        assert_eq!(value, "sk-fixture-lease-e2e");
+        // A cross-project dispatch scope for the SAME reference: refused.
+        let foreign = symbiote_context::LeaseScope {
+            project_id: symbiote_domain::ProjectId::new("project-foreign").unwrap(),
+            ..scope.clone()
+        };
+        assert!(matches!(
+            configured.resolve_leases(
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &foreign,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    use_credential_granted: true,
+                    at: Timestamp(60),
+                },
+            ),
+            Err(RunnerError::CredentialRefused("cross_project_denied"))
+        ));
+        // Revocation flips the next resolution to the sticky refusal.
+        broker.borrow_mut().revoke(&credential);
+        assert!(matches!(
+            configured.resolve_leases(
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &scope,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    use_credential_granted: true,
+                    at: Timestamp(60),
+                },
+            ),
+            Err(RunnerError::CredentialRefused("revoked"))
+        ));
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
     }
 
     /// Test fixtures for the store wiring. Mirrors the store's own
@@ -1610,10 +1677,17 @@ mod tests {
                     roles.clone(),
                 )
                 .unwrap();
+            // UseCredential is in the base grants so the credential-lease
+            // path (#217) can pass for profiles that reference a credential
+            // (the daemon gates leases on it).
             let access = AccessSnapshot {
                 project_id: project.id.clone(),
                 roots: project.roots.clone(),
-                grants: BTreeSet::from([Permission::ReadRoot, Permission::ExecuteProcess]),
+                grants: BTreeSet::from([
+                    Permission::ReadRoot,
+                    Permission::ExecuteProcess,
+                    Permission::UseCredential,
+                ]),
                 policy_revision: Revision(1),
             };
             let lead_policy = symbiote_domain::RolePolicy {
@@ -1634,6 +1708,7 @@ mod tests {
                 Permission::ReadRoot,
                 Permission::ExecuteProcess,
                 Permission::MutateStream,
+                Permission::UseCredential,
             ]);
             let worker_access_for_binding = worker_access.clone();
             let worker_policy = symbiote_domain::RolePolicy {
@@ -1792,6 +1867,7 @@ mod tests {
                         Control::Cancellation,
                         Control::CompletionAuthority,
                         Control::Process,
+                        Control::Credentials,
                     ]
                     .into_iter()
                     .map(|c| (c, EnforcementStrength::HostEnforced))
@@ -1890,6 +1966,7 @@ mod tests {
                     Control::Cancellation,
                     Control::CompletionAuthority,
                     Control::Process,
+                    Control::Credentials,
                 ]
                 .into_iter()
                 .map(|c| {

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -95,6 +95,12 @@ pub struct WorkerTransports {
     /// The operator's sandbox shell-executor composition. Absent means
     /// declared shell tools stay propose-only on native runs.
     shell: Option<Box<dyn ShellExecutorFactory>>,
+    /// The operator's credential broker (#217). Absent means runs resolve
+    /// context only — no credential leases are issued, and a profile
+    /// referencing a credential gets the typed `NoCredentialBroker`
+    /// refusal instead of a silent empty lease. The broker itself holds
+    /// the ONLY plaintext; nothing here serializes values.
+    pub(crate) broker: Option<std::rc::Rc<std::cell::RefCell<symbiote_context::CredentialBroker>>>,
     /// The Host's reserved-location base directory for derived worktrees
     /// (the premise symbiote-worktrees verifies). Empty means worktree
     /// provisioning has no configured base and refuses.
@@ -122,6 +128,21 @@ impl WorkerTransports {
     pub fn with_shell_executor(mut self, factory: Box<dyn ShellExecutorFactory>) -> Self {
         self.shell = Some(factory);
         self
+    }
+
+    /// Attaches the operator's credential broker. The broker is shared
+    /// (registration and revocation are operator surfaces outside the run
+    /// path); a run only ever reads leases from it.
+    pub fn with_credential_broker(
+        mut self,
+        broker: std::rc::Rc<std::cell::RefCell<symbiote_context::CredentialBroker>>,
+    ) -> Self {
+        self.broker = Some(broker);
+        self
+    }
+
+    pub fn broker_configured(&self) -> bool {
+        self.broker.is_some()
     }
 
     pub fn native_configured(&self) -> bool {
@@ -191,6 +212,38 @@ impl WorkerTransports {
             None => Ok(None),
         }
     }
+
+    /// Resolves credential leases for one dispatch from the operator's
+    /// broker. Refusal identities are mapped payload-free; a lease's
+    /// plaintext NEVER passes through the runner — leases are returned to
+    /// the caller, which materializes them only inside the sandbox launch
+    /// composition (native env) or hands nothing to the harness (external
+    /// credentials stay harness-owned; this method is native-only by
+    /// construction and is not called for external runs).
+    pub fn resolve_leases(
+        &self,
+        reference: &symbiote_domain::CredentialReferenceId,
+        request: symbiote_context::BrokerRequest<'_>,
+    ) -> Result<Option<symbiote_context::CredentialLease>, RunnerError> {
+        let Some(broker) = self.broker.as_ref() else {
+            return Err(RunnerError::NoCredentialBroker);
+        };
+        broker
+            .borrow()
+            .resolve(reference, request)
+            .map(Some)
+            .map_err(|error| RunnerError::CredentialRefused(broker_error_name(error)))
+    }
+}
+
+fn broker_error_name(error: symbiote_context::BrokerError) -> &'static str {
+    match error {
+        symbiote_context::BrokerError::UnknownReference => "unknown_reference",
+        symbiote_context::BrokerError::Revoked => "revoked",
+        symbiote_context::BrokerError::CrossProjectDenied => "cross_project_denied",
+        symbiote_context::BrokerError::NotReferencedByProfile => "not_referenced_by_profile",
+        symbiote_context::BrokerError::EnvironmentDenied => "environment_denied",
+    }
 }
 
 /// Builds one native inference transport per run. Tests install a factory
@@ -247,6 +300,13 @@ pub enum RunnerError {
     /// The configured shell executor factory refused to build. Nothing ran
     /// and nothing was filed.
     ShellExecutorBuild(&'static str),
+    /// The dispatch's profile references a credential, but the operator
+    /// has not configured a credential broker. Nothing ran and nothing
+    /// was filed — the run cannot receive its referenced credentials.
+    NoCredentialBroker,
+    /// The operator's broker refused this dispatch's lease (cross-project
+    /// reference, revoked, ungranted environment). Typed, payload-free.
+    CredentialRefused(&'static str),
 }
 
 impl std::fmt::Display for RunnerError {
@@ -1317,6 +1377,140 @@ mod tests {
         let _ = std::fs::remove_dir_all(&worktree);
     }
 
+    #[test]
+    fn run_context_resolves_from_store_and_reaches_the_loop_prompt() {
+        // End to end through the real store fixture: the run prompt now
+        // carries the origin work item's description AND its structured
+        // guidance (requirements/constraints/acceptance), resolved by
+        // symbiote-context over the store-backed source. The scripted
+        // transport asserts the rendered sections arrived in the task
+        // prompt it received.
+        let (mut store, task, dispatch) =
+            store_with_running_task("ctx-resolve", RuntimeKind::NativeSymbiote);
+        struct PromptAssertor {
+            seen: std::cell::RefCell<Option<String>>,
+        }
+        impl symbiote_native_agent::InferenceTransport for PromptAssertor {
+            fn request(
+                &mut self,
+                request: &symbiote_runtime_sdk::provider::ProviderRequest,
+                _model: &symbiote_runtime_sdk::provider::ModelDescriptor,
+            ) -> Result<
+                symbiote_runtime_sdk::provider::ProviderResponse,
+                symbiote_runtime_sdk::provider::ProviderError,
+            > {
+                use symbiote_runtime_sdk::provider::{
+                    FinishReason, PROVIDER_CONTRACT_VERSION, ProviderResponse,
+                };
+                *self.seen.borrow_mut() = Some(
+                    request
+                        .messages
+                        .iter()
+                        .filter_map(|m| {
+                            m.content.iter().find_map(|p| match p {
+                                symbiote_runtime_sdk::provider::InputPart::Text { text } => {
+                                    Some(text.clone())
+                                }
+                                _ => None,
+                            })
+                        })
+                        .next()
+                        .unwrap_or_default(),
+                );
+                Ok(ProviderResponse {
+                    schema_version: PROVIDER_CONTRACT_VERSION,
+                    request_id: request.request_id.clone(),
+                    provider_id: request.provider_id.clone(),
+                    model_id: request.model_id.clone(),
+                    text: "done".into(),
+                    tool_calls: Vec::new(),
+                    finish_reason: FinishReason::Stop,
+                    usage: symbiote_runtime_sdk::provider::TokenUsage::Known {
+                        input_tokens: 1,
+                        output_tokens: 1,
+                        cached_input_tokens: None,
+                        reasoning_tokens: None,
+                    },
+                })
+            }
+        }
+        let assertor = PromptAssertor {
+            seen: std::cell::RefCell::new(None),
+        };
+        let mut transport = assertor;
+        let outcome = run_native(
+            &mut store,
+            &task,
+            &dispatch,
+            "Owns task ctx-resolve\n\nRequirements:\n- requirement-of-ctx-resolve\n\nConstraints:\n- constraint-of-ctx-resolve\n\nAcceptance criteria:\n- acceptance-of-ctx-resolve",
+            &mut transport,
+            Timestamp(60),
+        )
+        .unwrap();
+        assert!(outcome.completion_filed);
+        // The store-backed resolution path: the task's origin work is
+        // resolvable and carries the fixture's structured guidance.
+        let (project, origin_work) =
+            crate::context_resolution::task_origin_work(&store, &task).unwrap();
+        let work = store.work_item(&project, &origin_work).unwrap();
+        let spec = work.spec();
+        assert_eq!(spec.requirements, vec!["requirement-of-ctx-resolve"]);
+        assert_eq!(spec.acceptance, vec!["acceptance-of-ctx-resolve"]);
+        // The loop received the prompt the daemon renders from these parts.
+        let seen = transport.seen.borrow().clone().unwrap_or_default();
+        assert!(seen.starts_with("Owns task ctx-resolve"));
+        assert!(seen.contains("Requirements:\n- requirement-of-ctx-resolve"));
+        assert!(seen.contains("Acceptance criteria:\n- acceptance-of-ctx-resolve"));
+    }
+
+    #[test]
+    fn lease_refusals_are_typed_and_broker_configured_gate() {
+        // The broker seam: without a broker, a credential-referencing
+        // dispatch refuses with NoCredentialBroker; with one, scope checks
+        // produce typed refusals (unknown → revoked ordering verified in
+        // symbiote-context's own tests; here the transport-level mapping).
+        let (store, _task, _dispatch) =
+            store_with_running_task("lease-refuse", RuntimeKind::NativeSymbiote);
+        let credential = symbiote_domain::CredentialReferenceId::new("credential").unwrap();
+        let transports = WorkerTransports::default();
+        let scope = symbiote_context::LeaseScope {
+            dispatch_id: symbiote_domain::DispatchId::new("disp-lease-refuse").unwrap(),
+            project_id: symbiote_domain::ProjectId::new("project-lease-refuse").unwrap(),
+            role_id: symbiote_domain::RoleId::new("worker-lease-refuse").unwrap(),
+            profile_id: symbiote_domain::RuntimeProfileId::new("profile-lease-refuse").unwrap(),
+            host_id: symbiote_domain::HostId::new("host-lease-refuse").unwrap(),
+        };
+        assert!(matches!(
+            transports.resolve_leases(
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &scope,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    environment_grants: &[],
+                    at: Timestamp(60),
+                },
+            ),
+            Err(RunnerError::NoCredentialBroker)
+        ));
+        // With a broker configured but no registration: UnknownReference.
+        let with_broker = WorkerTransports::default().with_credential_broker(std::rc::Rc::new(
+            std::cell::RefCell::new(symbiote_context::CredentialBroker::new()),
+        ));
+        assert!(matches!(
+            with_broker.resolve_leases(
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &scope,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    environment_grants: &[],
+                    at: Timestamp(60),
+                },
+            ),
+            Err(RunnerError::CredentialRefused("unknown_reference"))
+        ));
+        assert_eq!(store.task(&_task).unwrap().state(), &TaskState::Running);
+    }
+
     /// Test fixtures for the store wiring. Mirrors the store's own
     /// preparation_tests fixture: a full project/team/binding/provider
     /// composition whose profile carries the requested runtime kind.
@@ -1629,10 +1823,10 @@ mod tests {
                 objective_class: Some(ObjectiveClass::Maintenance),
                 parent: None,
                 dependencies: BTreeSet::new(),
-                requirements: vec![],
-                constraints: vec![],
+                requirements: vec![format!("requirement-of-{tag}")],
+                constraints: vec![format!("constraint-of-{tag}")],
                 risks: vec![],
-                acceptance: vec![],
+                acceptance: vec![format!("acceptance-of-{tag}")],
                 priority: 1,
                 budget: None,
                 external_references: vec![],

--- a/crates/symbiote-host/src/service.rs
+++ b/crates/symbiote-host/src/service.rs
@@ -567,10 +567,56 @@ fn execute(
                 &reservation_base,
             )
             .map_err(worker_error)?;
+            let context = resolve_run_context(store, task_id, current)?;
+            let prompt = symbiote_context::render_prompt(&context);
             match runtime {
                 symbiote_domain::RuntimeKind::NativeSymbiote => {
-                    let prompt = origin_prompt(store, task_id)?;
                     let mut transport = workers.native_build().map_err(worker_error)?;
+                    // Credential leases (#217): the dispatch's profile
+                    // references a credential, so the operator's broker
+                    // must be configured and must grant THIS dispatch's
+                    // scope. Cross-project references are refused by
+                    // construction; with no broker the run refuses rather
+                    // than proceeding without a credential it declared.
+                    // Values never enter the journal — the lease stays in
+                    // process memory and is dropped with the run.
+                    let credential = current.contract().profile().credential.clone();
+                    let scope = symbiote_context::LeaseScope {
+                        dispatch_id: current.id().clone(),
+                        project_id: context.project_id.clone(),
+                        role_id: current.contract().binding().role_id.clone(),
+                        profile_id: current.contract().profile().id.clone(),
+                        host_id: this_host.clone(),
+                    };
+                    let profile_refs = [credential.clone()];
+                    let grants: Vec<String> = current
+                        .contract()
+                        .binding()
+                        .access
+                        .grants
+                        .iter()
+                        .map(|g| format!("{g:?}"))
+                        .collect();
+                    let lease = workers
+                        .resolve_leases(
+                            &credential,
+                            symbiote_context::BrokerRequest {
+                                scope: &scope,
+                                profile_credential_refs: &profile_refs,
+                                environment_grants: &grants,
+                                at,
+                            },
+                        )
+                        .map_err(worker_error)?;
+                    // A lease materializes into the loop's prompt envelope
+                    // boundary only: the value itself stays inside the
+                    // process and is dropped after the run. The native loop
+                    // transport composition receives the prompt; lease
+                    // injection into the sandbox env is the next slice
+                    // (the current loop carries no env mechanism yet), so
+                    // holding an unmaterialized lease here documents the
+                    // boundary without pretending injection exists.
+                    let _materialization_pending = lease;
                     // Shell tool execution is the operator's composition:
                     // with a configured executor factory, declared shell
                     // tools run through the sandbox inside the provisioned
@@ -614,7 +660,6 @@ fn execute(
                     })))
                 }
                 symbiote_domain::RuntimeKind::ExternalHarness => {
-                    let prompt = origin_prompt(store, task_id)?;
                     let mut transport = workers.external_build().map_err(worker_error)?;
                     // The sandboxed launcher mounts the reserved worktree at
                     // /workspace; that is the only cwd the harness sees.
@@ -1151,23 +1196,41 @@ fn now_timestamp() -> Result<Timestamp, ProtocolError> {
     ))
 }
 
-/// The worker's task prompt comes from canonical state — the task origin's
-/// classified work item description — never from caller input.
-fn origin_prompt(store: &mut Store, task_id: &TaskId) -> Result<String, ProtocolError> {
-    let task = store.task(task_id).map_err(storage_error)?;
-    let origin = store
-        .task_origin(&task.project_id().clone(), task_id)
-        .map_err(storage_error)?
-        .ok_or_else(|| ProtocolError::new(ErrorCode::FailedPrecondition))?;
-    let reference = origin.reference();
-    let work = store
-        .work_item(&task.project_id().clone(), &reference.id)
-        .map_err(storage_error)?;
-    let description = work.spec().description.clone();
-    if description.trim().is_empty() {
-        return Err(ProtocolError::new(ErrorCode::FailedPrecondition));
-    }
-    Ok(description)
+/// The worker's task context comes from canonical state — the task origin's
+/// classified work item (description, requirements, constraints, risks,
+/// acceptance) plus the dispatch contract's own budget and access — never
+/// from caller input. Resolution failures map to stable protocol errors
+/// that carry no store or task text.
+fn resolve_run_context(
+    store: &Store,
+    task_id: &TaskId,
+    dispatch: &symbiote_domain::Dispatch,
+) -> Result<symbiote_context::ResolvedContext, ProtocolError> {
+    let (project_id, origin_work) =
+        crate::context_resolution::task_origin_work(store, task_id).map_err(context_error)?;
+    let contract = dispatch.contract();
+    let inputs = symbiote_context::ResolutionInputs {
+        dispatch_id: dispatch.id(),
+        task_id,
+        project_id: &project_id,
+        origin_work: &origin_work,
+        context: contract.binding().context.clone(),
+        access: contract.binding().access.clone(),
+    };
+    let source = crate::context_resolution::StoreContextSource { store };
+    symbiote_context::resolve_context(&source, inputs).map_err(context_error)
+}
+
+fn context_error(error: symbiote_context::ResolutionError) -> ProtocolError {
+    let mut protocol_error = ProtocolError::new(ErrorCode::FailedPrecondition);
+    protocol_error.message = match error {
+        symbiote_context::ResolutionError::NoPrompt => "task origin provides no run prompt".into(),
+        symbiote_context::ResolutionError::Overbound => {
+            "task origin text exceeds structural bounds".into()
+        }
+        symbiote_context::ResolutionError::StoreFailed => "store operation refused".into(),
+    };
+    protocol_error
 }
 
 fn dispatch_binding_refused() -> ProtocolError {
@@ -1206,6 +1269,12 @@ fn worker_error(error: crate::runner::RunnerError) -> ProtocolError {
         }
         crate::runner::RunnerError::ShellExecutorBuild(_) => {
             "worker shell executor factory refused to build".into()
+        }
+        crate::runner::RunnerError::NoCredentialBroker => {
+            "no credential broker configured for this dispatch's credential reference".into()
+        }
+        crate::runner::RunnerError::CredentialRefused(reason) => {
+            format!("credential lease refused: {reason}")
         }
         crate::runner::RunnerError::NoHostPath => "no repository placement for this host".into(),
         crate::runner::RunnerError::NoReservationBase => {

--- a/crates/symbiote-host/src/service.rs
+++ b/crates/symbiote-host/src/service.rs
@@ -574,12 +574,17 @@ fn execute(
                     let mut transport = workers.native_build().map_err(worker_error)?;
                     // Credential leases (#217): the dispatch's profile
                     // references a credential, so the operator's broker
-                    // must be configured and must grant THIS dispatch's
-                    // scope. Cross-project references are refused by
-                    // construction; with no broker the run refuses rather
-                    // than proceeding without a credential it declared.
-                    // Values never enter the journal — the lease stays in
-                    // process memory and is dropped with the run.
+                    // must be configured and THIS dispatch's binding
+                    // access must grant `UseCredential` — the typed
+                    // authority that a credential lease may issue at all.
+                    // Cross-project references are refused by the broker's
+                    // own project check; with no broker the run refuses
+                    // rather than proceeding without a credential it
+                    // declared. The lease is issued, held for this run's
+                    // scope check, and DROPPED UNMATERIALIZED: the native
+                    // loop has no environment-injection mechanism yet, so
+                    // no value moves anywhere. Values never enter the
+                    // journal — the lease lives in process memory only.
                     let credential = current.contract().profile().credential.clone();
                     let scope = symbiote_context::LeaseScope {
                         dispatch_id: current.id().clone(),
@@ -589,34 +594,24 @@ fn execute(
                         host_id: this_host.clone(),
                     };
                     let profile_refs = [credential.clone()];
-                    let grants: Vec<String> = current
+                    let use_credential_granted = current
                         .contract()
                         .binding()
                         .access
                         .grants
-                        .iter()
-                        .map(|g| format!("{g:?}"))
-                        .collect();
+                        .contains(&symbiote_domain::Permission::UseCredential);
                     let lease = workers
                         .resolve_leases(
                             &credential,
                             symbiote_context::BrokerRequest {
                                 scope: &scope,
                                 profile_credential_refs: &profile_refs,
-                                environment_grants: &grants,
+                                use_credential_granted,
                                 at,
                             },
                         )
                         .map_err(worker_error)?;
-                    // A lease materializes into the loop's prompt envelope
-                    // boundary only: the value itself stays inside the
-                    // process and is dropped after the run. The native loop
-                    // transport composition receives the prompt; lease
-                    // injection into the sandbox env is the next slice
-                    // (the current loop carries no env mechanism yet), so
-                    // holding an unmaterialized lease here documents the
-                    // boundary without pretending injection exists.
-                    let _materialization_pending = lease;
+                    drop(lease);
                     // Shell tool execution is the operator's composition:
                     // with a configured executor factory, declared shell
                     // tools run through the sandbox inside the provisioned

--- a/docs/contracts/context-credential-resolution.md
+++ b/docs/contracts/context-credential-resolution.md
@@ -18,15 +18,22 @@ halves the run must never conflate:
 
 - **Credentials (what the run may use).** `CredentialBroker` is the
   operator's process-local registry: secrets registered per
-  `CredentialReferenceId` with an owning project and an environment label.
+  `CredentialReferenceId` with an owning project and an environment label
+  (the label is the materialization NAME, not an authorization surface).
   `resolve` issues a short-lived `CredentialLease` (5-minute window,
-  expiry-checked at materialization) only when the dispatch's profile
-  references the credential, the owning project matches the dispatch's
-  project, and the environment label is granted by the binding access.
-  Distinct typed refusals: `UnknownReference`, `Revoked`, `CrossProjectDenied`,
-  `NotReferencedByProfile`, `EnvironmentDenied`. Values are zeroized on
-  drop, never serialized (no serde on the material type), never appear in
-  Debug, the store, the journal, manifests, task text, or events.
+  expiry-checked at materialization with distinct `Expired`/`NotYetValid`
+  identities) only when the dispatch's profile references the credential,
+  the owning project matches the dispatch's project, AND the binding
+  access grants `Permission::UseCredential` — the domain's typed authority
+  that a credential lease may issue at all (the dispatch compiler requires
+  `Control::Credentials` host enforcement whenever that permission is
+  granted). Distinct typed refusals: `UnknownReference`, `Revoked`,
+  `CrossProjectDenied`, `NotReferencedByProfile`, `UseCredentialNotGranted`,
+  `InvalidEnvironmentLabel`, `Expired`, `NotYetValid`. Values are zeroized
+  on drop, never serialized (no serde on the material type), never appear
+  in Debug, the store, the journal, manifests, task text, or events.
+  Rotation scrubs the previous value at replacement time; the caller must
+  hand `register` the only owning `Vec` of the value.
 
 ## Wiring
 
@@ -47,16 +54,20 @@ boundary). Refusals surface as `credential lease refused: <reason>` /
   typed refusal, never a stale value. OS keychain integration and the
   encrypted-at-rest fallback are later slices.
 - **Revocation is sticky per reference id**: a revoked reference can never
-  be re-registered (rotation uses a NEW reference id). Revocation of active
-  processes' retained values, lease cleanup of materialized files, and
+  be re-registered (rotation uses a NEW reference id). A lease ALREADY
+  issued before revocation still materializes until its own expiry —
+  active-process invalidation, lease cleanup of materialized files, and
   audit query surfaces are pending.
-- **Lease materialization is not yet consumed by a loop transport**: the
-  native loop has no environment-injection mechanism yet, so the daemon
-  holds the lease for the run boundary and drops it; env/file/stdin/header
+- **Lease materialization is not yet consumed by a loop transport**: no
+  `materialize` call exists on the daemon path — the lease is issued,
+  scope-checked, and dropped unmaterialized. Env/file/stdin/header
   injection according to adapter capability is the next slice. No live
   model turn exists — credential plumbing is exercised with fixture values
   only, and live verification remains gated on explicit user authorization
-  for credentials and billing.
+  for credentials and billing. The daemon-level positive lease path is
+  proven at the `WorkerTransports` seam with the real fixture contract
+  (the daemon's operator-provisioning surface for brokers does not exist
+  yet, so no `Host::call` test drives it).
 - Redaction across logs, terminals, artifacts, crash reports and export
   corpora, environment/resource-plan resolution (#176), and the full
   secret-descriptor model (versions, rotation windows, per-role/profile

--- a/docs/contracts/context-credential-resolution.md
+++ b/docs/contracts/context-credential-resolution.md
@@ -1,0 +1,63 @@
+# Context and credential resolution — dispatch runs (#217 slice)
+
+`symbiote-context` is the typed bridge between a started dispatch's trusted
+Host state and the exact payload a worker run receives. It resolves two
+halves the run must never conflate:
+
+- **Context (what the run sees).** `resolve_context` composes the origin
+  work item's description, requirements, constraints, risks and acceptance
+  — plus the dispatch contract's `ContextPolicy` budget and `AccessSnapshot`
+  — into a `ResolvedContext`, and `render_prompt` renders it as the task
+  prompt the loop receives. Every fact comes from the store through the
+  `ContextSource` adapter (`symbiote-host::context_resolution`); caller
+  input cannot steer it. All text is bounded per item (8 KiB with a
+  visible truncation marker) and per list (64 items, 64 KiB total);
+  structural overflow is a typed refusal (`Overbound`), never silent
+  narrowing. The daemon's `run_started_dispatch` resolves this for BOTH
+  runtimes — native and external receive the same resolved prompt.
+
+- **Credentials (what the run may use).** `CredentialBroker` is the
+  operator's process-local registry: secrets registered per
+  `CredentialReferenceId` with an owning project and an environment label.
+  `resolve` issues a short-lived `CredentialLease` (5-minute window,
+  expiry-checked at materialization) only when the dispatch's profile
+  references the credential, the owning project matches the dispatch's
+  project, and the environment label is granted by the binding access.
+  Distinct typed refusals: `UnknownReference`, `Revoked`, `CrossProjectDenied`,
+  `NotReferencedByProfile`, `EnvironmentDenied`. Values are zeroized on
+  drop, never serialized (no serde on the material type), never appear in
+  Debug, the store, the journal, manifests, task text, or events.
+
+## Wiring
+
+`WorkerTransports::with_credential_broker` attaches the operator's broker.
+The native arm of `run_started_dispatch` resolves a lease for the profile's
+`credential` reference — **with no broker configured, a native run refuses
+with the typed `NoCredentialBroker` precondition** (a profile declares its
+credential; proceeding without it would be a silent downgrade). External
+harness runs receive no native leases: harness credentials remain
+harness-owned and are never harvested into the native broker (the #217
+boundary). Refusals surface as `credential lease refused: <reason>` /
+`no credential broker configured` protocol errors — payload-free.
+
+## Honest non-claims (pending #217 scope)
+
+- The broker is **not durable**: values live in process memory only;
+  restart requires operator re-registration, and the failure mode is the
+  typed refusal, never a stale value. OS keychain integration and the
+  encrypted-at-rest fallback are later slices.
+- **Revocation is sticky per reference id**: a revoked reference can never
+  be re-registered (rotation uses a NEW reference id). Revocation of active
+  processes' retained values, lease cleanup of materialized files, and
+  audit query surfaces are pending.
+- **Lease materialization is not yet consumed by a loop transport**: the
+  native loop has no environment-injection mechanism yet, so the daemon
+  holds the lease for the run boundary and drops it; env/file/stdin/header
+  injection according to adapter capability is the next slice. No live
+  model turn exists — credential plumbing is exercised with fixture values
+  only, and live verification remains gated on explicit user authorization
+  for credentials and billing.
+- Redaction across logs, terminals, artifacts, crash reports and export
+  corpora, environment/resource-plan resolution (#176), and the full
+  secret-descriptor model (versions, rotation windows, per-role/profile
+  scopes, Host binding beyond the lease scope) remain with #217.


### PR DESCRIPTION
Closes nothing — slice of #217 (context/credential resolution; the full secret-broker scope stays open). Serves #269's #217 dependency and both worker loops' context path.

## What this does

Dispatch activation now resolves the run's full context and credential authorization from trusted store state:

- **Context**: `resolve_context` composes the origin work item's description, requirements, constraints, risks and acceptance — plus the dispatch contract's `ContextPolicy` budget and `AccessSnapshot` — into a `ResolvedContext`; `render_prompt` renders the loop's task prompt. Previously `origin_prompt` carried only the description; the structured guidance existed in the store but no run ever received it. All text bounded per item (8 KiB, visible marker) and per list (64 items / 64 KiB total); structural overflow is the typed `Overbound` refusal, never silent narrowing. Both runtimes receive the same resolved prompt.
- **Credentials**: `CredentialBroker` — the operator's process-local registry. A 5-minute `CredentialLease` is issued ONLY when the dispatch's profile references the credential, the owning project matches the dispatch's project, and the environment label is granted by the binding access. Values are zeroized on drop, never serialized, never in Debug. **Revocation is sticky per reference id** — re-registration is refused; rotation is a NEW reference id (found by my own adversarial test: my first draft let same-project re-registration clear the revoked record, which would resurrect a compromised secret).
- **The gate**: the native arm refuses a credential-referencing dispatch with a typed `NoCredentialBroker` precondition when the operator has not configured a broker — proceeding without a declared credential would be a silent downgrade. External harness runs get NO native leases (harness credentials stay harness-owned; the #217 boundary), enforced by construction (the lease path is native-only).

## Honest non-claims

Lease materialization into loop transports is explicitly pending — the native loop has no env-injection mechanism yet, so the lease is held for the run boundary and dropped (documented in service and contract doc). OS keychain/encrypted-at-rest storage, durable broker persistence, redaction corpus, active-process revocation reporting remain with #217. No live model turn exists; fixture values only; **nothing was spent**.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings` clean; `cargo test --workspace --locked` — 69 suites, 0 failures.
- Context crate: resolution bounds/truncation on char boundaries/typed refusals (missing/empty origin, over-bound lists at the REAL 9-item overflow boundary — the first test draft had the boundary wrong and the code proved it), lease issue/expiry-window (including backdated materialization refusal)/revocation stickiness/cross-project/unreferenced/ungranted distinct refusals, Debug value-leak assertions.
- Host: store-backed resolution end to end through the full fixture into the loop's received prompt (requirements/acceptance sections asserted in the transport), `NoCredentialBroker` and `UnknownReference` typed mappings, task stays Running on refusals.

## Review record

An independent reviewer round will be posted as a PR comment (per the audit-trail practice from #507), and merge happens only on its clean verdict.