### PR TITLE
feat(cli): the binary emits and regenerates its published schemas (#54)

### DIFF
--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -65,6 +65,12 @@ jobs:
       - if: matrix.toolchain == 'stable'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
+      - name: Committed CLI schemas match what the binary emits
+        if: matrix.toolchain == 'stable'
+        run: |
+          schemas=$(mktemp -d)
+          cargo run --locked -p symbiote-host --bin symbiote -- schema --write "$schemas"
+          diff -ru docs/contracts/schemas "$schemas"
       - name: Prove pinned Codex discovery without credentials or network
         if: matrix.toolchain == 'stable'
         run: |

--- a/.github/workflows/rust-contracts.yml
+++ b/.github/workflows/rust-contracts.yml
@@ -64,13 +64,13 @@ jobs:
         run: cargo fmt --all --check
       - if: matrix.toolchain == 'stable'
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
-      - run: cargo test --workspace --locked
       - name: Committed CLI schemas match what the binary emits
         if: matrix.toolchain == 'stable'
         run: |
           schemas=$(mktemp -d)
           cargo run --locked -p symbiote-host --bin symbiote -- schema --write "$schemas"
           diff -ru docs/contracts/schemas "$schemas"
+      - run: cargo test --workspace --locked
       - name: Prove pinned Codex discovery without credentials or network
         if: matrix.toolchain == 'stable'
         run: |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cargo run -p symbiote-protocol --example protocol_schema
 cargo run -p symbiote-runtime-sdk --example runtime_schema
 ```
 
-Schema examples emit JSON to stdout. The generated structural schemas do not replace runtime cross-field checks. The `symbiote` CLI's `--json` envelope and its authorization policy are published as committed JSON Schema fixtures in [docs/contracts/schemas](docs/contracts/schemas) and validated against the real binary's output. Rust 1.85 is the declared minimum; Cargo.lock pins dependencies. CI tests the minimum and current stable toolchain. Workspace code forbids unsafe Rust.
+Schema examples emit JSON to stdout. The generated structural schemas do not replace runtime cross-field checks. The `symbiote` CLI's `--json` envelope and its authorization policy are published as committed JSON Schema fixtures in [docs/contracts/schemas](docs/contracts/schemas); `symbiote schema` emits them from the binary (`--write DIR` regenerates the committed fixtures as generated artifacts), and a test diffs the emitted documents against them. Rust 1.85 is the declared minimum; Cargo.lock pins dependencies. CI tests the minimum and current stable toolchain. Workspace code forbids unsafe Rust.
 
 Contract documentation: [domain](docs/contracts/domain.md), [configuration](docs/contracts/configuration.md), [architecture governance](docs/contracts/architecture.md), [storage](docs/contracts/storage.md), [protocol](docs/contracts/protocol.md), [Host](docs/contracts/host.md), [CLI](docs/contracts/cli.md). Each records implemented behavior and pending integration acceptance. [Engineering handoff](docs/engineering-handoff.md) tracks the current Change Stream and next gates.
 

--- a/crates/symbiote-host/src/bin/symbiote.rs
+++ b/crates/symbiote-host/src/bin/symbiote.rs
@@ -655,6 +655,7 @@ fn print_help() {
     println!("  --state-dir DIR   the private directory symbioted runs with");
     println!("  --command-id ID   idempotency key for a retried command");
     println!("  --policy FILE     pre-authorize dangerous operation kinds for noninteractive runs");
+    println!("  --write DIR       with `schema`, regenerate the fixture files in DIR");
     println!("  --json            one machine-readable envelope per invocation on stdout");
     println!("  --yes             explicit authorization for this one dangerous command");
     println!();
@@ -686,6 +687,9 @@ fn print_help() {
     println!("unreadable, insecure or invalid policy is a usage failure that sends nothing.");
     println!();
     println!("commands:");
+    let schema_name = "schema";
+    let schema_summary = "print the published symbiote.cli and cli-policy JSON Schemas";
+    println!("   {schema_name:<62} {schema_summary}");
     for command in commands() {
         let gated = match command.kind {
             Some(kind) => risk_of_kind(kind).requires_authorization(),
@@ -703,6 +707,9 @@ struct Options {
     state_dir: Option<PathBuf>,
     command_id_override: Option<String>,
     policy: Option<PathBuf>,
+    /// With `schema`, the directory to regenerate the fixture files into
+    /// instead of printing them.
+    write: Option<PathBuf>,
     json: bool,
     yes: bool,
     command: Option<String>,
@@ -719,6 +726,7 @@ fn parse_options(arguments: &[String]) -> Result<Options, Usage> {
         state_dir: None,
         command_id_override: None,
         policy: None,
+        write: None,
         json: false,
         yes: false,
         command: None,
@@ -738,7 +746,7 @@ fn parse_options(arguments: &[String]) -> Result<Options, Usage> {
             "--" => only_positional = true,
             "--json" => options.json = true,
             "--yes" => options.yes = true,
-            "--state-dir" | "--command-id" | "--policy" => {
+            "--state-dir" | "--command-id" | "--policy" | "--write" => {
                 index += 1;
                 let value = arguments
                     .get(index)
@@ -746,6 +754,7 @@ fn parse_options(arguments: &[String]) -> Result<Options, Usage> {
                     .ok_or_else(|| Usage(format!("{token} needs a value")))?;
                 match token.as_str() {
                     "--state-dir" => options.state_dir = Some(PathBuf::from(value)),
+                    "--write" => options.write = Some(PathBuf::from(value)),
                     "--command-id" => {
                         // An empty idempotency key is refused rather than
                         // carried: every empty-id invocation would collide with
@@ -803,6 +812,192 @@ fn error_envelope(command: &str, command_id: &str, code: &str, message: &str) ->
     })
 }
 
+/// The published envelope schema, built here so this binary is its source of
+/// truth: `symbiote schema` prints it, and the committed fixture under
+/// `docs/contracts/schemas/` is proved equal to it by
+/// `tests/cli_schema_contract.rs`. The `const` reads the same `CLI_SCHEMA` the
+/// envelope constructors write, so the two cannot drift.
+fn envelope_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://symbiote.dev/schemas/symbiote.cli.v1.schema.json",
+        "title": "symbiote CLI JSON envelope (symbiote.cli/v1)",
+        "description": "One envelope printed to stdout by `symbiote --json`, one per invocation. A success carries `result` (the daemon's own response body, unmodified); a failure carries `error` (the daemon's typed error, or one of the CLI's own codes). Exactly one of the two is present, and `ok` agrees with which one it is. The default (non-`--json`) output is the daemon's body alone and is not described here.",
+        "type": "object",
+        "required": ["schema", "command", "command_id", "ok"],
+        "additionalProperties": false,
+        "properties": {
+            "schema": {
+                "description": "Schema identity. Automation keys on this string rather than on the presence of individual fields.",
+                "const": CLI_SCHEMA
+            },
+            "command": {
+                "description": "The command name as invoked, e.g. `health`, or `raw`.",
+                "type": "string",
+                "minLength": 1
+            },
+            "command_id": {
+                "description": "The idempotency key this invocation used: the minted id, or a caller-supplied `--command-id`.",
+                "type": "string",
+                "minLength": 1
+            },
+            "ok": {
+                "description": "True exactly when the command succeeded (exit 0) and `result` is present.",
+                "type": "boolean"
+            },
+            "result": {
+                "description": "The daemon's own response body, unmodified. An internally tagged object whose `kind` names the answer.",
+                "$ref": "#/$defs/result"
+            },
+            "error": {
+                "description": "A failure, whether the daemon refused the command or the CLI could not send it.",
+                "$ref": "#/$defs/error"
+            }
+        },
+        "oneOf": [
+            {
+                "description": "Success: a result and no error, with ok true.",
+                "required": ["result"],
+                "not": { "required": ["error"] },
+                "properties": { "ok": { "const": true } }
+            },
+            {
+                "description": "Failure: an error and no result, with ok false.",
+                "required": ["error"],
+                "not": { "required": ["result"] },
+                "properties": { "ok": { "const": false } }
+            }
+        ],
+        "$defs": {
+            "result": {
+                "description": "symbiote_protocol::ResponseBody, which is internally tagged on `kind`.",
+                "type": "object",
+                "required": ["kind"],
+                "properties": {
+                    "kind": {
+                        "description": "The response body variant, snake_case, e.g. `health`, `shutdown`.",
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "error": {
+                "description": "The daemon's own ProtocolError, or the CLI's own code when nothing was sent.",
+                "type": "object",
+                "required": ["code", "message"],
+                "additionalProperties": false,
+                "properties": {
+                    "code": {
+                        "description": "The daemon's error code, or one of the CLI's own: `authorization_required` (nothing was sent), `policy_invalid` (the configured policy could not be honored; nothing was sent), `unreachable`.",
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "message": {
+                        "description": "Human-readable detail. Not stable for automation; branch on `code`.",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// The published policy schema. The `authorize` enum is computed from the
+/// operation-risk table rather than transcribed, so promoting a kind to
+/// dangerous — or adding one — makes it nameable by a policy and published in
+/// the same change.
+fn policy_schema() -> serde_json::Value {
+    let mut dangerous: Vec<&str> = OPERATION_RISKS
+        .iter()
+        .filter(|(_, risk)| *risk == Risk::Dangerous)
+        .map(|(kind, _)| *kind)
+        .collect();
+    dangerous.sort_unstable();
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://symbiote.dev/schemas/symbiote.cli-policy.v1.schema.json",
+        "title": "symbiote CLI authorization policy (symbiote.cli-policy/v1)",
+        "description": "A document named by `--policy FILE`, or by $SYMBIOTE_CLI_POLICY when the flag is absent, that pre-authorizes dangerous operation kinds for noninteractive runs. It may name only the operation kinds this CLI classifies as dangerous: a read or a mutation is already ungated, so listing one would be a no-op an operator could mistake for coverage; an unknown kind cannot be classified; and a wildcard is deliberately not a syntax. A policy is a pre-authorization, never a widening — it cannot grant a permission the daemon would refuse.",
+        "type": "object",
+        "required": ["schema", "authorize"],
+        "additionalProperties": false,
+        "properties": {
+            "schema": {
+                "description": "Schema identity. A different version is refused rather than reinterpreted.",
+                "const": POLICY_SCHEMA
+            },
+            "authorize": {
+                "description": "The dangerous operation kinds this policy pre-authorizes. At least one. These are kinds, not command names: `shutdown` covers both the typed command and `raw` naming that operation. Repeating a kind is accepted and collapses: the grants are a set.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "description": "A kind this CLI classifies as dangerous.",
+                    "enum": dangerous
+                }
+            },
+            "expires_at": {
+                "description": "Optional unix-millisecond bound. The expiry instant itself is still authorized; a lapsed policy grants nothing and the refusal names the file and the lapse.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": u64::MAX
+            }
+        }
+    })
+}
+
+/// A published schema document: its identity, the committed fixture file it is
+/// published as, and the builder that produces it.
+struct PublishedSchema {
+    identity: &'static str,
+    file_name: &'static str,
+    build: fn() -> serde_json::Value,
+}
+
+/// The published documents. One table, so the object `symbiote schema` prints,
+/// the files `symbiote schema --write DIR` writes, and the committed fixtures
+/// cannot drift apart.
+const PUBLISHED_SCHEMAS: &[PublishedSchema] = &[
+    PublishedSchema {
+        identity: CLI_SCHEMA,
+        file_name: "symbiote.cli.v1.schema.json",
+        build: envelope_schema,
+    },
+    PublishedSchema {
+        identity: POLICY_SCHEMA,
+        file_name: "symbiote.cli-policy.v1.schema.json",
+        build: policy_schema,
+    },
+];
+
+/// Both published documents, keyed by the schema identity each declares. This
+/// is exactly what `symbiote schema` prints.
+fn published_schemas() -> serde_json::Value {
+    let mut documents = serde_json::Map::new();
+    for schema in PUBLISHED_SCHEMAS {
+        documents.insert(schema.identity.to_owned(), (schema.build)());
+    }
+    serde_json::Value::Object(documents)
+}
+
+/// Writes each published document to `directory/<fixture file name>` in the
+/// canonical form regeneration produces. Committing exactly what this writes
+/// is what keeps the fixtures generated artifacts: running it again on a clean
+/// tree leaves the files unchanged.
+fn write_schemas(directory: &Path) -> Result<(), Usage> {
+    for schema in PUBLISHED_SCHEMAS {
+        let document = serde_json::to_string_pretty(&(schema.build)()).map_err(|error| {
+            Usage(format!(
+                "cannot serialize the {} schema: {error}",
+                schema.identity
+            ))
+        })?;
+        let path = directory.join(schema.file_name);
+        std::fs::write(&path, format!("{document}\n"))
+            .map_err(|error| Usage(format!("cannot write {}: {error}", path.display())))?;
+    }
+    Ok(())
+}
+
 /// Names BOTH the typed command and the operation that makes it dangerous:
 /// for `raw`, the operation is the whole story and the operator must see it.
 fn confirm(command: &Command, kind: &str) -> bool {
@@ -830,6 +1025,20 @@ fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
     };
     if name == "help" || name == "--help" {
         print_help();
+        return Ok(EXIT_OK);
+    }
+    // `schema` is local: it emits this binary's own contract and needs no
+    // daemon, no state directory and no authorization, so it is answered
+    // before any of that is consulted.
+    if name == "schema" {
+        if !options.args.is_empty() {
+            eprintln!("symbiote: schema takes no arguments; try `symbiote help`");
+            return Ok(EXIT_USAGE);
+        }
+        match &options.write {
+            Some(directory) => write_schemas(directory)?,
+            None => println!("{}", serde_json::to_string_pretty(&published_schemas())?),
+        }
         return Ok(EXIT_OK);
     }
     let Some(command) = commands().into_iter().find(|c| c.name == name) else {

--- a/crates/symbiote-host/tests/cli_schema_contract.rs
+++ b/crates/symbiote-host/tests/cli_schema_contract.rs
@@ -17,11 +17,16 @@ use support::*;
 const ENVELOPE_SCHEMA: &str = "symbiote.cli.v1.schema.json";
 const POLICY_SCHEMA: &str = "symbiote.cli-policy.v1.schema.json";
 
+/// The path of a published fixture under `docs/contracts/schemas/`.
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../docs/contracts/schemas")
+        .join(name)
+}
+
 /// Loads a published fixture from `docs/contracts/schemas/`.
 fn fixture(name: &str) -> serde_json::Value {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../docs/contracts/schemas")
-        .join(name);
+    let path = fixture_path(name);
     let text = std::fs::read_to_string(&path)
         .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
     serde_json::from_str(&text)
@@ -384,6 +389,83 @@ mod bounded {
         }
         instance.as_f64()?.partial_cmp(&limit.as_f64()?)
     }
+}
+
+#[test]
+fn the_binary_emits_the_published_schemas_and_they_match_the_committed_fixtures() {
+    // `schema` is local: it must work with no `--state-dir` and no daemon.
+    let output = Process::new(CLI)
+        .arg("schema")
+        .stdin(Stdio::null())
+        .env_remove("SYMBIOTE_CLI_POLICY")
+        .output()
+        .expect("the CLI binary runs");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let emitted: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("`schema` prints one JSON document");
+    let emitted = emitted
+        .as_object()
+        .expect("`schema` prints an object keyed by schema identity");
+    assert_eq!(
+        emitted.len(),
+        2,
+        "the command publishes exactly the envelope and the policy"
+    );
+    // The published fixture IS the contract; the binary must emit it verbatim,
+    // not merely something the fixture happens to accept. A rename, a dropped
+    // description or a relaxed constraint is a drift this catches.
+    for (identity, fixture_name) in [
+        ("symbiote.cli/v1", ENVELOPE_SCHEMA),
+        ("symbiote.cli-policy/v1", POLICY_SCHEMA),
+    ] {
+        let published = emitted
+            .get(identity)
+            .unwrap_or_else(|| panic!("the binary must emit the {identity} schema"));
+        assert_eq!(
+            published,
+            &fixture(fixture_name),
+            "the {identity} schema emitted by the binary has drifted from {fixture_name}"
+        );
+    }
+}
+
+#[test]
+fn schema_write_regenerates_the_committed_fixtures_byte_for_byte() {
+    // The fixtures are generated artifacts: this is the command a maintainer
+    // runs to regenerate them, and it must reproduce the committed bytes
+    // exactly. If it did not, "regenerate" would leave a diff that no one could
+    // tell apart from a real contract change.
+    let directory = unique_directory();
+    std::fs::create_dir_all(&directory).unwrap();
+    let output = Process::new(CLI)
+        .args(["schema", "--write"])
+        .arg(&directory)
+        .stdin(Stdio::null())
+        .env_remove("SYMBIOTE_CLI_POLICY")
+        .output()
+        .expect("the CLI binary runs");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for name in [ENVELOPE_SCHEMA, POLICY_SCHEMA] {
+        let written = std::fs::read_to_string(directory.join(name))
+            .unwrap_or_else(|error| panic!("{} was not written: {error}", name));
+        let committed = std::fs::read_to_string(fixture_path(name))
+            .unwrap_or_else(|error| panic!("{name}: {error}"));
+        assert_eq!(
+            written, committed,
+            "{name} is not what `symbiote schema --write` regenerates"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&directory);
 }
 
 #[test]

--- a/docs/contracts/cli.md
+++ b/docs/contracts/cli.md
@@ -15,6 +15,14 @@ Both are JSON Schema **draft 2020-12**. Automation keys on the `schema` string
 inside the document, never on the presence of individual fields, so a future
 revision is a new `$id` rather than a silent reinterpretation of this one.
 
+The binary emits both documents: `symbiote schema` prints a JSON object keyed
+by schema identity (`symbiote.cli/v1`, `symbiote.cli-policy/v1`). It is a local
+command — no daemon, no `--state-dir`, no authorization — so any installed
+binary can hand out the contract it implements. `symbiote schema --write DIR`
+regenerates the committed fixture files instead of printing them, so the
+fixtures are **generated artifacts**: a contract change is made once in the
+binary and then regenerated, never edited into a fixture by hand.
+
 ## Exit codes
 
 Every invocation ends in one of four codes. They are distinct so a script can
@@ -111,9 +119,15 @@ sufficient for a policy to be honored.
 ## How these fixtures are kept honest
 
 The fixtures are the published contract and the repository keeps them from
-drifting from the binary in two places, because a schema that has quietly
+drifting from the binary in three places, because a schema that has quietly
 drifted is worse than none:
 
+- **Against the binary's own output** (`tests/cli_schema_contract.rs`):
+  `symbiote schema` is run and each emitted document must equal its committed
+  fixture **exactly**, so a fixture edited on its own — or a schema built
+  differently in code — fails the build. A second test runs `symbiote schema
+  --write` into a temporary directory and requires the files it writes to be
+  byte-for-byte the committed ones, so regenerating a clean tree is a no-op.
 - **Against the code** (`src/bin/symbiote.rs` unit tests): the envelope
   fixture's `const` must equal `CLI_SCHEMA`, the policy fixture's `const` must
   equal `POLICY_SCHEMA`, and the policy fixture's `enum` must be exactly the
@@ -159,9 +173,11 @@ The agreement test covers the boundaries both sides can represent.
 files from `docs/contracts/schemas/` and pin them to the binary's own
 constants and risk table. The integration test runs the actual binary and
 validates its stdout through the bounded checker, including the boundary
-documents the schema and the CLI must classify identically. The default,
-non-`--json` output is the daemon's body alone and is deliberately not covered
-by an envelope schema.
+documents the schema and the CLI must classify identically. CI additionally
+regenerates the fixtures with `symbiote schema --write` into a temporary
+directory and fails on any `diff`, so a hand-edited fixture is rejected even
+before the tests run. The default, non-`--json` output is the daemon's body
+alone and is deliberately not covered by an envelope schema.
 
 Published fixtures are not a compatibility policy: this page documents v1, and
 a v2 requires its own `$id`, a compatibility note and migration tests before

--- a/docs/contracts/host.md
+++ b/docs/contracts/host.md
@@ -34,10 +34,11 @@ refusal vs transport failure vs a missing authorization.
 dangerous kinds a policy may pre-authorize. `schema` is the one local
 command: it prints the binary's published envelope and policy JSON Schemas
 (see [cli.md](cli.md)) — or regenerates the committed fixtures with `--write
-DIR` — and needs no daemon, no state directory and no authorization. Identity arguments are passed as
-plain strings and typed on the wire; no caller-supplied actor identities
-exist. The interactive/headless coding-agent experience is #467's surface and
-shares this client plumbing; this binary carries no model loop.
+DIR` — and needs no daemon, no state directory and no authorization. Identity
+arguments are passed as plain strings and typed on the wire; no caller-supplied
+actor identities exist. The interactive/headless coding-agent experience is
+#467's surface and shares this client plumbing; this binary carries no model
+loop.
 
 ### Dangerous operations require explicit authorization
 

--- a/docs/contracts/host.md
+++ b/docs/contracts/host.md
@@ -31,7 +31,10 @@ are distinct: 0 success, 1 usage/connection failure, 2 a daemon-refused
 command (`Err` response), 3 authorization required — scripts branch on
 refusal vs transport failure vs a missing authorization.
 `help` lists the command table, marking dangerous commands and naming the
-dangerous kinds a policy may pre-authorize. Identity arguments are passed as
+dangerous kinds a policy may pre-authorize. `schema` is the one local
+command: it prints the binary's published envelope and policy JSON Schemas
+(see [cli.md](cli.md)) — or regenerates the committed fixtures with `--write
+DIR` — and needs no daemon, no state directory and no authorization. Identity arguments are passed as
 plain strings and typed on the wire; no caller-supplied actor identities
 exist. The interactive/headless coding-agent experience is #467's surface and
 shares this client plumbing; this binary carries no model loop.

--- a/docs/contracts/schemas/symbiote.cli-policy.v1.schema.json
+++ b/docs/contracts/schemas/symbiote.cli-policy.v1.schema.json
@@ -1,20 +1,11 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://symbiote.dev/schemas/symbiote.cli-policy.v1.schema.json",
-  "title": "symbiote CLI authorization policy (symbiote.cli-policy/v1)",
-  "description": "A document named by `--policy FILE`, or by $SYMBIOTE_CLI_POLICY when the flag is absent, that pre-authorizes dangerous operation kinds for noninteractive runs. It may name only the operation kinds this CLI classifies as dangerous: a read or a mutation is already ungated, so listing one would be a no-op an operator could mistake for coverage; an unknown kind cannot be classified; and a wildcard is deliberately not a syntax. A policy is a pre-authorization, never a widening — it cannot grant a permission the daemon would refuse.",
-  "type": "object",
-  "required": ["schema", "authorize"],
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "description": "A document named by `--policy FILE`, or by $SYMBIOTE_CLI_POLICY when the flag is absent, that pre-authorizes dangerous operation kinds for noninteractive runs. It may name only the operation kinds this CLI classifies as dangerous: a read or a mutation is already ungated, so listing one would be a no-op an operator could mistake for coverage; an unknown kind cannot be classified; and a wildcard is deliberately not a syntax. A policy is a pre-authorization, never a widening — it cannot grant a permission the daemon would refuse.",
   "properties": {
-    "schema": {
-      "description": "Schema identity. A different version is refused rather than reinterpreted.",
-      "const": "symbiote.cli-policy/v1"
-    },
     "authorize": {
       "description": "The dangerous operation kinds this policy pre-authorizes. At least one. These are kinds, not command names: `shutdown` covers both the typed command and `raw` naming that operation. Repeating a kind is accepted and collapses: the grants are a set.",
-      "type": "array",
-      "minItems": 1,
       "items": {
         "description": "A kind this CLI classifies as dangerous.",
         "enum": [
@@ -24,13 +15,25 @@
           "shutdown",
           "start_prepared_task"
         ]
-      }
+      },
+      "minItems": 1,
+      "type": "array"
     },
     "expires_at": {
       "description": "Optional unix-millisecond bound. The expiry instant itself is still authorized; a lapsed policy grants nothing and the refusal names the file and the lapse.",
-      "type": "integer",
+      "maximum": 18446744073709551615,
       "minimum": 0,
-      "maximum": 18446744073709551615
+      "type": "integer"
+    },
+    "schema": {
+      "const": "symbiote.cli-policy/v1",
+      "description": "Schema identity. A different version is refused rather than reinterpreted."
     }
-  }
+  },
+  "required": [
+    "schema",
+    "authorize"
+  ],
+  "title": "symbiote CLI authorization policy (symbiote.cli-policy/v1)",
+  "type": "object"
 }

--- a/docs/contracts/schemas/symbiote.cli.v1.schema.json
+++ b/docs/contracts/schemas/symbiote.cli.v1.schema.json
@@ -1,82 +1,112 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://symbiote.dev/schemas/symbiote.cli.v1.schema.json",
-  "title": "symbiote CLI JSON envelope (symbiote.cli/v1)",
-  "description": "One envelope printed to stdout by `symbiote --json`, one per invocation. A success carries `result` (the daemon's own response body, unmodified); a failure carries `error` (the daemon's typed error, or one of the CLI's own codes). Exactly one of the two is present, and `ok` agrees with which one it is. The default (non-`--json`) output is the daemon's body alone and is not described here.",
-  "type": "object",
-  "required": ["schema", "command", "command_id", "ok"],
-  "additionalProperties": false,
-  "properties": {
-    "schema": {
-      "description": "Schema identity. Automation keys on this string rather than on the presence of individual fields.",
-      "const": "symbiote.cli/v1"
+  "$defs": {
+    "error": {
+      "additionalProperties": false,
+      "description": "The daemon's own ProtocolError, or the CLI's own code when nothing was sent.",
+      "properties": {
+        "code": {
+          "description": "The daemon's error code, or one of the CLI's own: `authorization_required` (nothing was sent), `policy_invalid` (the configured policy could not be honored; nothing was sent), `unreachable`.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable detail. Not stable for automation; branch on `code`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
     },
+    "result": {
+      "description": "symbiote_protocol::ResponseBody, which is internally tagged on `kind`.",
+      "properties": {
+        "kind": {
+          "description": "The response body variant, snake_case, e.g. `health`, `shutdown`.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://symbiote.dev/schemas/symbiote.cli.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One envelope printed to stdout by `symbiote --json`, one per invocation. A success carries `result` (the daemon's own response body, unmodified); a failure carries `error` (the daemon's typed error, or one of the CLI's own codes). Exactly one of the two is present, and `ok` agrees with which one it is. The default (non-`--json`) output is the daemon's body alone and is not described here.",
+  "oneOf": [
+    {
+      "description": "Success: a result and no error, with ok true.",
+      "not": {
+        "required": [
+          "error"
+        ]
+      },
+      "properties": {
+        "ok": {
+          "const": true
+        }
+      },
+      "required": [
+        "result"
+      ]
+    },
+    {
+      "description": "Failure: an error and no result, with ok false.",
+      "not": {
+        "required": [
+          "result"
+        ]
+      },
+      "properties": {
+        "ok": {
+          "const": false
+        }
+      },
+      "required": [
+        "error"
+      ]
+    }
+  ],
+  "properties": {
     "command": {
       "description": "The command name as invoked, e.g. `health`, or `raw`.",
-      "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "type": "string"
     },
     "command_id": {
       "description": "The idempotency key this invocation used: the minted id, or a caller-supplied `--command-id`.",
-      "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "type": "string"
+    },
+    "error": {
+      "$ref": "#/$defs/error",
+      "description": "A failure, whether the daemon refused the command or the CLI could not send it."
     },
     "ok": {
       "description": "True exactly when the command succeeded (exit 0) and `result` is present.",
       "type": "boolean"
     },
     "result": {
-      "description": "The daemon's own response body, unmodified. An internally tagged object whose `kind` names the answer.",
-      "$ref": "#/$defs/result"
+      "$ref": "#/$defs/result",
+      "description": "The daemon's own response body, unmodified. An internally tagged object whose `kind` names the answer."
     },
-    "error": {
-      "description": "A failure, whether the daemon refused the command or the CLI could not send it.",
-      "$ref": "#/$defs/error"
+    "schema": {
+      "const": "symbiote.cli/v1",
+      "description": "Schema identity. Automation keys on this string rather than on the presence of individual fields."
     }
   },
-  "oneOf": [
-    {
-      "description": "Success: a result and no error, with ok true.",
-      "required": ["result"],
-      "not": { "required": ["error"] },
-      "properties": { "ok": { "const": true } }
-    },
-    {
-      "description": "Failure: an error and no result, with ok false.",
-      "required": ["error"],
-      "not": { "required": ["result"] },
-      "properties": { "ok": { "const": false } }
-    }
+  "required": [
+    "schema",
+    "command",
+    "command_id",
+    "ok"
   ],
-  "$defs": {
-    "result": {
-      "description": "symbiote_protocol::ResponseBody, which is internally tagged on `kind`.",
-      "type": "object",
-      "required": ["kind"],
-      "properties": {
-        "kind": {
-          "description": "The response body variant, snake_case, e.g. `health`, `shutdown`.",
-          "type": "string",
-          "minLength": 1
-        }
-      }
-    },
-    "error": {
-      "description": "The daemon's own ProtocolError, or the CLI's own code when nothing was sent.",
-      "type": "object",
-      "required": ["code", "message"],
-      "additionalProperties": false,
-      "properties": {
-        "code": {
-          "description": "The daemon's error code, or one of the CLI's own: `authorization_required` (nothing was sent), `policy_invalid` (the configured policy could not be honored; nothing was sent), `unreachable`.",
-          "type": "string",
-          "minLength": 1
-        },
-        "message": {
-          "description": "Human-readable detail. Not stable for automation; branch on `code`.",
-          "type": "string"
-        }
-      }
-    }
-  }
+  "title": "symbiote CLI JSON envelope (symbiote.cli/v1)",
+  "type": "object"
 }


### PR DESCRIPTION
## Intent

Publish the CLI's envelope and policy JSON Schemas from the binary itself, and make the committed fixtures generated artifacts rather than hand-maintained copies.

## What changed

- **`symbiote schema`** — a new local command (no daemon, no `--state-dir`, no authorization) that prints the `symbiote.cli/v1` envelope and `symbiote.cli-policy/v1` policy documents, keyed by schema identity.
- The schemas are **built in code**; the policy's authorizable-kind enum derives from the operation-risk table, so promoting or adding a dangerous kind publishes it in the same change. One table binds each schema's identity, committed filename and builder, so the printed output, the written files and the fixtures cannot drift apart.
- **`symbiote schema --write DIR`** regenerates the fixtures. The committed files were regenerated with it and are now in the binary's canonical generated form.
- Tests require the emitted documents to equal the committed fixtures exactly, and `--write` to reproduce them **byte-for-byte**, so regenerating a clean tree is a no-op.
- CI runs the regeneration into a temporary directory and fails on any `diff`, rejecting a hand-edited fixture before the test suite runs.
- Docs updated: `docs/contracts/cli.md`, `docs/contracts/host.md`, `README.md`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo test -p symbiote-host --locked` — 102 passed / 0 failed
- CI drift step validated locally: clean run exits 0, a one-byte edit to a written schema makes it exit 1

🤖 Generated with Codebuff