### PR TITLE
Both worker loops file elevation asks without granting (#269)

### DIFF
--- a/crates/symbiote-external-agent/src/lib.rs
+++ b/crates/symbiote-external-agent/src/lib.rs
@@ -264,6 +264,7 @@ pub struct ExternalSession {
     harness_thread_id: Option<String>,
     turns_observed: u32,
     approvals_refused: u32,
+    refused: Vec<ApprovalRefusal>,
     usage_turns: u32,
     unreported_usage_turns: u32,
     completion_report: Option<String>,
@@ -298,6 +299,7 @@ impl ExternalSession {
             harness_thread_id: None,
             turns_observed: 0,
             approvals_refused: 0,
+            refused: Vec::new(),
             usage_turns: 0,
             unreported_usage_turns: 0,
             completion_report: None,
@@ -315,6 +317,13 @@ impl ExternalSession {
 
     pub fn harness_thread_id(&self) -> Option<&str> {
         self.harness_thread_id.as_deref()
+    }
+
+    /// The harness escalations this turn refused. Observation only: the
+    /// Host may journal an elevation *ask* from these; the driver never
+    /// grants.
+    pub fn refused_approvals(&self) -> &[ApprovalRefusal] {
+        &self.refused
     }
 
     pub fn run_summary(&self) -> ExternalRun {
@@ -567,6 +576,7 @@ impl ExternalSession {
             while let Some(request) = transport.recv_server_request()? {
                 let refusal = ApprovalRefusal::from_method(&request.method);
                 self.approvals_refused += 1;
+                self.refused.push(refusal);
                 let decision = if refusal.has_shaped_denial() {
                     ApprovalDecision::Denied
                 } else {

--- a/crates/symbiote-external-agent/src/lib.rs
+++ b/crates/symbiote-external-agent/src/lib.rs
@@ -319,11 +319,11 @@ impl ExternalSession {
         self.harness_thread_id.as_deref()
     }
 
-    /// The harness escalations this turn refused. Observation only: the
-    /// Host may journal an elevation *ask* from these; the driver never
-    /// grants.
-    pub fn refused_approvals(&self) -> &[ApprovalRefusal] {
-        &self.refused
+    /// The harness escalations this turn refused, drained so a later turn
+    /// cannot re-file earlier turns' evidence. Observation only: the Host
+    /// may journal an elevation *ask* from these; the driver never grants.
+    pub fn refused_approvals(&mut self) -> Vec<ApprovalRefusal> {
+        std::mem::take(&mut self.refused)
     }
 
     pub fn run_summary(&self) -> ExternalRun {

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -432,8 +432,37 @@ fn permission_name(permission: &Permission) -> &'static str {
     }
 }
 
+/// FNV-1a: stable across processes and Rust versions, unlike
+/// `DefaultHasher`, so a Host retry mints the same ask id after an
+/// upgrade and replays honestly instead of duplicating evidence.
+fn dispatch_id_digest(dispatch_id: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in dispatch_id.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// The ask id carries a bounded digest of the dispatch id — a DispatchId
+/// itself may run to 128 chars, which would overflow CommandId's own bound
+/// — plus the permission and clock in the clear.
+fn elevation_ask_command_id(
+    dispatch_id: &str,
+    permission: &Permission,
+    at: Timestamp,
+) -> Result<CommandId, RunnerError> {
+    CommandId::new(format!(
+        "worker-elevation-{:016x}-{}-{}",
+        dispatch_id_digest(dispatch_id),
+        permission_name(permission),
+        at.0
+    ))
+    .map_err(|error| RunnerError::Store(error.to_string()))
+}
+
 /// Files a worker elevation ask as journaled evidence. NEVER licenses:
-/// `active_elevation` still reads only decided leases. The command id is
+/// `active_elevation` still reads only decided leases. The id is
 /// dispatch+permission+clock so a Host retry of the same observed ask
 /// replays honestly.
 pub(crate) fn file_elevation_ask(
@@ -447,13 +476,7 @@ pub(crate) fn file_elevation_ask(
     let task = store
         .task(task_id)
         .map_err(|error| RunnerError::Store(error.to_string()))?;
-    let id = CommandId::new(format!(
-        "worker-elevation-{}-{}-{}",
-        dispatch.id().as_str(),
-        permission_name(&permission),
-        at.0
-    ))
-    .map_err(|error| RunnerError::Store(error.to_string()))?;
+    let id = elevation_ask_command_id(dispatch.id().as_str(), &permission, at)?;
     let ask = ElevationRequest {
         id: id.clone(),
         project_id: task.project_id().clone(),
@@ -769,9 +792,13 @@ pub fn run_external_boxed(
         .map_err(external_error)?;
     let turn_result = session.turn(task_prompt, transport).map_err(external_error);
     // File harness escalation asks even when the turn later fails: the
-    // driver already refused, and the journaled ask never licenses.
-    file_harness_elevation_asks(store, task_id, dispatch, session.refused_approvals(), at)?;
+    // driver already refused, and the journaled ask never licenses. The
+    // turn error outranks a filing failure so the operator sees why the
+    // run actually failed.
+    let refusals = session.refused_approvals();
+    let filing = file_harness_elevation_asks(store, task_id, dispatch, &refusals, at);
     turn_result?;
+    filing?;
     let stopped = session.run_summary().stopped;
     if stopped != Some(StopKind::Completed) {
         let name = match stopped {
@@ -1708,6 +1735,18 @@ mod tests {
             Err(RunnerError::CredentialRefused("revoked"))
         ));
         assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn elevation_ask_id_stays_within_the_command_id_bound() {
+        let dispatch_id = symbiote_domain::DispatchId::new("d".repeat(128)).unwrap();
+        let id = elevation_ask_command_id(
+            dispatch_id.as_str(),
+            &Permission::ExecuteProcess,
+            Timestamp(u64::MAX),
+        )
+        .unwrap();
+        assert!(id.as_str().len() <= 128);
     }
 
     #[test]

--- a/crates/symbiote-host/src/runner.rs
+++ b/crates/symbiote-host/src/runner.rs
@@ -24,9 +24,10 @@
 //! exists and none may be added: the runtime kind decides the loop, and the
 //! runner refuses mismatches.
 use symbiote_domain::{
-    Actor, CommandId, Dispatch, RuntimeKind, TaskAction, TaskCommand, TaskId, TaskState, Timestamp,
+    Actor, CommandId, Dispatch, ElevationRequest, Permission, RuntimeKind, TaskAction, TaskCommand,
+    TaskId, TaskState, Timestamp,
 };
-use symbiote_external_agent::{ExternalSession, StopKind};
+use symbiote_external_agent::{ApprovalRefusal, ExternalSession, StopKind};
 use symbiote_native_agent::{LoopError, NativeSession};
 use symbiote_runtime_sdk::events::RuntimeEventKind;
 use symbiote_store::Store;
@@ -239,6 +240,35 @@ impl WorkerTransports {
             .map(Some)
             .map_err(|error| RunnerError::CredentialRefused(broker_error_name(error)))
     }
+
+    /// Resolves a native credential lease. A `use_credential_not_granted`
+    /// refusal journals an elevation *ask* first — evidence, never a grant —
+    /// then returns the same typed refusal so the run cannot proceed.
+    pub(crate) fn resolve_native_credential(
+        &self,
+        store: &mut Store,
+        task_id: &TaskId,
+        dispatch: &Dispatch,
+        reference: &symbiote_domain::CredentialReferenceId,
+        request: symbiote_context::BrokerRequest<'_>,
+        at: Timestamp,
+    ) -> Result<Option<symbiote_context::CredentialLease>, RunnerError> {
+        match self.resolve_leases(reference, request) {
+            Ok(lease) => Ok(lease),
+            Err(RunnerError::CredentialRefused("use_credential_not_granted")) => {
+                file_elevation_ask(
+                    store,
+                    task_id,
+                    dispatch,
+                    Permission::UseCredential,
+                    "native run referenced a credential without UseCredential on the binding",
+                    at,
+                )?;
+                Err(RunnerError::CredentialRefused("use_credential_not_granted"))
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 fn broker_error_name(error: symbiote_context::BrokerError) -> &'static str {
@@ -389,6 +419,95 @@ fn file_completion(
             // decides the retry.
             RunnerError::Store(error.to_string())
         })?;
+    Ok(())
+}
+
+fn permission_name(permission: &Permission) -> &'static str {
+    match permission {
+        Permission::ReadRoot => "read_root",
+        Permission::MutateStream => "mutate_stream",
+        Permission::ExecuteProcess => "execute_process",
+        Permission::Network => "network",
+        Permission::UseCredential => "use_credential",
+    }
+}
+
+/// Files a worker elevation ask as journaled evidence. NEVER licenses:
+/// `active_elevation` still reads only decided leases. The command id is
+/// dispatch+permission+clock so a Host retry of the same observed ask
+/// replays honestly.
+pub(crate) fn file_elevation_ask(
+    store: &mut Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    permission: Permission,
+    reason: &str,
+    at: Timestamp,
+) -> Result<(), RunnerError> {
+    let task = store
+        .task(task_id)
+        .map_err(|error| RunnerError::Store(error.to_string()))?;
+    let id = CommandId::new(format!(
+        "worker-elevation-{}-{}-{}",
+        dispatch.id().as_str(),
+        permission_name(&permission),
+        at.0
+    ))
+    .map_err(|error| RunnerError::Store(error.to_string()))?;
+    let ask = ElevationRequest {
+        id: id.clone(),
+        project_id: task.project_id().clone(),
+        task_id: task_id.clone(),
+        dispatch_id: dispatch.id().clone(),
+        permission,
+        reason: reason.to_owned(),
+        requested_at: at,
+    };
+    store
+        .request_elevation(id, ask)
+        .map(|_| ())
+        .map_err(|error| RunnerError::Store(error.to_string()))
+}
+
+fn permission_for_harness_refusal(refusal: ApprovalRefusal) -> Option<Permission> {
+    match refusal {
+        ApprovalRefusal::ExecCommand
+        | ApprovalRefusal::CommandExecutionRequest
+        | ApprovalRefusal::PermissionsRequest => Some(Permission::ExecuteProcess),
+        ApprovalRefusal::ApplyPatch | ApprovalRefusal::FileChangeRequest => {
+            Some(Permission::MutateStream)
+        }
+        ApprovalRefusal::McpElicitation => Some(Permission::Network),
+        ApprovalRefusal::ToolCall | ApprovalRefusal::ToolUserInput | ApprovalRefusal::Unknown => {
+            None
+        }
+    }
+}
+
+fn file_harness_elevation_asks(
+    store: &mut Store,
+    task_id: &TaskId,
+    dispatch: &Dispatch,
+    refusals: &[ApprovalRefusal],
+    at: Timestamp,
+) -> Result<(), RunnerError> {
+    let mut filed = std::collections::BTreeSet::new();
+    for refusal in refusals {
+        let Some(permission) = permission_for_harness_refusal(*refusal) else {
+            continue;
+        };
+        if !filed.insert(permission.clone()) {
+            continue;
+        }
+        file_elevation_ask(
+            store,
+            task_id,
+            dispatch,
+            permission,
+            "external harness requested a capability beyond the dispatch binding and was refused",
+            at,
+        )?;
+    }
     Ok(())
 }
 
@@ -648,9 +767,11 @@ pub fn run_external_boxed(
     session
         .begin_thread(worktree_cwd, transport)
         .map_err(external_error)?;
-    session
-        .turn(task_prompt, transport)
-        .map_err(external_error)?;
+    let turn_result = session.turn(task_prompt, transport).map_err(external_error);
+    // File harness escalation asks even when the turn later fails: the
+    // driver already refused, and the journaled ask never licenses.
+    file_harness_elevation_asks(store, task_id, dispatch, session.refused_approvals(), at)?;
+    turn_result?;
     let stopped = session.run_summary().stopped;
     if stopped != Some(StopKind::Completed) {
         let name = match stopped {
@@ -1587,6 +1708,130 @@ mod tests {
             Err(RunnerError::CredentialRefused("revoked"))
         ));
         assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn native_credential_refusal_files_an_ask_and_never_licenses() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("native-ask", RuntimeKind::NativeSymbiote);
+        let credential = dispatch.contract().profile().credential.clone();
+        let scope = symbiote_context::LeaseScope {
+            dispatch_id: dispatch.id().clone(),
+            project_id: store.task(&task).unwrap().project_id().clone(),
+            role_id: dispatch.contract().binding().role_id.clone(),
+            profile_id: dispatch.contract().profile().id.clone(),
+            host_id: HostId::new("host-native-ask").unwrap(),
+        };
+        let broker = std::rc::Rc::new(std::cell::RefCell::new(
+            symbiote_context::CredentialBroker::new(),
+        ));
+        broker
+            .borrow_mut()
+            .register(
+                credential.clone(),
+                scope.project_id.clone(),
+                "OPENAI_API_KEY".into(),
+                b"sk-fixture-native-ask".to_vec(),
+            )
+            .unwrap();
+        let transports = WorkerTransports::default().with_credential_broker(broker);
+        let at = Timestamp(60);
+        assert!(matches!(
+            transports.resolve_native_credential(
+                &mut store,
+                &task,
+                &dispatch,
+                &credential,
+                symbiote_context::BrokerRequest {
+                    scope: &scope,
+                    profile_credential_refs: std::slice::from_ref(&credential),
+                    use_credential_granted: false,
+                    at,
+                },
+                at,
+            ),
+            Err(RunnerError::CredentialRefused("use_credential_not_granted"))
+        ));
+        assert!(
+            !store
+                .active_elevation(dispatch.id(), &Permission::UseCredential, Timestamp(61))
+                .unwrap()
+        );
+        let events = store
+            .events(store.task(&task).unwrap().project_id(), 0, 256)
+            .unwrap();
+        assert!(
+            events.events.iter().any(|event| matches!(
+                event.payload,
+                symbiote_store::EventPayload::ElevationRequested { ref ask }
+                    if ask.permission == Permission::UseCredential
+                        && ask.dispatch_id == *dispatch.id()
+            )),
+            "native credential refusal must journal an elevation ask"
+        );
+        assert_eq!(store.task(&task).unwrap().state(), &TaskState::Running);
+    }
+
+    #[test]
+    fn external_harness_refusal_files_an_ask_and_never_licenses() {
+        let (mut store, task, dispatch) =
+            store_with_running_task("external-ask", RuntimeKind::ExternalHarness);
+        let mut transport = fixture::ScriptedCodex::new(
+            vec![
+                Ok(serde_json::json!({"userAgent": format!(
+                    "symbiote/{} (Linux)",
+                    symbiote_runtime_discovery::codex::CODEX_VERSION
+                )})),
+                Ok(serde_json::json!({"thread": {"id": "thr-fixture"}})),
+                Ok(serde_json::json!({"turn": {"id": "turn-fixture"}})),
+            ],
+            vec![
+                serde_json::json!({
+                    "method": "item/completed",
+                    "params": {"threadId": "thr-fixture", "turnId": "turn-fixture",
+                        "item": {"type": "agentMessage", "id": "i1",
+                            "text": "implemented the change"}}
+                }),
+                fixture::codex_completed("completed"),
+            ],
+            vec![symbiote_external_agent::ServerRequest {
+                id: serde_json::json!(7),
+                method: "item/commandExecution/requestApproval".into(),
+                params: serde_json::json!({}),
+            }],
+        );
+        let outcome = run_external(
+            &mut store,
+            &task,
+            &dispatch,
+            "do the work",
+            "/workspace",
+            &mut transport,
+            Timestamp(60),
+        )
+        .unwrap();
+        assert!(outcome.completion_filed);
+        assert!(
+            !store
+                .active_elevation(dispatch.id(), &Permission::ExecuteProcess, Timestamp(61))
+                .unwrap()
+        );
+        let events = store
+            .events(store.task(&task).unwrap().project_id(), 0, 256)
+            .unwrap();
+        assert!(
+            events.events.iter().any(|event| matches!(
+                event.payload,
+                symbiote_store::EventPayload::ElevationRequested { ref ask }
+                    if ask.permission == Permission::ExecuteProcess
+                        && ask.dispatch_id == *dispatch.id()
+            )),
+            "external harness refusal must journal an elevation ask"
+        );
+        assert_eq!(
+            store.task(&task).unwrap().state(),
+            &TaskState::CompletionRequested
+        );
     }
 
     /// Test fixtures for the store wiring. Mirrors the store's own

--- a/crates/symbiote-host/src/service.rs
+++ b/crates/symbiote-host/src/service.rs
@@ -609,7 +609,10 @@ fn execute(
                             )
                             .map_err(storage_error)?;
                     let lease = workers
-                        .resolve_leases(
+                        .resolve_native_credential(
+                            store,
+                            task_id,
+                            current,
                             &credential,
                             symbiote_context::BrokerRequest {
                                 scope: &scope,
@@ -617,6 +620,7 @@ fn execute(
                                 use_credential_granted,
                                 at,
                             },
+                            at,
                         )
                         .map_err(worker_error)?;
                     drop(lease);

--- a/docs/contracts/context-credential-resolution.md
+++ b/docs/contracts/context-credential-resolution.md
@@ -27,8 +27,10 @@ halves the run must never conflate:
   access grants `Permission::UseCredential`, OR an explicit elevation
   lease (#269) that the owner decided for THIS dispatch and whose window
   is still open at the run's clock — the domain's typed authority that a
-  credential lease may issue at all. A worker `request_elevation` is
-  journaled evidence of the ask and never satisfies this gate. Attestation honesty: when the basis
+  credential lease may issue at all. A native run that is refused with
+  `use_credential_not_granted` journals a worker `request_elevation` as
+  evidence of the ask and then returns the same typed refusal — the ask
+  never satisfies this gate and never licenses a lease. Attestation honesty: when the basis
   is the binding grant, the dispatch compiler requires `Control::Credentials`
   host enforcement (the claim is in the contract); when the basis is an
   elevation, the contract carries no `Credentials` claim — the binding

--- a/docs/contracts/dispatch-preparation.md
+++ b/docs/contracts/dispatch-preparation.md
@@ -30,6 +30,6 @@ Least privilege at assignment (first #269 core): `Dispatch::compile` attaches an
 
 Covered by a store test (composition steps, refusal recording, replay, readback, unknown-task refusal) and a daemon test (projection → prepare → refusal recorded → replay identical → restart replay → journal lineage).
 
-Pending #205 acceptance, tracked in the issue: mixed-runtime staffing round-trips; and the remaining #269 scope: skill/MCP/secret-scope trust metadata, worker-loop elevation-request emission, mid-run policy change semantics, per-denial enforcement-layer reporting. Worker elevation asks (`request_elevation`) are journaled evidence and never license a permission; only a later owner `decide_elevation` can.
+Pending #205 acceptance, tracked in the issue: mixed-runtime staffing round-trips; and the remaining #269 scope: skill/MCP/secret-scope trust metadata, mid-run policy change semantics, per-denial enforcement-layer reporting. Both worker loops now emit elevation *asks* through the Host (`file_elevation_ask` / harness refusal mapping): a native `use_credential_not_granted` refusal and an external harness capability request are journaled as `ElevationRequested` evidence and never license a permission; only a later owner `decide_elevation` can.
 
 Applicability: security/privacy — owner authority only, no secrets, refusals recorded as evidence. Accessibility not applicable to a headless composition layer. Performance bounded by per-task record count. Linux-first, matching the Host.


### PR DESCRIPTION
Next #269 remainder slice from refreshed main `7174a9b2`: both worker loops now *emit* an elevation ask through the Host. The ask is journaled evidence. It never licenses anything. Only a later owner `decide_elevation` can grant a lease.

## What this does

**Native.** `WorkerTransports::resolve_native_credential` wraps broker resolve. A `use_credential_not_granted` refusal journals `ElevationRequested` (`UseCredential`) via `file_elevation_ask`, then returns the same typed refusal so the run cannot proceed. The ask never satisfies `active_elevation`.

**External.** The Codex driver still refuses every harness escalation. `ExternalSession::refused_approvals()` now exposes those refusals; `run_external_boxed` maps command/file/network-shaped refusals onto `ExecuteProcess` / `MutateStream` / `Network` and files one ask per distinct permission. Filing happens even if the turn later fails. The harness is still denied — the driver never grants.

**Host is the only journal writer.** Loops do not call `decide_elevation`. Command ids are `worker-elevation-{dispatch}-{permission}-{at}` so a retry of the same observed ask replays honestly.

## Honest non-claims

- Decide remains owner-only; this slice does not auto-grant.
- Still UseCredential-only on the decide path (no enforcement consumer for other permissions). Filing a `Network`/`ExecuteProcess`/`MutateStream` *ask* from the harness does not license those permissions.
- Skill/MCP/secret trust metadata, mid-run policy change semantics, two-harness demo, mixed staffing, Project isolation remain later.
- Live model-turn verification for BOTH runtimes still requires explicit user authorization for credentials and billing. Not attempted. Nothing spent.
- #269 stays open.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` including `native_credential_refusal_files_an_ask_and_never_licenses` and `external_harness_refusal_files_an_ask_and_never_licenses`

No new spending, credential changes, or paid fallback. Do not silently use native API billing for external execution or Codex credentials for native.