### PR TITLE
Driver restart resume: serialized journal-position restore test and honest error taxonomy (#54)

### DIFF
--- a/crates/symbiote-client-sdk/src/lib.rs
+++ b/crates/symbiote-client-sdk/src/lib.rs
@@ -24,7 +24,8 @@ use symbiote_protocol::{
 /// re-read from `cursor` after reconnect; pages advance it only over events
 /// actually returned. Cursor 0 means "bootstrap from the beginning" — the
 /// caller decides whether a full bootstrap or a tail read is appropriate.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// The JSON form is what a desktop shell persists across its own restart.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct JournalPosition {
     pub project: ProjectId,
     pub cursor: JournalCursor,
@@ -108,6 +109,12 @@ impl ClientSession {
             .find(|p| &p.project == project)
             .map(|p| p.cursor)
             .unwrap_or(JournalCursor(0))
+    }
+
+    /// The positions to persist across a process restart; restore them
+    /// with [`Self::with_positions`].
+    pub fn positions(&self) -> &[JournalPosition] {
+        &self.positions
     }
 
     fn observe_page(&mut self, page: &Value, project: &ProjectId) {

--- a/crates/symbiote-workflow/src/demo.rs
+++ b/crates/symbiote-workflow/src/demo.rs
@@ -74,6 +74,12 @@ impl DemoWorkflow {
         self.driver.journal_position(project)
     }
 
+    /// The positions to persist across a desktop restart; restore with
+    /// [`Self::with_positions`].
+    pub fn positions(&self) -> Vec<symbiote_client_sdk::JournalPosition> {
+        self.driver.positions()
+    }
+
     fn register_operation() -> serde_json::Value {
         serde_json::from_str::<serde_json::Value>(include_str!(
             "../../../fixtures/project-team/register.json"
@@ -116,7 +122,7 @@ impl DemoWorkflow {
         // by the Host right after registration.
         let mut git = symbiote_repo::SystemGit::new();
         let head = symbiote_repo::observe_head(&mut git, &self.repository)
-            .map_err(|_| WorkflowError::Socket)?;
+            .map_err(|_| WorkflowError::LocalObservation)?;
         let base = head.commit.clone();
         let target = "b".repeat(40);
         let host_id = self.host_pulse()?;
@@ -187,15 +193,15 @@ impl DemoWorkflow {
         let stream_id = symbiote_domain::ChangeStreamId::new(STREAM).expect("fixture stream");
         let root_id = symbiote_domain::RootId::new(ROOT).expect("fixture root");
         let digest = symbiote_trust::Fingerprint::of(stream_id.as_str().as_bytes());
-        let seed =
-            symbiote_worktrees::policy_seed(digest.as_str()).map_err(|_| WorkflowError::Socket)?;
+        let seed = symbiote_worktrees::policy_seed(digest.as_str())
+            .map_err(|_| WorkflowError::LocalObservation)?;
         let derived = symbiote_worktrees::Derived::derive(symbiote_worktrees::DeriveInputs {
             project_id: &project,
             root_id: &root_id,
             stream_id: &stream_id,
             seed,
         })
-        .map_err(|_| WorkflowError::Socket)?;
+        .map_err(|_| WorkflowError::LocalObservation)?;
         self.call(
             "wf-task",
             serde_json::json!({"kind":"create_task","task":{"id":TASK,"project_id":PROJECT,

--- a/crates/symbiote-workflow/src/lib.rs
+++ b/crates/symbiote-workflow/src/lib.rs
@@ -40,6 +40,10 @@ pub enum WorkflowError {
     UnexpectedBody,
     /// Local filesystem/socket framing failure before anything was sent.
     Socket,
+    /// A local observation failed (git read, worktree derivation, status):
+    /// nothing touched the wire, and the failure is on this machine, not
+    /// the daemon's.
+    LocalObservation,
 }
 
 impl From<ClientError> for WorkflowError {
@@ -91,6 +95,12 @@ impl Driver {
         project: &symbiote_domain::ProjectId,
     ) -> symbiote_protocol::JournalCursor {
         self.session.journal_position(project)
+    }
+
+    /// The positions to persist across a driver restart; restore with
+    /// [`Driver::with_positions`].
+    pub fn positions(&self) -> Vec<symbiote_client_sdk::JournalPosition> {
+        self.session.positions().to_vec()
     }
 
     /// Sends one operation; a transport failure is recovered by replaying

--- a/crates/symbiote-workflow/src/lib.rs
+++ b/crates/symbiote-workflow/src/lib.rs
@@ -173,19 +173,19 @@ pub fn observe_worktree_evidence(
     stream_id: &symbiote_domain::ChangeStreamId,
 ) -> Result<WorktreeEvidence, WorkflowError> {
     let digest = symbiote_trust::Fingerprint::of(stream_id.as_str().as_bytes());
-    let seed =
-        symbiote_worktrees::policy_seed(digest.as_str()).map_err(|_| WorkflowError::Socket)?;
+    let seed = symbiote_worktrees::policy_seed(digest.as_str())
+        .map_err(|_| WorkflowError::LocalObservation)?;
     let derived = symbiote_worktrees::Derived::derive(symbiote_worktrees::DeriveInputs {
         project_id,
         root_id,
         stream_id,
         seed,
     })
-    .map_err(|_| WorkflowError::Socket)?;
+    .map_err(|_| WorkflowError::LocalObservation)?;
     let worktree = derived.worktree_path(reservation_base);
     let mut git = symbiote_repo::SystemGit::new();
-    let status =
-        symbiote_repo::observe_status(&mut git, &worktree).map_err(|_| WorkflowError::Socket)?;
+    let status = symbiote_repo::observe_status(&mut git, &worktree)
+        .map_err(|_| WorkflowError::LocalObservation)?;
     Ok(WorktreeEvidence {
         worktree,
         uncommitted: status.uncommitted,

--- a/crates/symbiote-workflow/src/socket.rs
+++ b/crates/symbiote-workflow/src/socket.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 use symbiote_protocol::MAX_RESPONSE_BYTES;
 
 pub const SOCKET_NAME: &str = "host.sock";
-const FRAME_LIMIT: usize = 64 * 1024;
 const DEADLINE: Duration = Duration::from_secs(30);
 
 fn invalid(message: &'static str) -> std::io::Error {
@@ -60,9 +59,11 @@ fn io_timeout(message: &'static str) -> std::io::Error {
 /// frame, read the bounded response. `Err` = transport failure (the
 /// command's disposition is unknown; the SDK's recover replays it).
 pub fn exchange(directory: &Path, request: &[u8]) -> std::io::Result<Vec<u8>> {
-    if request.len() > FRAME_LIMIT || request.contains(&b'\n') {
-        return Err(invalid("request must be a single bounded JSON frame"));
-    }
+    // No local re-validation of the frame: the driver's requests are
+    // built and bounded by the SDK's `build_request`, and the daemon's
+    // own `parse_request` is the enforcement point — an invalid or
+    // oversized frame comes back as a TYPED refusal (known disposition)
+    // rather than a locally-invented unknown disposition.
     let mut stream = UnixStream::connect(directory.join(SOCKET_NAME))?;
     authenticate(&stream)?;
     stream.write_all(request)?;

--- a/crates/symbiote-workflow/src/socket.rs
+++ b/crates/symbiote-workflow/src/socket.rs
@@ -58,12 +58,15 @@ fn io_timeout(message: &'static str) -> std::io::Error {
 /// One bounded exchange: connect, authenticate, write the single JSON
 /// frame, read the bounded response. `Err` = transport failure (the
 /// command's disposition is unknown; the SDK's recover replays it).
+///
+/// Precondition: `request` is already bounded by `MAX_REQUEST_BYTES` and
+/// contains no newline — the SDK's `build_request` guarantees both. There
+/// is deliberately no local re-validation: the daemon's transport frame
+/// reader is the enforcement point, and an invalid or oversized frame is
+/// answered with a TYPED refusal (known disposition) rather than a
+/// locally-invented unknown disposition that would trigger pointless
+/// recover retries.
 pub fn exchange(directory: &Path, request: &[u8]) -> std::io::Result<Vec<u8>> {
-    // No local re-validation of the frame: the driver's requests are
-    // built and bounded by the SDK's `build_request`, and the daemon's
-    // own `parse_request` is the enforcement point — an invalid or
-    // oversized frame comes back as a TYPED refusal (known disposition)
-    // rather than a locally-invented unknown disposition.
     let mut stream = UnixStream::connect(directory.join(SOCKET_NAME))?;
     authenticate(&stream)?;
     stream.write_all(request)?;

--- a/crates/symbiote-workflow/tests/end_to_end.rs
+++ b/crates/symbiote-workflow/tests/end_to_end.rs
@@ -155,18 +155,32 @@ fn write_operator_config(
         .unwrap();
 }
 
-#[test]
-fn first_release_demo_workflow_drives_daemon_end_to_end_with_restart_resume() {
-    let scratch =
-        std::env::temp_dir().join(format!("symbiote-workflow-demo-{}", std::process::id()));
+/// The demo's private environment: scratch state directory, reservation
+/// base, a real one-commit git repository, and the operator config. Each
+/// test gets its own namespace so parallel runs never collide.
+struct DemoEnv {
+    scratch: PathBuf,
+    state_dir: PathBuf,
+    reservation_base: PathBuf,
+    repo: PathBuf,
+    config_path: PathBuf,
+}
+impl Drop for DemoEnv {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.scratch);
+    }
+}
+fn demo_environment(tag: &str) -> DemoEnv {
+    let scratch = std::env::temp_dir().join(format!(
+        "symbiote-workflow-demo-{tag}-{}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&scratch);
     std::fs::create_dir_all(&scratch).unwrap();
     let state_dir = scratch.join("state");
     let reservation_base = scratch.join("worktrees");
     DirBuilder::new().mode(0o700).create(&state_dir).unwrap();
     std::fs::create_dir_all(&reservation_base).unwrap();
-    // The repository the demo "opens": a real git repository with one
-    // base commit.
     let repo = scratch.join("repo");
     std::fs::create_dir_all(&repo).unwrap();
     git(&repo, &["init", "-q", "-b", "main"]);
@@ -187,14 +201,29 @@ fn first_release_demo_workflow_drives_daemon_end_to_end_with_restart_resume() {
     );
     let config_path = scratch.join("operator-config.json");
     write_operator_config(&config_path, &reservation_base, &launcher_binary());
+    DemoEnv {
+        scratch,
+        state_dir,
+        reservation_base,
+        repo,
+        config_path,
+    }
+}
+
+#[test]
+fn first_release_demo_workflow_drives_daemon_end_to_end_with_restart_resume() {
+    let env = demo_environment("main");
+    let state_dir = &env.state_dir;
+    let reservation_base = &env.reservation_base;
+    let repo = &env.repo;
+    let config_path = &env.config_path;
 
     // Generation 1: drive the workflow up to the STARTED dispatch — the
     // point where canonical state is fully journaled — then SIGKILL the
     // daemon exactly like a crashed desktop process.
-    let mut daemon = Daemon::spawn(&state_dir, &config_path);
-    let mut workflow =
-        symbiote_workflow::DemoWorkflow::connect(&state_dir, &reservation_base, &repo)
-            .expect("connect");
+    let mut daemon = Daemon::spawn(state_dir, config_path);
+    let mut workflow = symbiote_workflow::DemoWorkflow::connect(state_dir, reservation_base, repo)
+        .expect("connect");
     let dispatch_id = workflow.start_demo().expect("demo start half");
     // The desktop shell follows the evidence trail before the crash: the
     // driver's tracked journal position is what resumes across restart.
@@ -208,7 +237,7 @@ fn first_release_demo_workflow_drives_daemon_end_to_end_with_restart_resume() {
     // Generation 2: restart on the SAME state directory. The project,
     // task, and started dispatch all survived; the driver reconnects and
     // finishes the workflow against the restarted daemon.
-    let _daemon = Daemon::spawn(&state_dir_after_kill, &config_path);
+    let _daemon = Daemon::spawn(&state_dir_after_kill, config_path);
     let outcome = workflow
         .finish_demo(&dispatch_id)
         .expect("demo finish half after restart");
@@ -235,5 +264,68 @@ fn first_release_demo_workflow_drives_daemon_end_to_end_with_restart_resume() {
         outcome.journal_cursor >= cursor_at_kill,
         "journal cursor must not go backwards across a restart"
     );
-    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn driver_restart_restores_serialized_journal_positions_and_resumes() {
+    let env = demo_environment("driver-restart");
+    let state_dir = &env.state_dir;
+    let reservation_base = &env.reservation_base;
+    let repo = &env.repo;
+    let config_path = &env.config_path;
+    let project = symbiote_domain::ProjectId::new(symbiote_workflow::demo::PROJECT).unwrap();
+
+    // Generation 1: the start half plus a read of the evidence trail —
+    // then the desktop process itself dies, taking the driver's in-memory
+    // state with it.
+    let mut daemon = Daemon::spawn(state_dir, config_path);
+    let mut workflow = symbiote_workflow::DemoWorkflow::connect(state_dir, reservation_base, repo)
+        .expect("connect");
+    let dispatch_id = workflow.start_demo().expect("demo start half");
+    let cursor_at_kill = workflow.read_journal().expect("journal read before kill");
+    assert!(
+        cursor_at_kill > 0,
+        "the journal page advanced before the kill"
+    );
+    // Persist the driver's positions exactly as a desktop shell would:
+    // serialize to disk, so the restored driver shares NO memory with the
+    // one that observed these events.
+    let positions_path = env.scratch.join("driver-positions.json");
+    std::fs::write(
+        &positions_path,
+        serde_json::to_vec(&workflow.positions()).expect("serialize positions"),
+    )
+    .unwrap();
+    let _state_dir = daemon.kill9();
+
+    // Generation 2: the daemon restarts on the same state directory and a
+    // FRESH driver is reconstructed from the serialized positions.
+    let _daemon = Daemon::spawn(state_dir, config_path);
+    let restored: Vec<symbiote_client_sdk::JournalPosition> =
+        serde_json::from_slice(&std::fs::read(&positions_path).unwrap())
+            .expect("restore serialized positions");
+    let mut workflow = symbiote_workflow::DemoWorkflow::connect(state_dir, reservation_base, repo)
+        .expect("connect")
+        .with_positions(restored);
+    assert_eq!(
+        workflow.journal_position(&project).0,
+        cursor_at_kill,
+        "the restored driver must resume exactly where the dead one stopped"
+    );
+    // Resume: the run's own events (filed after the restored position)
+    // carry the completion evidence, and the journal never rewinds.
+    let outcome = workflow
+        .finish_demo(&dispatch_id)
+        .expect("demo finish half");
+    assert!(outcome.journal_cursor >= cursor_at_kill);
+    assert_eq!(outcome.task_state, "completion_requested");
+    assert_eq!(
+        outcome.report.as_deref(),
+        Some("implemented the bounded change; produced.txt written by the sandboxed tool")
+    );
+    assert!(
+        outcome.worktree.contains("produced.txt"),
+        "worktree evidence must list produced.txt: {:?}",
+        outcome.worktree
+    );
 }


### PR DESCRIPTION
Closes the three #509 review follow-ups in the `symbiote-workflow`/`symbiote-client-sdk` crates (F-5 driver-side restore coverage, F-4 error taxonomy, F-6 socket pre-send error identity). Based on refreshed main 00ba543e.

## What this does

**1. The restore path is now proven, not just provided (F-5).** A new e2e test mirrors what a real desktop restart does: generation-1 driver runs the start half, follows the evidence trail, and **persists its journal positions to disk as JSON**; the daemon is SIGKILLed; generation 2 constructs a **fresh driver sharing no memory with the dead one**, restores the serialized positions, and must resume **exactly at the recorded cursor** (asserted before any call), then completes the workflow against the restarted daemon — the run's own events (filed after the restored position) carry the completion evidence, the report, and the worktree diff. The daemon-side SIGKILL/restart proof from #509 plus this driver-side restore together cover both halves of "restart the desktop and resume without losing canonical state".

Supporting API: `ClientSession::positions()` (the persist-side accessor paired with `with_positions`), `JournalPosition` gains a JSON form, and `DemoWorkflow`/`Driver` expose both.

**2. Honest error taxonomy (F-4).** `WorkflowError::LocalObservation` now carries local git read/worktree-derivation/status failures; `Socket` remains strictly a wire-transport/local-framing failure. A desktop UI branching on the variant no longer misreads a filesystem failure as a daemon problem.

**3. No locally-invented unknown dispositions (F-6).** The socket launcher drops its redundant pre-send frame check: the SDK's `build_request` already bounds requests, and the daemon's `parse_request` is the enforcement point — an invalid or oversized frame comes back as a **typed refusal (known disposition)** instead of a locally synthesized transport failure that would trigger pointless recover retries.

## Verification

- New test `driver_restart_restores_serialized_journal_positions_and_resumes` passes alongside the original demo e2e (both SIGKILL-based).
- Full local gauntlet green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`.
- The shared demo environment was factored into one helper; each test gets a private scratch namespace.

## Standing gate (unchanged)

Live model-turn verification for BOTH runtimes (native OpenAI Responses API, Codex App Server) requires explicit user authorization for credentials and billing. Nothing spent; the fixture model transport remains explicitly labeled; external execution never falls back to native billing.