### PR TITLE
docs(repo): the observation contract, crate doc, and Tests section match the code (#54)

### DIFF
--- a/crates/symbiote-repo/src/lib.rs
+++ b/crates/symbiote-repo/src/lib.rs
@@ -15,8 +15,13 @@
 //! compose this crate inside the Host sandbox (no network). Repository
 //! identity stays with the canonical Root records; this crate never
 //! second-guesses them. Credential delegation, remotes,
-//! submodules/LFS/sparse-checkout, status/diff/history normalization and
-//! safe multi-step transactions remain pending on #190.
+//! submodules/LFS/sparse-checkout, history normalization and safe
+//! multi-step transactions remain pending on #190. Diff evidence is
+//! bounded preview material only: `observe_run_diff` collects the tracked
+//! diff and 16 KiB heads of the untracked files for rendering inert
+//! downstream, size-capped at every layer with an explicit flag or note
+//! for every degradation; it authorizes nothing, and full diff/history
+//! normalization remains pending.
 //!
 //! Everything is offline-testable: `GitExecutor` is injected, and tests use
 //! the real `git` binary against temporary repositories plus scripted

--- a/docs/contracts/repository.md
+++ b/docs/contracts/repository.md
@@ -110,12 +110,18 @@ bytes, the seed bound is 64).
 
 ## Tests
 
-Seven tests cover the real binary against temporary repositories (branch,
-detached, unborn, changed/untracked separation, clean tree, real
-materialization with content verification, non-empty and missing-branch
-refusals) and scripted executors (exact invocation rooting and ordering,
-malformed output rejection per parser, refusal surfacing, output-bound
-constant contract).
+Tests run the real `git` binary against temporary repositories — HEAD
+classification (branch, detached, unborn), uncommitted/untracked
+separation including a clean tree, real worktree materialization, and the
+executor's 256 KiB output bound observed end to end. The run-diff tests
+cover tracked and untracked evidence, every size and omission degradation
+(`--stat` fallback, per-head `truncated`, `untracked_omitted`, a non-UTF-8
+placeholder, the complete-character prefix kept at a byte cut) and every
+path refusal (absolute, `..`, quoted porcelain form, symlinked final
+component, symlinked parent directory, FIFO). Scripted executors pin exact
+invocation rooting and ordering and malformed-output rejection per parser;
+`provision`'s tests cover materialization at the recorded base plus its
+moved-base and tampered-identity refusals.
 
 ## Honest non-claims
 

--- a/docs/contracts/repository.md
+++ b/docs/contracts/repository.md
@@ -38,8 +38,31 @@ plausible shape.
   structure) — into uncommitted and untracked path lists. Rename/copy
   records carry their origin as the next NUL field; the destination is
   recorded and a missing origin is a truncated frame, not a skip. Paths
-  only, never content: content belongs to the diff commands, which remain
-  pending.
+  only, never content: reading content is `observe_run_diff`'s business
+  below, and it reads bounded PREVIEW material only.
+- `observe_run_diff` collects bounded diff evidence for a worktree whose
+  changed-path set is already known: the tracked unified diff, plus up to
+  32 untracked file content heads of at most 16 KiB each. It is TOTAL —
+  it never fails the caller. An oversized tracked diff degrades to the
+  `--stat` summary with `tracked_truncated`; every other tracked failure
+  (a non-UTF-8 patch, a `--stat` summary past the bound, a git refusal)
+  becomes a bracketed placeholder plus a `tracked_note` naming the
+  reason. An unborn HEAD is an empty tracked diff; a HEAD with nothing
+  reachable while other refs exist is a named refusal, not "nothing
+  changed". Untracked heads carry their own `truncated` flag and
+  `untracked_omitted` counts the paths the head cap left without one. A
+  byte bound cutting through a multi-byte character keeps the complete
+  character prefix instead of discarding the head as non-UTF-8, while a
+  genuinely invalid byte still yields `<non-utf8 content>`.
+- The status path list is an advertisement, not authority, so every read
+  re-checks it: non-relative paths (joining an absolute path REPLACES the
+  base), `..` components and the C-quoted porcelain form are refused; the
+  parent directory is canonicalized and must land inside the worktree, so
+  an intermediate symlinked directory cannot walk the read out of it; and
+  the final component is OPENED with `O_NOFOLLOW | O_NONBLOCK` and
+  classified from the opened handle's own metadata — there is no
+  check-then-open window, a symlinked final component is refused by the
+  kernel, and a FIFO is neither waited on nor read.
 
 All observations are advertisements — observed provenance, never
 authorization or proof of remote identity.
@@ -97,9 +120,10 @@ constant contract).
 ## Honest non-claims
 
 Remotes, fetch/push, credential delegation, submodules/sparse checkout,
-status/diff/history normalization with exact provenance, safe multi-step
-transactions with recovery, and base-commit validation before dispatch
-all remain pending on #190. Network claim, scoped honestly: the crate
+full status/diff/history normalization with exact provenance (bounded
+preview diff evidence is implemented, normalization is not), safe
+multi-step transactions with recovery, and base-commit validation before
+dispatch all remain pending on #190. Network claim, scoped honestly: the crate
 sends no fetch/push/pull/clone command, but `checkout` executes
 repo-configured post-checkout hooks and smudge filters — a repo with
 git-lfs configured could reach its remote through the filter — so callers


### PR DESCRIPTION
Follow-up to #526 (merged `e1ef2701`), which added `observe_run_diff` and in doing so made two honest-scope statements false.

## What this changes

### `c61946af` — the observation contract records bounded diff evidence

- `docs/contracts/repository.md` said the observed facts were "Paths only, never content: content belongs to the diff commands, which remain pending."
- The `symbiote-repo` module doc listed "status/diff/history normalization" among the wholly-pending items.

Both now describe what exists, without over-claiming it:

- **`docs/contracts/repository.md`** gains an `observe_run_diff` bullet (total collection; `--stat` degradation with `tracked_truncated`; a placeholder plus `tracked_note` for every other tracked failure; unborn HEAD empty vs. a named broken HEAD; per-head `truncated`; `untracked_omitted`; the complete-character UTF-8 boundary rule) and a bullet for the path rules (non-relative / `..` / C-quoted refused, parent canonicalized inside the worktree, final component opened with `O_NOFOLLOW | O_NONBLOCK` and classified from the opened handle — no check-then-open window, no FIFO wait). The `observe_status` bullet now points at it instead of claiming content is unimplemented.
- **The crate module doc** keeps remotes/credential delegation/history normalization/multi-step transactions pending while stating that diff evidence is bounded preview material that authorizes nothing.
- The doc's honest non-claims now distinguish **bounded preview diff evidence (implemented)** from **full status/diff/history normalization (pending)**.

### `12ae499b` — the Tests section names the suite that exists

The same file's `## Tests` section still counted "seven tests" against the real binary and named scenarios the crate no longer has: the missing-branch-refusal test was replaced by the scripted `-b` pin, and real materialization now lives in `provision`. The section also predated #526 entirely, so it omitted every run-diff degradation and path-refusal case. It now records the coverage that exists — **25 tests, 21 of them against the real `git` binary, 15 of those the run-diff collection** — instead of a count that drifts. This is the same class of defect the first commit removed, found in the same file.

## Verification (head 12ae499b, local, real exit codes)

```
cargo fmt --all --check                                          -> 0
cargo clippy --workspace --all-targets --locked -- -D warnings   -> 0
cargo test --workspace --locked                                  -> 0  (76 suites, 458 passed / 0 failed)
```

`symbiote-repo` alone: 25 passed. Docs-only plus a doc comment, so no behaviour is touched.

These numbers come from a full `cargo clean` and cold rebuild: this worktree's `target/` had been populated from a different source state (a stale gated `symbiote` binary that made two unrelated daemon tests fail), so the binary under test had to be rebuilt to match the source before the run could be trusted.

## Honest non-claims

- **Live model turns remain gated**: one live native OpenAI Responses API turn and one live Codex 0.118.0 App Server turn require explicit user authorization for credentials and billing. Nothing was spent; no live turn was attempted; the labeled fixture transports remain the only execution path.
- No new spending, no credential changes, and no paid fallback authorization is implied.
- This slice does not change what the code does, and its statements are only as good as the review that checks them against the code.

Refs #54
