### PR TITLE
feat(preview): bounded run diff + untracked content heads on the Preview surface (#54)

### DIFF
--- a/crates/symbiote-desktop/src/controller.rs
+++ b/crates/symbiote-desktop/src/controller.rs
@@ -305,6 +305,27 @@ impl DesktopController {
         self.workflow = None;
     }
 
+    /// Bounded diff evidence for a finished run's worktree. The
+    /// requested path must resolve inside THIS controller's reservation
+    /// base — the UI is the owner surface, but the boundary stays
+    /// structural rather than trusting the front end's path strings.
+    pub fn run_diff(&self, worktree: &str) -> Result<symbiote_repo::RunDiff, DesktopError> {
+        let requested = std::fs::canonicalize(worktree)
+            .map_err(|error| DesktopError::Setup(format!("worktree resolve: {error}")))?;
+        let base = std::fs::canonicalize(&self.reservation_base)
+            .map_err(|error| DesktopError::Setup(format!("reservation base: {error}")))?;
+        if !requested.starts_with(&base) {
+            return Err(DesktopError::Setup(
+                "worktree outside this session's reservation base".into(),
+            ));
+        }
+        let mut git = symbiote_repo::SystemGit::new();
+        let status = symbiote_repo::observe_status(&mut git, &requested)
+            .map_err(|error| DesktopError::Setup(error.to_string()))?;
+        symbiote_repo::observe_run_diff(&mut git, &requested, &status)
+            .map_err(|error| DesktopError::Setup(error.to_string()))
+    }
+
     fn workflow(&mut self) -> Result<&mut DemoWorkflow, DesktopError> {
         self.workflow.as_mut().ok_or(DesktopError::Setup(
             "no connected generation; begin one".into(),

--- a/crates/symbiote-desktop/src/controller.rs
+++ b/crates/symbiote-desktop/src/controller.rs
@@ -322,8 +322,12 @@ impl DesktopController {
         let mut git = symbiote_repo::SystemGit::new();
         let status = symbiote_repo::observe_status(&mut git, &requested)
             .map_err(|error| DesktopError::Setup(error.to_string()))?;
-        symbiote_repo::observe_run_diff(&mut git, &requested, &status)
-            .map_err(|error| DesktopError::Setup(error.to_string()))
+        // Collecting the diff itself is total: every degradation is inside
+        // the returned RunDiff (flags and notes), so a partly unreadable
+        // worktree still previews what it can.
+        Ok(symbiote_repo::observe_run_diff(
+            &mut git, &requested, &status,
+        ))
     }
 
     fn workflow(&mut self) -> Result<&mut DemoWorkflow, DesktopError> {

--- a/crates/symbiote-desktop/src/lib.rs
+++ b/crates/symbiote-desktop/src/lib.rs
@@ -43,6 +43,7 @@ fn preview_document(
     worktree: &str,
     files: &[String],
     diff: &symbiote_repo::RunDiff,
+    diff_note: &str,
 ) -> String {
     fn escape(value: &str) -> String {
         value
@@ -79,8 +80,15 @@ fn preview_document(
     document.push_str(&escape(worktree));
     document.push_str("</pre>\n");
     // The run's diff evidence — bounded upstream (symbiote-repo), escaped
-    // here like every other dynamic value.
+    // here like every other dynamic value. A gathering refusal is a note
+    // (owner-built text, escaped like everything else), so the report
+    // above still previews.
     document.push_str("<h2>Tracked diff</h2>\n");
+    if !diff_note.is_empty() {
+        document.push_str("<p>");
+        document.push_str(&escape(diff_note));
+        document.push_str("</p>\n");
+    }
     if diff.tracked_truncated {
         document.push_str("<p>The full diff exceeded the bound; this is the --stat summary.</p>\n");
     }
@@ -97,6 +105,15 @@ fn preview_document(
         document.push_str("</p>\n<pre>");
         document.push_str(&escape(&head.content));
         document.push_str("</pre>\n");
+    }
+    // The content-head cap is stated, not silent: the count below is how
+    // many untracked paths the bound left head-less.
+    if diff.untracked_omitted > 0 {
+        document.push_str("<p>");
+        document.push_str(&diff.untracked_omitted.to_string());
+        document.push_str(" further untracked path(s): content heads omitted (bound ");
+        document.push_str(&symbiote_repo::MAX_UNTRACKED_FILES.to_string());
+        document.push_str(")</p>\n");
     }
     document.push_str("<h2>Files produced (");
     document.push_str(&files.len().to_string());
@@ -183,12 +200,20 @@ fn open_preview(
     let state = app.state::<Session>();
     let (diff, diff_note) = {
         let guard = lock_session(&state);
-        let controller = guard.as_ref().ok_or("no session")?;
-        match controller.run_diff(&worktree) {
-            Ok(diff) => (diff, String::new()),
-            Err(error) => (
+        match guard.as_ref() {
+            Some(controller) => match controller.run_diff(&worktree) {
+                Ok(diff) => (diff, String::new()),
+                Err(error) => (
+                    symbiote_repo::RunDiff::default(),
+                    format!("diff unavailable: {error}"),
+                ),
+            },
+            // With no session there is no reservation base to validate the
+            // worktree against, so no diff is gathered — but the report
+            // above still previews (only the diff section degrades).
+            None => (
                 symbiote_repo::RunDiff::default(),
-                format!("diff unavailable: {error}"),
+                "diff unavailable: no active session".to_owned(),
             ),
         }
     };
@@ -199,21 +224,8 @@ fn open_preview(
         &worktree,
         &files,
         &diff,
+        &diff_note,
     );
-    let document = if diff_note.is_empty() {
-        document
-    } else {
-        // The note is owner-built text (controller error identities);
-        // escape it the same way preview_document escapes everything.
-        let escaped = diff_note
-            .replace('&', "&amp;")
-            .replace('<', "&lt;")
-            .replace('>', "&gt;");
-        document.replace(
-            "<h2>Tracked diff</h2>",
-            &format!("<p>{escaped}</p>\n<h2>Tracked diff</h2>"),
-        )
-    };
     let state = app.state::<PreviewDocument>();
     *preview_lock(&state) = document;
     if let Some(window) = app.get_webview_window("preview") {
@@ -437,6 +449,7 @@ mod preview_tests {
                 content: "worker output".into(),
                 truncated: false,
             }],
+            untracked_omitted: 0,
         };
         let document = preview_document(
             "disp_staffing-task",
@@ -448,6 +461,7 @@ mod preview_tests {
                 "<img src=x onerror=alert(2)>".to_string(),
             ],
             &hostile_diff,
+            "",
         );
         assert!(!document.contains("<script>"), "{document}");
         assert!(!document.contains("<img"), "{document}");
@@ -467,10 +481,47 @@ mod preview_tests {
     /// the isolation statement are present for the empty case too.
     #[test]
     fn an_empty_outcome_still_carries_the_isolation_statement() {
-        let document = preview_document("", "", "", "", &[], &Default::default());
+        let document = preview_document("", "", "", "", &[], &Default::default(), "");
         assert!(document.contains("default-src 'none'"));
         assert!(document.contains("no application commands"));
         assert!(document.contains("Files produced (0)"));
+        assert!(!document.contains("diff unavailable"));
+    }
+
+    /// A degraded diff is an escaped owner note; the report above it
+    /// still renders, so a refusal never costs the preview its content.
+    #[test]
+    fn a_diff_note_renders_escaped_and_keeps_the_report() {
+        let document = preview_document(
+            "disp_staffing-task",
+            "probe-test-1",
+            "the worker's report",
+            "/wt",
+            &[],
+            &Default::default(),
+            "diff unavailable: <b>no active session</b>",
+        );
+        assert!(document.contains("the worker&#39;s report"), "{document}");
+        assert!(!document.contains("<b>no active session</b>"), "{document}");
+        assert!(
+            document.contains("diff unavailable: &lt;b&gt;no active session&lt;/b&gt;"),
+            "{document}"
+        );
+        assert!(!document.to_lowercase().contains("<script"));
+    }
+
+    /// The content-head cap is stated in the document, never silent.
+    #[test]
+    fn omitted_untracked_heads_are_counted_in_the_document() {
+        let diff = symbiote_repo::RunDiff {
+            untracked_omitted: 4,
+            ..Default::default()
+        };
+        let document = preview_document("disp", "probe-1", "", "/wt", &[], &diff, "");
+        assert!(
+            document.contains("4 further untracked path(s): content heads omitted"),
+            "{document}"
+        );
     }
 }
 

--- a/crates/symbiote-desktop/src/lib.rs
+++ b/crates/symbiote-desktop/src/lib.rs
@@ -89,6 +89,13 @@ fn preview_document(
         document.push_str(&escape(diff_note));
         document.push_str("</p>\n");
     }
+    // The collector's own degradation note (not-UTF-8 tracked diff, a
+    // refusal): owner-built text naming why the hunks are absent.
+    if !diff.tracked_note.is_empty() {
+        document.push_str("<p>");
+        document.push_str(&escape(&diff.tracked_note));
+        document.push_str("</p>\n");
+    }
     if diff.tracked_truncated {
         document.push_str("<p>The full diff exceeded the bound; this is the --stat summary.</p>\n");
     }
@@ -444,11 +451,21 @@ mod preview_tests {
         let hostile_diff = symbiote_repo::RunDiff {
             tracked: "<script>alert('diff')</script> broke <b>things</b>".into(),
             tracked_truncated: true,
-            untracked: vec![symbiote_repo::UntrackedContent {
-                path: "produced.txt".into(),
-                content: "worker output".into(),
-                truncated: false,
-            }],
+            tracked_note: String::new(),
+            untracked: vec![
+                symbiote_repo::UntrackedContent {
+                    path: "produced.txt".into(),
+                    content: "worker output".into(),
+                    truncated: false,
+                },
+                // Both untracked fields are worker-controlled: they must
+                // be escaped just like the tracked diff.
+                symbiote_repo::UntrackedContent {
+                    path: "</code><script>alert('path')</script>".into(),
+                    content: "</pre><script>alert('head')</script>".into(),
+                    truncated: false,
+                },
+            ],
             untracked_omitted: 0,
         };
         let document = preview_document(
@@ -474,7 +491,36 @@ mod preview_tests {
         assert!(document.contains("default-src 'none'"));
         assert!(document.contains("Run <code>disp_staffing-task</code>"));
         assert!(document.contains("The full diff exceeded the bound"));
+        assert!(
+            document.contains("&lt;/code&gt;&lt;script&gt;alert(&#39;path&#39;)&lt;/script&gt;"),
+            "the hostile untracked path must render as escaped text"
+        );
+        assert!(
+            document.contains("&lt;/pre&gt;&lt;script&gt;alert(&#39;head&#39;)&lt;/script&gt;"),
+            "the hostile untracked content must render as escaped text"
+        );
         assert!(!document.to_lowercase().contains("<script"));
+    }
+
+    /// The collector's degradation note is rendered escaped, so a refusal
+    /// or a non-UTF-8 tracked diff is visible instead of silent.
+    #[test]
+    fn a_tracked_degradation_note_renders_escaped() {
+        let diff = symbiote_repo::RunDiff {
+            tracked: "<tracked diff is not UTF-8>".into(),
+            tracked_note: "the tracked diff is not UTF-8: <binary>".into(),
+            ..Default::default()
+        };
+        let document = preview_document("disp", "probe-1", "report", "/wt", &[], &diff, "");
+        assert!(!document.contains("<binary>"), "{document}");
+        assert!(
+            document.contains("the tracked diff is not UTF-8: &lt;binary&gt;"),
+            "{document}"
+        );
+        assert!(
+            document.contains("&lt;tracked diff is not UTF-8&gt;"),
+            "{document}"
+        );
     }
 
     /// The document's own structure must survive any input: the CSP and

--- a/crates/symbiote-desktop/src/lib.rs
+++ b/crates/symbiote-desktop/src/lib.rs
@@ -42,6 +42,7 @@ fn preview_document(
     report: &str,
     worktree: &str,
     files: &[String],
+    diff: &symbiote_repo::RunDiff,
 ) -> String {
     fn escape(value: &str) -> String {
         value
@@ -76,7 +77,28 @@ fn preview_document(
     document.push_str(&escape(report));
     document.push_str("</pre>\n<h2>Worktree</h2>\n<pre>");
     document.push_str(&escape(worktree));
-    document.push_str("</pre>\n<h2>Files produced (");
+    document.push_str("</pre>\n");
+    // The run's diff evidence — bounded upstream (symbiote-repo), escaped
+    // here like every other dynamic value.
+    document.push_str("<h2>Tracked diff</h2>\n");
+    if diff.tracked_truncated {
+        document.push_str("<p>The full diff exceeded the bound; this is the --stat summary.</p>\n");
+    }
+    document.push_str("<pre>");
+    document.push_str(&escape(&diff.tracked));
+    document.push_str("</pre>\n<h2>Untracked content heads</h2>\n");
+    for head in &diff.untracked {
+        document.push_str("<p><code>");
+        document.push_str(&escape(&head.path));
+        document.push_str("</code>");
+        if head.truncated {
+            document.push_str(" (truncated)");
+        }
+        document.push_str("</p>\n<pre>");
+        document.push_str(&escape(&head.content));
+        document.push_str("</pre>\n");
+    }
+    document.push_str("<h2>Files produced (");
     document.push_str(&files.len().to_string());
     document.push_str(")</h2>\n<ul>\n");
     document.push_str(&files_html);
@@ -154,7 +176,44 @@ fn open_preview(
             .map(|elapsed| elapsed.subsec_nanos())
             .unwrap_or_default()
     );
-    let document = preview_document(&dispatch_id, &probe_nonce, &report, &worktree, &files);
+    // The diff evidence is gathered owner-side through the controller:
+    // the worktree path must resolve inside this session's reservation
+    // base, and the observation is bounded. A refusal degrades to a
+    // note in the document — the preview still shows the report.
+    let state = app.state::<Session>();
+    let (diff, diff_note) = {
+        let guard = lock_session(&state);
+        let controller = guard.as_ref().ok_or("no session")?;
+        match controller.run_diff(&worktree) {
+            Ok(diff) => (diff, String::new()),
+            Err(error) => (
+                symbiote_repo::RunDiff::default(),
+                format!("diff unavailable: {error}"),
+            ),
+        }
+    };
+    let document = preview_document(
+        &dispatch_id,
+        &probe_nonce,
+        &report,
+        &worktree,
+        &files,
+        &diff,
+    );
+    let document = if diff_note.is_empty() {
+        document
+    } else {
+        // The note is owner-built text (controller error identities);
+        // escape it the same way preview_document escapes everything.
+        let escaped = diff_note
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;");
+        document.replace(
+            "<h2>Tracked diff</h2>",
+            &format!("<p>{escaped}</p>\n<h2>Tracked diff</h2>"),
+        )
+    };
     let state = app.state::<PreviewDocument>();
     *preview_lock(&state) = document;
     if let Some(window) = app.get_webview_window("preview") {
@@ -370,6 +429,15 @@ mod preview_tests {
     /// document carries a deny-all CSP with no script.
     #[test]
     fn worker_content_renders_as_inert_text() {
+        let hostile_diff = symbiote_repo::RunDiff {
+            tracked: "<script>alert('diff')</script> broke <b>things</b>".into(),
+            tracked_truncated: true,
+            untracked: vec![symbiote_repo::UntrackedContent {
+                path: "produced.txt".into(),
+                content: "worker output".into(),
+                truncated: false,
+            }],
+        };
         let document = preview_document(
             "disp_staffing-task",
             "probe-test-1",
@@ -379,13 +447,19 @@ mod preview_tests {
                 "produced.txt".to_string(),
                 "<img src=x onerror=alert(2)>".to_string(),
             ],
+            &hostile_diff,
         );
         assert!(!document.contains("<script>"), "{document}");
         assert!(!document.contains("<img"), "{document}");
         assert!(document.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(
+            document.contains("&lt;script&gt;alert(&#39;diff&#39;)&lt;/script&gt;"),
+            "the hostile diff must render as escaped text"
+        );
         assert!(document.contains("<li>&lt;img src=x onerror=alert(2)&gt;</li>"));
         assert!(document.contains("default-src 'none'"));
         assert!(document.contains("Run <code>disp_staffing-task</code>"));
+        assert!(document.contains("The full diff exceeded the bound"));
         assert!(!document.to_lowercase().contains("<script"));
     }
 
@@ -393,7 +467,7 @@ mod preview_tests {
     /// the isolation statement are present for the empty case too.
     #[test]
     fn an_empty_outcome_still_carries_the_isolation_statement() {
-        let document = preview_document("", "", "", "", &[]);
+        let document = preview_document("", "", "", "", &[], &Default::default());
         assert!(document.contains("default-src 'none'"));
         assert!(document.contains("no application commands"));
         assert!(document.contains("Files produced (0)"));

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -316,6 +316,18 @@ fn run_diff_observes_inside_the_reservation_base_and_refuses_outside() {
         "expected a setup refusal, got {error:?}"
     );
     let _ = std::fs::remove_dir_all(&outside);
+
+    // Containment is component-wise, not a string prefix: a sibling whose
+    // name merely starts with the base's name is outside it.
+    let prefix_sibling = env.scratch.join("worktreesEVIL");
+    std::fs::create_dir_all(&prefix_sibling).unwrap();
+    let error = controller
+        .run_diff(&prefix_sibling.display().to_string())
+        .expect_err("a name-prefix sibling must refuse");
+    assert!(
+        matches!(error, DesktopError::Setup(_)),
+        "expected a setup refusal, got {error:?}"
+    );
 }
 
 /// The containment check resolves symlinks: a link that sits inside the

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -318,6 +318,36 @@ fn run_diff_observes_inside_the_reservation_base_and_refuses_outside() {
     let _ = std::fs::remove_dir_all(&outside);
 }
 
+/// The containment check resolves symlinks: a link that sits inside the
+/// reservation base but points outside it is refused, never followed.
+#[test]
+fn run_diff_refuses_a_symlink_that_escapes_the_reservation_base() {
+    use symbiote_desktop_lib::controller::{DesktopController, DesktopError};
+    let env = test_env("run-diff-symlink");
+    let controller = DesktopController::new(
+        bin_dir_paths(),
+        &env.state_dir,
+        &env.reservation_base,
+        &env.repo,
+    )
+    .expect("controller environment");
+    std::fs::create_dir_all(&env.reservation_base).unwrap();
+    let outside =
+        std::env::temp_dir().join(format!("symbiote-run-diff-escape-{}", std::process::id()));
+    std::fs::create_dir_all(&outside).unwrap();
+    let link = env.reservation_base.join("escape");
+    std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+    let error = controller
+        .run_diff(&link.display().to_string())
+        .expect_err("a symlink out of the base must refuse");
+    assert!(
+        matches!(error, DesktopError::Setup(_)),
+        "expected a setup refusal, got {error:?}"
+    );
+    let _ = std::fs::remove_dir_all(&outside);
+}
+
 /// The DesktopPaths from the workspace target directory (the gauntlet
 /// builds every binary).
 fn bin_dir_paths() -> symbiote_desktop_lib::controller::DesktopPaths {

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -245,6 +245,79 @@ fn begin_generation_reports_the_daemon_status_when_it_exits() {
     }
 }
 
+/// The run-diff boundary (#54): a worktree inside the session's
+/// reservation base is observed (real repo, real changes); a path
+/// outside it is refused structurally.
+#[test]
+fn run_diff_observes_inside_the_reservation_base_and_refuses_outside() {
+    use symbiote_desktop_lib::controller::{DesktopController, DesktopError};
+    let env = test_env("run-diff");
+    let controller = DesktopController::new(
+        bin_dir_paths(),
+        &env.state_dir,
+        &env.reservation_base,
+        &env.repo,
+    )
+    .expect("controller environment");
+
+    // A real git repository INSIDE the reservation base, with a tracked
+    // modification and an untracked file.
+    let inner = env.reservation_base.join("inner-repo");
+    std::fs::create_dir_all(&inner).unwrap();
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&inner)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-q", "-b", "main"]);
+    std::fs::write(inner.join("tracked.txt"), "original\n").unwrap();
+    git(&["add", "."]);
+    git(&[
+        "-c",
+        "user.email=t@t",
+        "-c",
+        "user.name=t",
+        "commit",
+        "-q",
+        "-m",
+        "base",
+    ]);
+    std::fs::write(inner.join("tracked.txt"), "changed\n").unwrap();
+    std::fs::write(inner.join("produced.txt"), "worker output\n").unwrap();
+
+    let diff = controller
+        .run_diff(&inner.display().to_string())
+        .expect("inside the reservation base must observe");
+    assert!(diff.tracked.contains("+changed"), "{:?}", diff.tracked);
+    let produced = diff
+        .untracked
+        .iter()
+        .find(|head| head.path == "produced.txt")
+        .expect("untracked head");
+    assert_eq!(produced.content, "worker output\n");
+
+    // A repository OUTSIDE the reservation base is refused structurally.
+    let outside =
+        std::env::temp_dir().join(format!("symbiote-run-diff-outside-{}", std::process::id()));
+    std::fs::create_dir_all(&outside).unwrap();
+    let error = controller
+        .run_diff(&outside.display().to_string())
+        .expect_err("outside must refuse");
+    assert!(
+        matches!(error, DesktopError::Setup(_)),
+        "expected a setup refusal, got {error:?}"
+    );
+    let _ = std::fs::remove_dir_all(&outside);
+}
+
 /// The DesktopPaths from the workspace target directory (the gauntlet
 /// builds every binary).
 fn bin_dir_paths() -> symbiote_desktop_lib::controller::DesktopPaths {

--- a/crates/symbiote-repo/Cargo.toml
+++ b/crates/symbiote-repo/Cargo.toml
@@ -10,7 +10,7 @@ symbiote-domain = { path = "../symbiote-domain" }
 symbiote-worktrees = { path = "../symbiote-worktrees" }
 serde.workspace = true
 serde_json.workspace = true
-nix = { version = "=0.30.1", features = ["signal", "user"] }
+nix = { version = "=0.30.1", features = ["signal", "user", "fs"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/symbiote-repo/src/lib.rs
+++ b/crates/symbiote-repo/src/lib.rs
@@ -317,6 +317,10 @@ pub struct RunDiff {
     /// Untracked paths (at most [`MAX_UNTRACKED_FILES`], in status
     /// order) with bounded content heads.
     pub untracked: Vec<UntrackedContent>,
+    /// How many further untracked paths the [`MAX_UNTRACKED_FILES`]
+    /// bound left without a content head. Non-zero means this evidence
+    /// is partial in a way its consumers must say out loud.
+    pub untracked_omitted: usize,
 }
 
 /// One untracked path's bounded content head.
@@ -369,6 +373,7 @@ pub fn observe_run_diff(
     for path in status.untracked.iter().take(MAX_UNTRACKED_FILES) {
         diff.untracked.push(untracked_content(worktree, path));
     }
+    diff.untracked_omitted = status.untracked.len().saturating_sub(MAX_UNTRACKED_FILES);
     Ok(diff)
 }
 
@@ -414,12 +419,24 @@ fn untracked_content(worktree: &Path, path: &str) -> UntrackedContent {
     }
     let truncated = head.len() > MAX_UNTRACKED_FILE_BYTES;
     head.truncate(MAX_UNTRACKED_FILE_BYTES);
-    match String::from_utf8(head) {
+    match std::str::from_utf8(&head) {
         Ok(text) => UntrackedContent {
             path: path.to_owned(),
-            content: text,
+            content: text.to_owned(),
             truncated,
         },
+        // The byte bound cut through a multi-byte character: keep the
+        // complete character prefix. `error_len() == None` is exactly
+        // "the input ends mid-character", so a genuinely invalid byte
+        // still falls through to the placeholder below.
+        Err(error) if truncated && error.error_len().is_none() && error.valid_up_to() > 0 => {
+            UntrackedContent {
+                path: path.to_owned(),
+                content: String::from_utf8(head[..error.valid_up_to()].to_vec())
+                    .expect("a valid-UTF-8 prefix is valid UTF-8"),
+                truncated,
+            }
+        }
         Err(_) => placeholder("<non-utf8 content>"),
     }
 }
@@ -826,6 +843,62 @@ mod tests {
             .expect("untracked content head");
         assert_eq!(produced.content, "worker output\nsecond line\n");
         assert!(!produced.truncated);
+        assert_eq!(diff.untracked_omitted, 0);
+    }
+
+    /// The byte bound cutting through a multi-byte character keeps the
+    /// complete character prefix — a truncated head, never a bogus
+    /// `<non-utf8 content>` placeholder for a UTF-8 file.
+    #[test]
+    fn a_boundary_cut_keeps_the_complete_character_prefix() {
+        let repo = TempRepo::new("run-diff-utf8-bound");
+        let mut git = SystemGit::new();
+        // The leading ASCII byte makes the 16 KiB bound land inside one
+        // of the two-byte characters.
+        let text = format!("a{}", "é".repeat(MAX_UNTRACKED_FILE_BYTES));
+        std::fs::write(repo.dir.join("accents.txt"), text.as_bytes()).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let head = &diff.untracked[0];
+        assert!(head.truncated);
+        assert!(!head.content.contains("non-utf8"), "{:?}", head.content);
+        assert_eq!(head.content.len(), MAX_UNTRACKED_FILE_BYTES - 1);
+        assert!(head.content.starts_with('a'));
+        assert!(
+            head.content
+                .chars()
+                .all(|character| character == 'a' || character == 'é'),
+            "{:?}",
+            head.content
+        );
+    }
+
+    /// A genuinely invalid byte is named as non-UTF-8 content, never
+    /// rendered as mojibake or as a silent truncation.
+    #[test]
+    fn non_utf8_untracked_content_is_a_placeholder() {
+        let repo = TempRepo::new("run-diff-non-utf8");
+        let mut git = SystemGit::new();
+        std::fs::write(repo.dir.join("blob.bin"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        assert_eq!(diff.untracked[0].content, "<non-utf8 content>");
+        assert!(!diff.untracked[0].truncated);
+    }
+
+    /// The content-head cap is explicit: the paths it left out are
+    /// counted, never silently dropped.
+    #[test]
+    fn untracked_heads_are_capped_with_an_omitted_count() {
+        let repo = TempRepo::new("run-diff-cap");
+        let mut git = SystemGit::new();
+        for index in 0..(MAX_UNTRACKED_FILES + 3) {
+            std::fs::write(repo.dir.join(format!("file-{index:02}.txt")), "x\n").unwrap();
+        }
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        assert_eq!(diff.untracked.len(), MAX_UNTRACKED_FILES);
+        assert_eq!(diff.untracked_omitted, 3);
     }
 
     /// An oversized untracked file is truncated with an explicit flag,

--- a/crates/symbiote-repo/src/lib.rs
+++ b/crates/symbiote-repo/src/lib.rs
@@ -305,15 +305,27 @@ pub const MAX_UNTRACKED_FILES: usize = 32;
 /// `--stat` summary with an explicit flag, an oversized untracked file is
 /// truncated with an explicit flag, and symlinked or non-regular paths
 /// are never read (a bracketed placeholder names them instead).
+///
+/// Collection never fails the caller: a tracked diff that cannot be
+/// observed degrades to a bracketed placeholder plus a
+/// [`RunDiff::tracked_note`], and the untracked heads are collected
+/// regardless. Losing every untracked head because one tracked byte was
+/// not UTF-8 would make the preview less honest, not safer.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RunDiff {
-    /// The tracked unified diff (`git diff HEAD`), or the degraded
-    /// `--stat` summary when the full diff exceeded the output bound.
+    /// The tracked unified diff (`git diff HEAD`), the degraded `--stat`
+    /// summary when the full diff exceeded the output bound, or a
+    /// bracketed placeholder when the diff could not be observed at all
+    /// (see [`RunDiff::tracked_note`]).
     pub tracked: String,
     /// True when `tracked` is the degraded `--stat` summary, not the
     /// full diff.
     pub tracked_truncated: bool,
+    /// Why `tracked` is degraded — empty when it is the full diff. The
+    /// `--stat` degradation is described by [`RunDiff::tracked_truncated`]
+    /// instead, so the two never disagree.
+    pub tracked_note: String,
     /// Untracked paths (at most [`MAX_UNTRACKED_FILES`], in status
     /// order) with bounded content heads.
     pub untracked: Vec<UntrackedContent>,
@@ -338,80 +350,194 @@ pub struct UntrackedContent {
 }
 
 /// Observes the bounded diff evidence for a worktree whose changed-path
-/// set is already known (from [`observe_status`]).
+/// set is already known (from [`observe_status`]). Total by design: every
+/// degradation is recorded in the returned [`RunDiff`] rather than
+/// returned as an error, so one unobservable tracked diff cannot cost the
+/// caller its untracked evidence.
 pub fn observe_run_diff(
     git: &mut impl GitExecutor,
     worktree: &Path,
     status: &WorktreeStatus,
-) -> Result<RunDiff, GitError> {
+) -> RunDiff {
     let mut diff = RunDiff::default();
-    match git.run(worktree, &["diff", "HEAD", "--"]) {
-        Ok(bytes) => {
-            diff.tracked = std::str::from_utf8(&bytes)
-                .map_err(|_| GitError::MalformedOutput)?
-                .to_owned();
-        }
-        Err(GitError::OutputTooLarge) => {
-            // Degrade honestly: the summary names what changed, the flag
-            // says the full diff did not fit the bound.
-            diff.tracked_truncated = true;
-            let summary = git.run(worktree, &["diff", "HEAD", "--stat"])?;
-            diff.tracked = std::str::from_utf8(&summary)
-                .map_err(|_| GitError::MalformedOutput)?
-                .to_owned();
-        }
-        // An unborn HEAD has nothing to diff against: that is not a
-        // refusal for preview evidence — the tracked diff is empty. A
-        // real git refusal still surfaces.
-        Err(GitError::GitRefused) => {
-            if !head_is_unborn(git, worktree)? {
-                return Err(GitError::GitRefused);
-            }
-        }
-        Err(error) => return Err(error),
-    }
+    // Untracked heads are filesystem reads only, so they are collected
+    // first and survive any tracked-side failure.
     for path in status.untracked.iter().take(MAX_UNTRACKED_FILES) {
         diff.untracked.push(untracked_content(worktree, path));
     }
     diff.untracked_omitted = status.untracked.len().saturating_sub(MAX_UNTRACKED_FILES);
-    Ok(diff)
+    observe_tracked_diff(git, worktree, &mut diff);
+    diff
 }
 
-/// `rev-parse --verify -q HEAD` fails exactly on an unborn branch.
+/// Fills `diff.tracked`, or records why it could not be filled. Git's
+/// `diff` output is only non-UTF-8 when the changed content is (a binary
+/// blob, a latin-1 source file): that is a fact about the run, so it is
+/// named rather than dropped.
+fn observe_tracked_diff(git: &mut impl GitExecutor, worktree: &Path, diff: &mut RunDiff) {
+    match git.run(worktree, &["diff", "HEAD", "--"]) {
+        Ok(bytes) => match std::str::from_utf8(&bytes) {
+            Ok(text) => diff.tracked = text.to_owned(),
+            Err(_) => degrade_tracked(
+                diff,
+                "<tracked diff is not UTF-8>",
+                "the tracked diff is not UTF-8",
+            ),
+        },
+        Err(GitError::OutputTooLarge) => {
+            // Degrade honestly: the summary names what changed, the flag
+            // says the full diff did not fit the bound.
+            match git.run(worktree, &["diff", "HEAD", "--stat"]) {
+                Ok(summary) => match std::str::from_utf8(&summary) {
+                    Ok(text) => {
+                        diff.tracked = text.to_owned();
+                        diff.tracked_truncated = true;
+                    }
+                    Err(_) => degrade_tracked(
+                        diff,
+                        "<the --stat summary is not UTF-8>",
+                        "the --stat summary is not UTF-8",
+                    ),
+                },
+                Err(error) => degrade_tracked(
+                    diff,
+                    "<the --stat summary also failed>",
+                    &format!(
+                        "the --stat summary also failed after the full diff exceeded the bound: {error}"
+                    ),
+                ),
+            }
+        }
+        // An unborn HEAD has nothing to diff against: that is not a
+        // refusal for preview evidence — the tracked diff is empty. Every
+        // other refusal is named.
+        Err(GitError::GitRefused) => match head_is_unborn(git, worktree) {
+            Ok(true) => {}
+            Ok(false) => degrade_tracked(
+                diff,
+                "<git refused the tracked diff>",
+                "git refused the tracked diff",
+            ),
+            Err(error) => degrade_tracked(
+                diff,
+                "<git refused the tracked diff>",
+                &format!("git refused the tracked diff: {error}"),
+            ),
+        },
+        Err(error) => degrade_tracked(
+            diff,
+            "<the tracked diff could not be observed>",
+            &format!("the tracked diff could not be observed: {error}"),
+        ),
+    }
+}
+
+/// Records a degraded tracked diff: the placeholder is what renders, the
+/// note says why. Never sets `tracked_truncated` — that flag means the
+/// `--stat` summary specifically.
+fn degrade_tracked(diff: &mut RunDiff, placeholder: &str, note: &str) {
+    diff.tracked = placeholder.to_owned();
+    diff.tracked_note = note.to_owned();
+}
+
+/// Distinguishes an unborn HEAD from a refusal, mirroring [`observe_head`]:
+/// an unborn branch is one whose `symbolic-ref` resolves while
+/// `rev-parse HEAD` refuses. A HEAD that resolves to nothing while other
+/// refs exist is a broken HEAD, not an unborn branch, and `Ok(false)`
+/// says so.
 fn head_is_unborn(git: &mut impl GitExecutor, worktree: &Path) -> Result<bool, GitError> {
-    match git.run(worktree, &["rev-parse", "--verify", "-q", "HEAD"]) {
-        Ok(_) => Ok(false),
-        Err(GitError::GitRefused) => Ok(true),
+    match git.run(worktree, &["symbolic-ref", "--quiet", "--short", "HEAD"]) {
+        // Detached HEAD, or not a repository at all: rev-parse decides.
+        Err(GitError::GitRefused) => {
+            match git.run(worktree, &["rev-parse", "--verify", "-q", "HEAD"]) {
+                Ok(_) => Ok(false),
+                Err(error) => Err(error),
+            }
+        }
         Err(error) => Err(error),
+        Ok(_) => match git.run(worktree, &["rev-parse", "--verify", "-q", "HEAD"]) {
+            Ok(_) => Ok(false),
+            Err(GitError::GitRefused) => {
+                // Nothing is reachable from HEAD. That is an unborn branch
+                // only when the repository holds no refs at all.
+                match git.run(worktree, &["show-ref", "--quiet"]) {
+                    Err(GitError::GitRefused) => Ok(true),
+                    Ok(_) => Ok(false),
+                    Err(_) => Ok(false),
+                }
+            }
+            Err(error) => Err(error),
+        },
     }
 }
 
 /// Reads one untracked path's bounded content head. Never fails the
 /// collection: an unreadable path yields an explicit placeholder (the
-/// status list still names it). Quoted (git-escaped) paths and `..`
-/// components are never touched on disk.
+/// status list still names it).
+///
+/// The path list is an advertisement, not authority, so every component
+/// is checked here instead of trusted: non-relative paths (joining an
+/// absolute path REPLACES the base), `..` components and the C-quoted
+/// porcelain form this crate's `-z` reads never produce are refused, and
+/// the parent directory is resolved and must land inside the worktree, so
+/// an intermediate symlinked directory cannot walk the read out of it.
+///
+/// The final component is then OPENED with `O_NOFOLLOW | O_NONBLOCK` and
+/// classified by the opened handle's own metadata — never by a check on
+/// the path that a rename could invalidate between the two calls. A
+/// symlinked final component is refused by the kernel (ELOOP), and a FIFO
+/// or device is neither waited on nor read.
 fn untracked_content(worktree: &Path, path: &str) -> UntrackedContent {
     use std::io::Read;
+    use std::os::unix::fs::OpenOptionsExt;
     let placeholder = |content: &str| UntrackedContent {
         path: path.to_owned(),
         content: content.to_owned(),
         truncated: false,
     };
-    if path.contains('"') || path.split('/').any(|component| component == "..") {
+    let relative = Path::new(path);
+    if relative.is_absolute()
+        || path.starts_with('"')
+        || relative
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
         return placeholder("<path not readable>");
     }
-    let full = worktree.join(path);
-    let metadata = match std::fs::symlink_metadata(&full) {
-        Ok(metadata) => metadata,
+    let full = worktree.join(relative);
+    let root = match std::fs::canonicalize(worktree) {
+        Ok(root) => root,
         Err(_) => return placeholder("<unreadable>"),
     };
-    if !metadata.is_file() {
-        return placeholder("<directory or non-regular file>");
+    let parent = match full
+        .parent()
+        .and_then(|parent| std::fs::canonicalize(parent).ok())
+    {
+        Some(parent) => parent,
+        None => return placeholder("<unreadable>"),
+    };
+    if !parent.starts_with(&root) {
+        return placeholder("<path outside the worktree>");
     }
-    let file = match std::fs::File::open(&full) {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(
+            nix::fcntl::OFlag::O_NOFOLLOW.bits()
+                | nix::fcntl::OFlag::O_NONBLOCK.bits()
+                | nix::fcntl::OFlag::O_CLOEXEC.bits(),
+        )
+        .open(&full)
+    {
         Ok(file) => file,
-        Err(_) => return placeholder("<unreadable>"),
+        Err(_) => return placeholder("<unreadable or non-regular file>"),
     };
+    // Classify what was actually opened: a directory open succeeds on
+    // Linux, and a FIFO opened without O_NONBLOCK would never return.
+    match file.metadata() {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return placeholder("<directory or non-regular file>"),
+        Err(_) => return placeholder("<unreadable>"),
+    }
     let mut head = Vec::new();
     let mut limited = file.take((MAX_UNTRACKED_FILE_BYTES + 1) as u64);
     if limited.read_to_end(&mut head).is_err() {
@@ -829,7 +955,7 @@ mod tests {
         )
         .unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         assert!(
             diff.tracked.contains("+modified line"),
             "{:?}",
@@ -858,7 +984,7 @@ mod tests {
         let text = format!("a{}", "é".repeat(MAX_UNTRACKED_FILE_BYTES));
         std::fs::write(repo.dir.join("accents.txt"), text.as_bytes()).unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         let head = &diff.untracked[0];
         assert!(head.truncated);
         assert!(!head.content.contains("non-utf8"), "{:?}", head.content);
@@ -881,7 +1007,7 @@ mod tests {
         let mut git = SystemGit::new();
         std::fs::write(repo.dir.join("blob.bin"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         assert_eq!(diff.untracked[0].content, "<non-utf8 content>");
         assert!(!diff.untracked[0].truncated);
     }
@@ -896,7 +1022,7 @@ mod tests {
             std::fs::write(repo.dir.join(format!("file-{index:02}.txt")), "x\n").unwrap();
         }
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         assert_eq!(diff.untracked.len(), MAX_UNTRACKED_FILES);
         assert_eq!(diff.untracked_omitted, 3);
     }
@@ -910,7 +1036,7 @@ mod tests {
         let big = "x".repeat(MAX_UNTRACKED_FILE_BYTES * 3);
         std::fs::write(repo.dir.join("big.txt"), &big).unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         let head = &diff.untracked[0];
         assert_eq!(head.path, "big.txt");
         assert!(head.truncated);
@@ -928,23 +1054,58 @@ mod tests {
         let big = format!("{}\n", "y".repeat(64)).repeat(300 * 1024 / 65 + 8);
         std::fs::write(repo.dir.join("README.md"), &big).unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         assert!(diff.tracked_truncated, "{:?}", diff.tracked);
         assert!(diff.tracked.contains("README.md"), "{:?}", diff.tracked);
+        // The degradation is the summary, not a partial patch, and the
+        // flag is the whole story: no note competes with it.
+        assert!(!diff.tracked.contains("@@"), "{:?}", diff.tracked);
+        assert!(diff.tracked_note.is_empty(), "{}", diff.tracked_note);
     }
 
-    /// A symlinked untracked path is never read: the placeholder names
-    /// it instead.
+    /// A symlinked untracked path is never read: `O_NOFOLLOW` refuses it
+    /// in the kernel and the placeholder names it instead.
     #[test]
     fn symlinked_untracked_paths_are_never_read() {
         let repo = TempRepo::new("run-diff-symlink");
         let mut git = SystemGit::new();
+        let host_secret = std::fs::read_to_string("/etc/hostname").unwrap();
         std::os::unix::fs::symlink("/etc/hostname", repo.dir.join("sneaky.txt")).unwrap();
         let status = observe_status(&mut git, &repo.dir).unwrap();
-        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
         let head = &diff.untracked[0];
         assert_eq!(head.path, "sneaky.txt");
-        assert_eq!(head.content, "<directory or non-regular file>");
+        assert_eq!(head.content, "<unreadable or non-regular file>");
+        assert_ne!(head.content, host_secret);
+    }
+
+    /// A FIFO named by the status list cannot hang the preview: the open
+    /// is non-blocking and the classification is of the opened handle.
+    #[test]
+    fn a_fifo_untracked_path_is_named_and_never_waited_on() {
+        use std::sync::mpsc;
+        let repo = TempRepo::new("run-diff-fifo");
+        nix::unistd::mkfifo(
+            &repo.dir.join("pipe"),
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .unwrap();
+        let dir = repo.dir.clone();
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut git = SystemGit::new();
+            let status = WorktreeStatus {
+                uncommitted: Vec::new(),
+                untracked: vec!["pipe".to_string()],
+            };
+            let _ = sender.send(observe_run_diff(&mut git, &dir, &status));
+        });
+        // Without O_NONBLOCK this open waits for a writer forever; the
+        // bounded receive turns that regression into a failure.
+        let diff = receiver
+            .recv_timeout(Duration::from_secs(10))
+            .expect("reading a FIFO must not wait for a writer");
+        assert_eq!(diff.untracked[0].content, "<directory or non-regular file>");
     }
 
     /// An unborn HEAD (no commits) is not a refusal: the tracked diff
@@ -971,10 +1132,133 @@ mod tests {
         std::fs::write(dir.join("new.txt"), "content\n").unwrap();
         let mut git = SystemGit::new();
         let status = observe_status(&mut git, &dir).unwrap();
-        let diff = observe_run_diff(&mut git, &dir, &status).unwrap();
+        let diff = observe_run_diff(&mut git, &dir, &status);
         assert!(diff.tracked.is_empty());
         assert!(!diff.tracked_truncated);
+        assert!(diff.tracked_note.is_empty(), "{}", diff.tracked_note);
         assert_eq!(diff.untracked[0].path, "new.txt");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A tracked diff that is not UTF-8 (a binary blob, a latin-1 source
+    /// file) is NAMED, and the untracked heads are still collected: one
+    /// bad tracked byte must not cost the whole preview.
+    #[test]
+    fn a_non_utf8_tracked_diff_is_named_and_untracked_heads_survive() {
+        let repo = TempRepo::new("run-diff-tracked-non-utf8");
+        let mut git = SystemGit::new();
+        // 0xff with no NUL: git treats the file as text and emits the raw
+        // byte in the patch, so the diff output is not UTF-8.
+        std::fs::write(repo.dir.join("README.md"), b"line\n\xff\n").unwrap();
+        std::fs::write(repo.dir.join("produced.txt"), "worker output\n").unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        assert_eq!(diff.tracked, "<tracked diff is not UTF-8>");
+        assert!(
+            diff.tracked_note.contains("not UTF-8"),
+            "{}",
+            diff.tracked_note
+        );
+        assert!(!diff.tracked_truncated);
+        assert_eq!(diff.untracked.len(), 1);
+        assert_eq!(diff.untracked[0].content, "worker output\n");
+    }
+
+    /// A HEAD that resolves to nothing while the repository holds other
+    /// refs is BROKEN, not unborn: it is named instead of previewing as
+    /// "nothing changed".
+    #[test]
+    fn a_broken_head_is_named_rather_than_reported_as_empty() {
+        let repo = TempRepo::new("run-diff-broken-head");
+        let mut git = SystemGit::new();
+        std::fs::write(repo.dir.join("README.md"), "changed\n").unwrap();
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&repo.dir)
+            .args(["symbolic-ref", "HEAD", "refs/heads/no-such-branch"])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        assert_eq!(diff.tracked, "<git refused the tracked diff>");
+        assert!(!diff.tracked_note.is_empty(), "the refusal must be named");
+        assert!(!diff.tracked_truncated);
+    }
+
+    /// The path list is an advertisement, not authority: an absolute path
+    /// (which REPLACES the base when joined) is refused and never read.
+    #[test]
+    fn an_absolute_untracked_path_is_never_read() {
+        let repo = TempRepo::new("run-diff-absolute");
+        let mut git = SystemGit::new();
+        let host_secret = std::fs::read_to_string("/etc/hostname").unwrap();
+        let status = WorktreeStatus {
+            uncommitted: Vec::new(),
+            untracked: vec!["/etc/hostname".to_string()],
+        };
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        assert_eq!(diff.untracked[0].content, "<path not readable>");
+        assert_ne!(diff.untracked[0].content, host_secret);
+    }
+
+    /// An intermediate symlinked directory cannot walk the read out of the
+    /// worktree, even when the status list names a path beneath it.
+    #[test]
+    fn a_symlinked_parent_directory_is_never_followed() {
+        let repo = TempRepo::new("run-diff-parent-link");
+        let mut git = SystemGit::new();
+        let outside =
+            std::env::temp_dir().join(format!("symbiote-repo-outside-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&outside);
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "OUTSIDE-SECRET\n").unwrap();
+        std::os::unix::fs::symlink(&outside, repo.dir.join("link")).unwrap();
+        let status = WorktreeStatus {
+            uncommitted: Vec::new(),
+            untracked: vec!["link/secret.txt".to_string()],
+        };
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        assert_eq!(diff.untracked[0].content, "<path outside the worktree>");
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    /// A three-byte character cut by the bound keeps its complete prefix
+    /// too (the two-byte case has its own test).
+    #[test]
+    fn a_three_byte_character_cut_keeps_the_complete_prefix() {
+        let repo = TempRepo::new("run-diff-utf8-bound-3");
+        let mut git = SystemGit::new();
+        // Two leading ASCII bytes: 16384 - 2 = 16382 = 3 x 5460 + 2, so the
+        // bound lands two bytes into a three-byte character.
+        let text = format!("ab{}", "€".repeat(MAX_UNTRACKED_FILE_BYTES));
+        std::fs::write(repo.dir.join("euros.txt"), text.as_bytes()).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        let head = &diff.untracked[0];
+        assert!(head.truncated);
+        assert_eq!(head.content.len(), MAX_UNTRACKED_FILE_BYTES - 2);
+        assert!(!head.content.contains("non-utf8"), "{:?}", head.content);
+        assert!(head.content.starts_with("ab"));
+    }
+
+    /// A filename that merely CONTAINS a quote is read — porcelain `-z`
+    /// never quotes — while the C-quoted form (always a leading quote) is
+    /// refused.
+    #[test]
+    fn an_interior_quote_is_read_but_a_quoted_porcelain_path_is_refused() {
+        let repo = TempRepo::new("run-diff-quote");
+        let mut git = SystemGit::new();
+        std::fs::write(repo.dir.join("od\"d.txt"), "quoted name\n").unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status);
+        assert_eq!(diff.untracked[0].path, "od\"d.txt");
+        assert_eq!(diff.untracked[0].content, "quoted name\n");
+        let quoted = WorktreeStatus {
+            uncommitted: Vec::new(),
+            untracked: vec!["\"od\\303\\251.txt\"".to_string()],
+        };
+        let diff = observe_run_diff(&mut git, &repo.dir, &quoted);
+        assert_eq!(diff.untracked[0].content, "<path not readable>");
     }
 }

--- a/crates/symbiote-repo/src/lib.rs
+++ b/crates/symbiote-repo/src/lib.rs
@@ -293,6 +293,137 @@ pub fn observe_status(
     Ok(status)
 }
 
+/// Per-file bounds for the untracked content heads.
+pub const MAX_UNTRACKED_FILE_BYTES: usize = 16 * 1024;
+/// The maximum number of untracked files that get content heads.
+pub const MAX_UNTRACKED_FILES: usize = 32;
+
+/// The bounded diff evidence of a run in a worktree: the tracked unified
+/// diff plus bounded content heads of the untracked paths. This is
+/// PREVIEW evidence — rendered inert (escaped) downstream — and it is
+/// size-capped at every layer: an oversized tracked diff degrades to the
+/// `--stat` summary with an explicit flag, an oversized untracked file is
+/// truncated with an explicit flag, and symlinked or non-regular paths
+/// are never read (a bracketed placeholder names them instead).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RunDiff {
+    /// The tracked unified diff (`git diff HEAD`), or the degraded
+    /// `--stat` summary when the full diff exceeded the output bound.
+    pub tracked: String,
+    /// True when `tracked` is the degraded `--stat` summary, not the
+    /// full diff.
+    pub tracked_truncated: bool,
+    /// Untracked paths (at most [`MAX_UNTRACKED_FILES`], in status
+    /// order) with bounded content heads.
+    pub untracked: Vec<UntrackedContent>,
+}
+
+/// One untracked path's bounded content head.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UntrackedContent {
+    pub path: String,
+    /// The file's content head (at most
+    /// [`MAX_UNTRACKED_FILE_BYTES`]), or a bracketed placeholder when
+    /// the content was not read (symlink, directory, non-UTF-8,
+    /// unreadable).
+    pub content: String,
+    /// True when `content` is a truncated head.
+    pub truncated: bool,
+}
+
+/// Observes the bounded diff evidence for a worktree whose changed-path
+/// set is already known (from [`observe_status`]).
+pub fn observe_run_diff(
+    git: &mut impl GitExecutor,
+    worktree: &Path,
+    status: &WorktreeStatus,
+) -> Result<RunDiff, GitError> {
+    let mut diff = RunDiff::default();
+    match git.run(worktree, &["diff", "HEAD", "--"]) {
+        Ok(bytes) => {
+            diff.tracked = std::str::from_utf8(&bytes)
+                .map_err(|_| GitError::MalformedOutput)?
+                .to_owned();
+        }
+        Err(GitError::OutputTooLarge) => {
+            // Degrade honestly: the summary names what changed, the flag
+            // says the full diff did not fit the bound.
+            diff.tracked_truncated = true;
+            let summary = git.run(worktree, &["diff", "HEAD", "--stat"])?;
+            diff.tracked = std::str::from_utf8(&summary)
+                .map_err(|_| GitError::MalformedOutput)?
+                .to_owned();
+        }
+        // An unborn HEAD has nothing to diff against: that is not a
+        // refusal for preview evidence — the tracked diff is empty. A
+        // real git refusal still surfaces.
+        Err(GitError::GitRefused) => {
+            if !head_is_unborn(git, worktree)? {
+                return Err(GitError::GitRefused);
+            }
+        }
+        Err(error) => return Err(error),
+    }
+    for path in status.untracked.iter().take(MAX_UNTRACKED_FILES) {
+        diff.untracked.push(untracked_content(worktree, path));
+    }
+    Ok(diff)
+}
+
+/// `rev-parse --verify -q HEAD` fails exactly on an unborn branch.
+fn head_is_unborn(git: &mut impl GitExecutor, worktree: &Path) -> Result<bool, GitError> {
+    match git.run(worktree, &["rev-parse", "--verify", "-q", "HEAD"]) {
+        Ok(_) => Ok(false),
+        Err(GitError::GitRefused) => Ok(true),
+        Err(error) => Err(error),
+    }
+}
+
+/// Reads one untracked path's bounded content head. Never fails the
+/// collection: an unreadable path yields an explicit placeholder (the
+/// status list still names it). Quoted (git-escaped) paths and `..`
+/// components are never touched on disk.
+fn untracked_content(worktree: &Path, path: &str) -> UntrackedContent {
+    use std::io::Read;
+    let placeholder = |content: &str| UntrackedContent {
+        path: path.to_owned(),
+        content: content.to_owned(),
+        truncated: false,
+    };
+    if path.contains('"') || path.split('/').any(|component| component == "..") {
+        return placeholder("<path not readable>");
+    }
+    let full = worktree.join(path);
+    let metadata = match std::fs::symlink_metadata(&full) {
+        Ok(metadata) => metadata,
+        Err(_) => return placeholder("<unreadable>"),
+    };
+    if !metadata.is_file() {
+        return placeholder("<directory or non-regular file>");
+    }
+    let file = match std::fs::File::open(&full) {
+        Ok(file) => file,
+        Err(_) => return placeholder("<unreadable>"),
+    };
+    let mut head = Vec::new();
+    let mut limited = file.take((MAX_UNTRACKED_FILE_BYTES + 1) as u64);
+    if limited.read_to_end(&mut head).is_err() {
+        return placeholder("<unreadable>");
+    }
+    let truncated = head.len() > MAX_UNTRACKED_FILE_BYTES;
+    head.truncate(MAX_UNTRACKED_FILE_BYTES);
+    match String::from_utf8(head) {
+        Ok(text) => UntrackedContent {
+            path: path.to_owned(),
+            content: text,
+            truncated,
+        },
+        Err(_) => placeholder("<non-utf8 content>"),
+    }
+}
+
 fn trimmed_hex(bytes: &[u8]) -> Result<String, GitError> {
     let text = std::str::from_utf8(bytes).map_err(|_| GitError::MalformedOutput)?;
     let trimmed = text.trim();
@@ -666,5 +797,111 @@ mod tests {
             observe_status(&mut git, &repo.dir),
             Err(GitError::OutputTooLarge)
         );
+    }
+
+    /// Observes the bounded diff evidence: tracked hunks plus untracked
+    /// content heads, from a REAL repository.
+    #[test]
+    fn run_diff_covers_tracked_and_untracked_changes() {
+        let repo = TempRepo::new("run-diff");
+        let mut git = SystemGit::new();
+        std::fs::write(repo.dir.join("README.md"), "modified line\n").unwrap();
+        std::fs::write(
+            repo.dir.join("produced.txt"),
+            "worker output\nsecond line\n",
+        )
+        .unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        assert!(
+            diff.tracked.contains("+modified line"),
+            "{:?}",
+            diff.tracked
+        );
+        assert!(!diff.tracked_truncated);
+        let produced = diff
+            .untracked
+            .iter()
+            .find(|head| head.path == "produced.txt")
+            .expect("untracked content head");
+        assert_eq!(produced.content, "worker output\nsecond line\n");
+        assert!(!produced.truncated);
+    }
+
+    /// An oversized untracked file is truncated with an explicit flag,
+    /// never silently and never unbounded.
+    #[test]
+    fn oversized_untracked_files_are_truncated_with_a_flag() {
+        let repo = TempRepo::new("run-diff-truncate");
+        let mut git = SystemGit::new();
+        let big = "x".repeat(MAX_UNTRACKED_FILE_BYTES * 3);
+        std::fs::write(repo.dir.join("big.txt"), &big).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let head = &diff.untracked[0];
+        assert_eq!(head.path, "big.txt");
+        assert!(head.truncated);
+        assert_eq!(head.content.len(), MAX_UNTRACKED_FILE_BYTES);
+    }
+
+    /// An oversized tracked diff degrades to the `--stat` summary with
+    /// an explicit flag.
+    #[test]
+    fn oversized_tracked_diffs_degrade_to_the_stat_summary() {
+        let repo = TempRepo::new("run-diff-stat");
+        let mut git = SystemGit::new();
+        // Three hundred kilobytes of changed lines exceed the 256 KiB
+        // invocation bound for `git diff HEAD`.
+        let big = format!("{}\n", "y".repeat(64)).repeat(300 * 1024 / 65 + 8);
+        std::fs::write(repo.dir.join("README.md"), &big).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        assert!(diff.tracked_truncated, "{:?}", diff.tracked);
+        assert!(diff.tracked.contains("README.md"), "{:?}", diff.tracked);
+    }
+
+    /// A symlinked untracked path is never read: the placeholder names
+    /// it instead.
+    #[test]
+    fn symlinked_untracked_paths_are_never_read() {
+        let repo = TempRepo::new("run-diff-symlink");
+        let mut git = SystemGit::new();
+        std::os::unix::fs::symlink("/etc/hostname", repo.dir.join("sneaky.txt")).unwrap();
+        let status = observe_status(&mut git, &repo.dir).unwrap();
+        let diff = observe_run_diff(&mut git, &repo.dir, &status).unwrap();
+        let head = &diff.untracked[0];
+        assert_eq!(head.path, "sneaky.txt");
+        assert_eq!(head.content, "<directory or non-regular file>");
+    }
+
+    /// An unborn HEAD (no commits) is not a refusal: the tracked diff
+    /// is empty and untracked heads still collect.
+    #[test]
+    fn an_unborn_head_is_empty_tracked_diff_not_a_refusal() {
+        let dir = std::env::temp_dir().join(format!("symbiote-repo-unborn-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        run(&["init", "-q", "-b", "main"]);
+        std::fs::write(dir.join("new.txt"), "content\n").unwrap();
+        let mut git = SystemGit::new();
+        let status = observe_status(&mut git, &dir).unwrap();
+        let diff = observe_run_diff(&mut git, &dir, &status).unwrap();
+        assert!(diff.tracked.is_empty());
+        assert!(!diff.tracked_truncated);
+        assert_eq!(diff.untracked[0].path, "new.txt");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## What this changes

The Preview surface gains bounded diff evidence for a finished run, gathered owner-side (never from the front end).

**`symbiote-repo::observe_run_diff`** (new) — a `RunDiff` built from an already-observed `WorktreeStatus`. Collection is **total**: no tracked-side problem can cost the caller its untracked evidence, and every degradation is explicit.

- **tracked**: `git diff HEAD` (unified). Past the git output bound it degrades to `git diff HEAD --stat` with `tracked_truncated = true`; any other failure (a non-UTF-8 patch from a binary/latin-1 tracked file, a `--stat` summary that also exceeds the bound, a git refusal) becomes a bracketed placeholder plus a `tracked_note` naming the reason. An unborn HEAD is an empty tracked diff — not a refusal — and a HEAD that resolves to nothing while other refs exist is a broken HEAD and is named.
- **untracked**: per-path content heads, each at most 16 KiB, at most 32 paths, each carrying its own `truncated` flag; `untracked_omitted` counts the paths the cap left head-less.
- **never read**: the status path list is an advertisement, not authority. Non-relative paths (joining an absolute path *replaces* the base), `..` components and the C-quoted porcelain form are refused; the parent directory is canonicalized and must land **inside the worktree**, so an intermediate symlinked directory cannot walk the read out; and the final component is **opened** with `O_NOFOLLOW | O_NONBLOCK` and classified by the opened handle's own metadata — there is no check-then-open window, a symlinked final component is refused by the kernel, and a FIFO is neither waited on nor read.
- A byte bound cutting a multi-byte character keeps the complete character prefix instead of reporting a UTF-8 file as `<non-utf8 content>`.
- Tests drive real repositories: tracked + untracked, 16 KiB truncation, `--stat` degradation and its shape, symlink (final and parent), FIFO, absolute path, non-UTF-8 tracked patch, non-UTF-8 untracked content, broken HEAD, unborn HEAD, 2- and 3-byte boundary cuts, interior quotes, and the cap/omit count.

**Controller `run_diff(worktree)`** — canonicalizes both the requested path and the session's reservation base and refuses anything that does not resolve inside the base (component-wise, not string-prefix). This is structural: the front end's path string is never trusted. Tests cover a real repo inside the base, a repo outside it, a symlink inside pointing outside, and a name-prefix sibling (`worktreesEVIL`).

**`open_preview`** — gathers the diff through the controller and hands it to `preview_document`, which renders a *Tracked diff* section (with any degradation note) plus per-file untracked content heads through the same HTML escaper as every other dynamic value. A gathering refusal (outside the base, or no live session) degrades to an escaped owner note: the run's report still previews. Hostile content in a diff, a file path, or a file head renders inert — pinned by tests.

## Bounds, all explicit

| layer | bound | flag |
| --- | --- | --- |
| tracked diff output | git invocation output bound | `tracked_truncated` (the degradation is `--stat`); any other tracked failure → `tracked_note` |
| per-file untracked head | 16 KiB | `truncated` (per head) |
| untracked paths given heads | 32 | `untracked_omitted` |

## Security boundary

- The UI cannot widen the observation: the path must resolve inside the session's reservation base, and refusals are typed.
- Content is never read through a symlink — final or intermediate — and containment is checked on resolved paths.
- Everything rendered passes through `escape()`; the document keeps its `default-src 'none'` CSP and contains no script.

## Verification (head f09e347a, local, real exit codes)

```
cargo fmt --all --check                                          -> 0
cargo clippy --workspace --all-targets --locked -- -D warnings   -> 0
cargo test --workspace --locked                                  -> 0  (458 passed / 0 failed)
```

Plus the documented rebuild-first step (`cargo build -p symbiote-host --bins -p symbiote-sandbox --bin symbiote-sandbox-launch`) because e2e tests spawn the workspace `target/debug` daemon binary.

## Honest non-claims

- **No live GUI verification of this increment yet.** The new sections inherit the Preview surface's CSP and escaper, and the surface's no-IPC isolation was live-verified on Wayland in #525, but the diff rendering itself is pinned headlessly only — there is no screenshot or a11y capture of it. A live capture is a separate follow-up.
- The race-winning two-thread TOCTOU is not deterministically testable; the window is closed by construction (open with `O_NOFOLLOW`, classify the opened handle), and the deterministic escapes are pinned by tests.
- **Live model turns remain gated.** One live native OpenAI Responses API turn and one live Codex 0.118.0 App Server turn require explicit user authorization for credentials and billing. Nothing was spent; no live turn was attempted; the explicitly labeled fixture transports remain the only execution path.
- No new spending, no credential changes, and no paid fallback authorization is implied.

## Review status

Independent review (fresh local agent, headless, against `e72d674d`) returned **APPROVE_WITH_COMMENTS** with one P1 and three P2s; the full findings table, evidence, and disposition per finding is here: [#526 review record](https://github.com/RepairYourTech/SymbioteIDE/pull/526#issuecomment-5630762195). All P1/P2 findings are fixed in `f09e347a` with tests pinning each one; the single accepted P3 (a path exactly equal to the reservation base) is documented in that record. CodeRabbit reports "manual review required for this OSS repository" and Qodo is paused — both are stated as a coverage gap rather than counted as review.
