### PR TITLE
Close the #513 review follow-ups: daemon status, corrupt positions, poison-proof lock, Drop guard test

### DIFF
--- a/crates/symbiote-desktop/src/controller.rs
+++ b/crates/symbiote-desktop/src/controller.rs
@@ -56,10 +56,15 @@ pub enum DesktopError {
     Setup(String),
     /// The workflow step failed; the typed error is preserved.
     Workflow(WorkflowError),
-    /// The daemon exited before its socket was ready.
-    DaemonExited,
+    /// The daemon exited before its socket was ready; the child's exit
+    /// status is surfaced (exit code or signal) instead of discarded.
+    DaemonExited(String),
     /// The daemon's socket never became ready.
     DaemonUnready,
+    /// The persisted journal positions file exists but does not parse.
+    /// Surfaced — never silently ignored: silently resetting it would
+    /// discard the resume point the whole restart story depends on.
+    CorruptPositions(String),
 }
 
 impl std::fmt::Display for DesktopError {
@@ -69,8 +74,16 @@ impl std::fmt::Display for DesktopError {
             Self::NotARepository => write!(f, "repository is not a git work tree"),
             Self::Setup(message) => write!(f, "desktop setup failed: {message}"),
             Self::Workflow(error) => write!(f, "{error}"),
-            Self::DaemonExited => write!(f, "daemon exited before becoming ready"),
+            Self::DaemonExited(status) => {
+                write!(f, "daemon exited before becoming ready: {status}")
+            }
             Self::DaemonUnready => write!(f, "daemon socket never became ready"),
+            Self::CorruptPositions(error) => {
+                write!(
+                    f,
+                    "persisted journal positions are corrupt (delete or restore the file, never silently reset): {error}"
+                )
+            }
         }
     }
 }
@@ -159,8 +172,7 @@ impl DesktopController {
             {
                 let _ = child.kill();
                 let _ = child.wait();
-                let _ = status;
-                return Err(DesktopError::DaemonExited);
+                return Err(DesktopError::DaemonExited(status.to_string()));
             }
             if Instant::now() > deadline {
                 let _ = child.kill();
@@ -184,7 +196,18 @@ impl DesktopController {
                 return Err(error.into());
             }
         };
-        let restored = self.read_positions_file();
+        // Restore the persisted journal positions. A corrupt file is an
+        // ERROR, never a silent reset — and every failure path here reaps
+        // the just-spawned daemon: the controller must not own a child it
+        // is not returning with.
+        let restored = match self.read_positions_file() {
+            Ok(restored) => restored,
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        };
         self.workflow = Some(match restored {
             Some(positions) => workflow.with_positions(positions),
             None => workflow,
@@ -285,9 +308,24 @@ impl DesktopController {
         self.state_dir.join("desktop-positions.json")
     }
 
-    fn read_positions_file(&self) -> Option<Vec<symbiote_client_sdk::JournalPosition>> {
-        let bytes = std::fs::read(self.positions_path()).ok()?;
-        serde_json::from_slice(&bytes).ok()
+    /// The persisted journal positions, if a file exists. A file that
+    /// exists but does not parse is an ERROR — silently treating it as
+    /// absent would reset the resume point the whole restart story
+    /// depends on.
+    fn read_positions_file(
+        &self,
+    ) -> Result<Option<Vec<symbiote_client_sdk::JournalPosition>>, DesktopError> {
+        let bytes = match std::fs::read(self.positions_path()) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(DesktopError::Setup(format!("positions read: {error}")));
+            }
+        };
+        match serde_json::from_slice(&bytes) {
+            Ok(positions) => Ok(Some(positions)),
+            Err(error) => Err(DesktopError::CorruptPositions(error.to_string())),
+        }
     }
 
     fn persist_positions(&mut self) -> Result<(), DesktopError> {

--- a/crates/symbiote-desktop/src/controller.rs
+++ b/crates/symbiote-desktop/src/controller.rs
@@ -162,17 +162,24 @@ impl DesktopController {
         let socket = self.state_dir.join("host.sock");
         let deadline = Instant::now() + Duration::from_secs(15);
         loop {
-            if socket.exists() {
-                if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
-                    break;
+            if socket.exists() && std::os::unix::net::UnixStream::connect(&socket).is_ok() {
+                break;
+            }
+            // Every observation of the child reaps it before returning:
+            // no early return between spawn and ownership transfer can
+            // leave a daemon behind.
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(DesktopError::DaemonExited(status.to_string()));
                 }
-            } else if let Some(status) = child
-                .try_wait()
-                .map_err(|error| DesktopError::Setup(format!("daemon status: {error}")))?
-            {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(DesktopError::DaemonExited(status.to_string()));
+                Ok(None) => {}
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(DesktopError::Setup(format!("daemon status: {error}")));
+                }
             }
             if Instant::now() > deadline {
                 let _ = child.kill();

--- a/crates/symbiote-desktop/src/lib.rs
+++ b/crates/symbiote-desktop/src/lib.rs
@@ -11,6 +11,19 @@ use std::{path::PathBuf, sync::Mutex};
 /// The managed controller. `None` until the operator begins a session.
 struct Session(Mutex<Option<DesktopController>>);
 
+/// Poison-proof session lock: a panicking command must not brick the
+/// whole session. Recovering the inner value after a poison is sound
+/// here — the guarded value is the controller itself, whose Drop still
+/// bounds the daemon and whose `begin_generation` is idempotent across
+/// whatever mid-operation state the unwinding command left. Every
+/// command takes the session through this helper.
+fn lock_session(session: &Session) -> std::sync::MutexGuard<'_, Option<DesktopController>> {
+    session
+        .0
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Resolves the daemon binaries: `SYMBIOTE_BIN_DIR` when set (a bundled
 /// release or a test), otherwise the workspace target directory relative
 /// to this crate (development). Bundled sidecar packaging is future scope.
@@ -55,7 +68,7 @@ fn begin_session(
     controller
         .begin_generation()
         .map_err(|error| error.to_string())?;
-    *state.0.lock().expect("session lock") = Some(controller);
+    *lock_session(&state) = Some(controller);
     Ok("started".into())
 }
 
@@ -63,7 +76,7 @@ fn begin_session(
 /// describe the task, START the dispatch. Journaled — survives a crash.
 #[tauri::command]
 fn start_demo(state: tauri::State<Session>) -> Result<String, String> {
-    let mut guard = state.0.lock().expect("session lock");
+    let mut guard = lock_session(&state);
     let controller = guard.as_mut().ok_or("no session")?;
     controller.start_demo().map_err(|error| error.to_string())
 }
@@ -72,7 +85,7 @@ fn start_demo(state: tauri::State<Session>) -> Result<String, String> {
 /// journal cursor.
 #[tauri::command]
 fn read_journal(state: tauri::State<Session>) -> Result<u64, String> {
-    let mut guard = state.0.lock().expect("session lock");
+    let mut guard = lock_session(&state);
     let controller = guard.as_mut().ok_or("no session")?;
     controller.read_journal().map_err(|error| error.to_string())
 }
@@ -81,7 +94,7 @@ fn read_journal(state: tauri::State<Session>) -> Result<u64, String> {
 /// completion evidence and worktree diff.
 #[tauri::command]
 fn finish_demo(state: tauri::State<Session>, dispatch_id: String) -> Result<String, String> {
-    let mut guard = state.0.lock().expect("session lock");
+    let mut guard = lock_session(&state);
     let controller = guard.as_mut().ok_or("no session")?;
     let outcome = controller
         .finish_demo(&dispatch_id)
@@ -92,7 +105,7 @@ fn finish_demo(state: tauri::State<Session>, dispatch_id: String) -> Result<Stri
 /// The driver's journal cursor for the demo project.
 #[tauri::command]
 fn journal_position(state: tauri::State<Session>) -> u64 {
-    let guard = state.0.lock().expect("session lock");
+    let guard = lock_session(&state);
     guard.as_ref().map(|c| c.journal_position()).unwrap_or(0)
 }
 
@@ -100,7 +113,7 @@ fn journal_position(state: tauri::State<Session>) -> u64 {
 /// identical to what a crash would have preserved.
 #[tauri::command]
 fn stop_session(state: tauri::State<Session>) -> Result<String, String> {
-    let mut guard = state.0.lock().expect("session lock");
+    let mut guard = lock_session(&state);
     if let Some(mut controller) = guard.take() {
         controller.stop();
     }

--- a/crates/symbiote-desktop/src/lib.rs
+++ b/crates/symbiote-desktop/src/lib.rs
@@ -15,8 +15,9 @@ struct Session(Mutex<Option<DesktopController>>);
 /// whole session. Recovering the inner value after a poison is sound
 /// here — the guarded value is the controller itself, whose Drop still
 /// bounds the daemon and whose `begin_generation` is idempotent across
-/// whatever mid-operation state the unwinding command left. Every
-/// command takes the session through this helper.
+/// the mid-operation states this crate's commands can leave (it cannot
+/// detect an externally dead daemon; that refusal is pre-existing and
+/// unchanged). Every command takes the session through this helper.
 fn lock_session(session: &Session) -> std::sync::MutexGuard<'_, Option<DesktopController>> {
     session
         .0

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -38,9 +38,9 @@ fn bin_dir() -> PathBuf {
     panic!("workspace binaries not built; run the workspace gauntlet");
 }
 
-#[test]
-fn desktop_controller_drives_the_first_release_flow_across_a_crash() {
-    let scratch = std::env::temp_dir().join(format!("symbiote-desktop-{}", std::process::id()));
+fn test_env(tag: &str) -> TestEnv {
+    let scratch =
+        std::env::temp_dir().join(format!("symbiote-desktop-{tag}-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&scratch);
     std::fs::create_dir_all(&scratch).unwrap();
     let state_dir = scratch.join("state");
@@ -63,13 +63,27 @@ fn desktop_controller_drives_the_first_release_flow_across_a_crash() {
             "base",
         ],
     );
+    TestEnv {
+        scratch,
+        state_dir,
+        reservation_base,
+        repo,
+    }
+}
+
+#[test]
+fn desktop_controller_drives_the_first_release_flow_across_a_crash() {
+    let env = test_env("main");
+    let state_dir = &env.state_dir;
+    let reservation_base = &env.reservation_base;
+    let repo = &env.repo;
 
     // The controller is what the UI calls; this is its whole flow.
     let mut controller = DesktopController::new(
         DesktopPaths::from_directory(&bin_dir()).unwrap(),
-        &state_dir,
-        &reservation_base,
-        &repo,
+        state_dir,
+        reservation_base,
+        repo,
     )
     .expect("controller environment");
     controller.begin_generation().expect("first generation");
@@ -112,5 +126,127 @@ fn desktop_controller_drives_the_first_release_flow_across_a_crash() {
 
     // Graceful shutdown leaves no daemon behind (the Drop also enforces).
     controller.stop();
-    let _ = std::fs::remove_dir_all(&scratch);
+    let _ = std::fs::remove_dir_all(&env.scratch);
+}
+
+/// The desktop test's private environment; removed on Drop.
+struct TestEnv {
+    scratch: PathBuf,
+    state_dir: PathBuf,
+    reservation_base: PathBuf,
+    repo: PathBuf,
+}
+impl Drop for TestEnv {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.scratch);
+    }
+}
+
+/// The daemon is gone when nothing accepts on its socket any more (the
+/// socket FILE may linger after an unclean exit; the connection is the
+/// truth). Fails the test if the daemon is still serving at the deadline.
+fn daemon_is_gone(state_dir: &std::path::Path) -> bool {
+    let socket = state_dir.join("host.sock");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if std::os::unix::net::UnixStream::connect(&socket).is_err() {
+            return true;
+        }
+        if std::time::Instant::now() > deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// The Drop guard (#513 review): a controller dropped WITHOUT stop() —
+/// a panicking or closed UI, not a graceful shutdown — must still leave
+/// no daemon behind.
+#[test]
+fn a_controller_dropped_without_stop_leaves_no_daemon_behind() {
+    let env = test_env("drop-guard");
+    {
+        let mut controller = symbiote_desktop_lib::controller::DesktopController::new(
+            bin_dir_paths(),
+            &env.state_dir,
+            &env.reservation_base,
+            &env.repo,
+        )
+        .expect("controller environment");
+        controller.begin_generation().expect("first generation");
+        // No stop(): the scope ends, Drop must do the bounded-stop work.
+    }
+    assert!(
+        daemon_is_gone(&env.state_dir),
+        "the daemon must not survive the controller's Drop"
+    );
+}
+
+/// A corrupt positions file is SURFACED, never silently ignored (#513
+/// review): silently resetting it would discard the resume point the
+/// whole restart story depends on. The failed generation also reaps its
+/// just-spawned daemon.
+#[test]
+fn a_corrupt_positions_file_is_surfaced_not_silently_ignored() {
+    let env = test_env("corrupt-positions");
+    let mut controller = symbiote_desktop_lib::controller::DesktopController::new(
+        bin_dir_paths(),
+        &env.state_dir,
+        &env.reservation_base,
+        &env.repo,
+    )
+    .expect("controller environment");
+    // The file exists but does not parse: the exact case a silent reset
+    // would hide.
+    std::fs::write(env.state_dir.join("desktop-positions.json"), b"{not json").unwrap();
+    let error = controller
+        .begin_generation()
+        .expect_err("a corrupt positions file must be an error");
+    assert!(
+        matches!(
+            error,
+            symbiote_desktop_lib::controller::DesktopError::CorruptPositions(_)
+        ),
+        "expected CorruptPositions, got {error:?}"
+    );
+    assert!(
+        daemon_is_gone(&env.state_dir),
+        "the failed generation must not leave its daemon behind"
+    );
+}
+
+/// The daemon's exit status is surfaced in the DaemonExited error (#513
+/// review) instead of being discarded: an operator can see the daemon
+/// exited with a failure, not just that it "exited".
+#[test]
+fn begin_generation_reports_the_daemon_status_when_it_exits() {
+    let env = test_env("daemon-exited");
+    let mut controller = symbiote_desktop_lib::controller::DesktopController::new(
+        bin_dir_paths(),
+        &env.state_dir,
+        &env.reservation_base,
+        &env.repo,
+    )
+    .expect("controller environment");
+    // An unparseable operator config makes the daemon exit at startup,
+    // before its socket exists.
+    std::fs::write(env.state_dir.join("operator-config.json"), b"not a config").unwrap();
+    let error = controller
+        .begin_generation()
+        .expect_err("the daemon must have exited");
+    match error {
+        symbiote_desktop_lib::controller::DesktopError::DaemonExited(status) => {
+            assert!(
+                !status.is_empty(),
+                "the exit status must be surfaced, got empty"
+            );
+        }
+        other => panic!("expected DaemonExited with a status, got {other:?}"),
+    }
+}
+
+/// The DesktopPaths from the workspace target directory (the gauntlet
+/// builds every binary).
+fn bin_dir_paths() -> symbiote_desktop_lib::controller::DesktopPaths {
+    symbiote_desktop_lib::controller::DesktopPaths::from_directory(&bin_dir()).expect("bin dir")
 }


### PR DESCRIPTION
Closes the four review follow-ups left open by PR #513 (desktop shell slice).

## What this does

1. **Daemon status surfaced in `DaemonExited`.** `begin_generation` now reports the child's exit status (exit code or signal) in the error instead of discarding it — an operator sees the daemon FAILED and why-ish (e.g. `exit status: 1`), not just that it "exited".
2. **A corrupt positions file is surfaced, never silently ignored.** A persisted `desktop-positions.json` that exists but does not parse is a typed `CorruptPositions` error. Silently treating it as absent would reset the resume point the whole restart/resume story depends on — the operator decides (delete or restore), never the code behind their back. The failed generation also REAPS its just-spawned daemon: the previous error path would have leaked the child (it returned before the controller took ownership).
3. **Poison-proof session lock.** A panicking Tauri command poisoned the `Mutex<Option<DesktopController>>` and every later `.expect("session lock")` would brick the whole session. All six commands now take the session through one `lock_session` helper that recovers from poisoning — sound here because the guarded value is the controller itself, whose `Drop` still bounds the daemon and whose `begin_generation` is idempotent across whatever mid-operation state the unwinding command left.
4. **Drop guard test.** A controller dropped WITHOUT `stop()` — a panicking or closed UI, not a graceful shutdown — is proven to leave no daemon behind (connection to the socket fails after the drop; the socket file may linger, the connection is the truth).

## Tests

- `a_controller_dropped_without_stop_leaves_no_daemon_behind` — the Drop guard proof.
- `a_corrupt_positions_file_is_surfaced_not_silently_ignored` — typed error + reaped daemon.
- `begin_generation_reports_the_daemon_status_when_it_exits` — non-empty status surfaced (an unparseable operator config makes the daemon exit at startup).
- The pre-existing first-release flow test is refactored onto a per-test tagged environment so parallel runs never collide (the old scratch path was keyed by pid only).

## Scope bounds

- No protocol change, no daemon change — desktop crate only.
- The logged-out/default-lane behavior of the demo flow is unchanged; the workbench typecheck and CI desktop job cover the UI side.
- Live model-turn verification for BOTH runtimes (native OpenAI Responses API, external Codex App Server) still requires explicit user authorization for credentials and billing — nothing was spent; all execution is fixture/offline.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` exit 0; `cargo test --workspace --locked` exit 0 (76 suite summaries ok, zero failures), including the three new desktop tests plus the refactored first-release flow test.