### PR TITLE
refactor(cli): one owner for the published contract; flags are never silently dropped (#54)

### DIFF
--- a/crates/symbiote-host/src/bin/symbiote.rs
+++ b/crates/symbiote-host/src/bin/symbiote.rs
@@ -36,20 +36,16 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use symbiote_host::cli_schema::{
+    CLI_SCHEMA, POLICY_SCHEMA, Risk, dangerous_kinds, known_risk_of_kind, published_schemas,
+    risk_of_kind, write_schemas,
+};
+
 /// Exit codes, stable for scripts.
 const EXIT_OK: i32 = 0;
 const EXIT_USAGE: i32 = 1;
 const EXIT_REFUSED: i32 = 2;
 const EXIT_AUTHORIZATION_REQUIRED: i32 = 3;
-
-/// The machine-readable envelope's schema identity. Automation keys on this
-/// string, not on the presence of individual fields.
-pub const CLI_SCHEMA: &str = "symbiote.cli/v1";
-
-/// The authorization policy file's schema identity, versioned independently
-/// of the envelope so either can evolve without silently reinterpreting the
-/// other.
-pub const POLICY_SCHEMA: &str = "symbiote.cli-policy/v1";
 
 /// The environment variable consulted when `--policy` is absent. An empty
 /// value means "no policy", like an unset one.
@@ -85,97 +81,6 @@ impl std::fmt::Display for Usage {
 impl std::error::Error for Usage {}
 
 type Args<'a> = &'a [String];
-
-/// What a command can do to the Host. The classification decides whether the
-/// CLI sends it without an explicit authorization.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Risk {
-    /// Reads only: no daemon state changes.
-    ReadOnly,
-    /// Changes daemon state but starts and stops nothing.
-    Mutation,
-    /// Starts or ends execution — or can express any operation (`raw`).
-    Dangerous,
-}
-
-impl Risk {
-    fn requires_authorization(self) -> bool {
-        matches!(self, Risk::Dangerous)
-    }
-}
-
-/// The ONE table of operation kinds this CLI knows and what sending each can
-/// do. Lookups, the dangerous list the help prints, and policy validation all
-/// read this array, so they cannot drift apart. A kind absent from the table
-/// cannot be proven safe and is treated as dangerous.
-const OPERATION_RISKS: &[(&str, Risk)] = &[
-    // Reads: no daemon state changes.
-    ("hello", Risk::ReadOnly),
-    ("health", Risk::ReadOnly),
-    ("get_host_pulse", Risk::ReadOnly),
-    ("get_project", Risk::ReadOnly),
-    ("get_task", Risk::ReadOnly),
-    ("read_journal", Risk::ReadOnly),
-    ("get_dispatch_preparation", Risk::ReadOnly),
-    ("get_scheduling_projection", Risk::ReadOnly),
-    ("get_team", Risk::ReadOnly),
-    ("get_task_origin", Risk::ReadOnly),
-    ("get_binding", Risk::ReadOnly),
-    ("get_binding_readiness", Risk::ReadOnly),
-    ("get_task_dependencies", Risk::ReadOnly),
-    ("get_route", Risk::ReadOnly),
-    ("resolve_route", Risk::ReadOnly),
-    ("get_work", Risk::ReadOnly),
-    ("get_provider_connection", Risk::ReadOnly),
-    ("get_billing_entitlement", Risk::ReadOnly),
-    ("get_model_descriptor", Risk::ReadOnly),
-    ("get_resource_consent", Risk::ReadOnly),
-    // Mutations: they change state, but they neither start or end execution
-    // nor widen authority.
-    ("create_task", Risk::Mutation),
-    ("prepare_dispatch", Risk::Mutation),
-    ("request_task_completion", Risk::Mutation),
-    ("request_elevation", Risk::Mutation),
-    ("replace_binding", Risk::Mutation),
-    ("record_route", Risk::Mutation),
-    ("set_task_dependencies", Risk::Mutation),
-    ("acquire_task_lease", Risk::Mutation),
-    ("release_task_lease", Risk::Mutation),
-    ("expire_stale_leases", Risk::Mutation),
-    ("replace_provider_connection", Risk::Mutation),
-    ("replace_billing_entitlement", Risk::Mutation),
-    ("replace_model_descriptor", Risk::Mutation),
-    ("replace_team", Risk::Mutation),
-    ("create_work", Risk::Mutation),
-    ("change_work", Risk::Mutation),
-    ("assign_task_origin", Risk::Mutation),
-    ("register_project", Risk::Mutation),
-    ("observe_root_placement", Risk::Mutation),
-    ("revoke_elevation", Risk::Mutation),
-    ("revoke_resource_consent", Risk::Mutation),
-    // Starting or ending execution, or granting capability.
-    ("start_prepared_task", Risk::Dangerous),
-    ("run_started_dispatch", Risk::Dangerous),
-    ("shutdown", Risk::Dangerous),
-    ("decide_elevation", Risk::Dangerous),
-    ("record_resource_consent", Risk::Dangerous),
-];
-
-/// `None` for a kind this build does not know: the caller must fail closed
-/// rather than assume safety.
-fn known_risk_of_kind(kind: &str) -> Option<Risk> {
-    OPERATION_RISKS
-        .iter()
-        .find(|(known, _)| *known == kind)
-        .map(|(_, risk)| *risk)
-}
-
-/// An unknown kind cannot be proven safe, so it is Dangerous rather than
-/// silently allowed — and, for the same reason, it is not *nameable* by a
-/// policy (`known_risk_of_kind` returns `None` for it).
-fn risk_of_kind(kind: &str) -> Risk {
-    known_risk_of_kind(kind).unwrap_or(Risk::Dangerous)
-}
 
 /// How a request came to be authorized. Kept as a value so the decision is
 /// pure and every branch is unit tested without a daemon or a terminal.
@@ -665,11 +570,7 @@ fn print_help() {
     println!();
     println!("commands marked * can send a dangerous operation — one that starts or ends");
     println!("execution, or grants capability:");
-    let dangerous: Vec<&str> = OPERATION_RISKS
-        .iter()
-        .filter(|(_, risk)| risk.requires_authorization())
-        .map(|(kind, _)| *kind)
-        .collect();
+    let dangerous = dangerous_kinds();
     println!("  {}", dangerous.join(", "));
     println!("Those are authorized by --yes, or by an interactive \"yes\" prompt when stdin is");
     println!("a terminal, or by a policy file that names the operation kind. Otherwise they");
@@ -812,192 +713,6 @@ fn error_envelope(command: &str, command_id: &str, code: &str, message: &str) ->
     })
 }
 
-/// The published envelope schema, built here so this binary is its source of
-/// truth: `symbiote schema` prints it, and the committed fixture under
-/// `docs/contracts/schemas/` is proved equal to it by
-/// `tests/cli_schema_contract.rs`. The `const` reads the same `CLI_SCHEMA` the
-/// envelope constructors write, so the two cannot drift.
-fn envelope_schema() -> serde_json::Value {
-    serde_json::json!({
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://symbiote.dev/schemas/symbiote.cli.v1.schema.json",
-        "title": "symbiote CLI JSON envelope (symbiote.cli/v1)",
-        "description": "One envelope printed to stdout by `symbiote --json`, one per invocation. A success carries `result` (the daemon's own response body, unmodified); a failure carries `error` (the daemon's typed error, or one of the CLI's own codes). Exactly one of the two is present, and `ok` agrees with which one it is. The default (non-`--json`) output is the daemon's body alone and is not described here.",
-        "type": "object",
-        "required": ["schema", "command", "command_id", "ok"],
-        "additionalProperties": false,
-        "properties": {
-            "schema": {
-                "description": "Schema identity. Automation keys on this string rather than on the presence of individual fields.",
-                "const": CLI_SCHEMA
-            },
-            "command": {
-                "description": "The command name as invoked, e.g. `health`, or `raw`.",
-                "type": "string",
-                "minLength": 1
-            },
-            "command_id": {
-                "description": "The idempotency key this invocation used: the minted id, or a caller-supplied `--command-id`.",
-                "type": "string",
-                "minLength": 1
-            },
-            "ok": {
-                "description": "True exactly when the command succeeded (exit 0) and `result` is present.",
-                "type": "boolean"
-            },
-            "result": {
-                "description": "The daemon's own response body, unmodified. An internally tagged object whose `kind` names the answer.",
-                "$ref": "#/$defs/result"
-            },
-            "error": {
-                "description": "A failure, whether the daemon refused the command or the CLI could not send it.",
-                "$ref": "#/$defs/error"
-            }
-        },
-        "oneOf": [
-            {
-                "description": "Success: a result and no error, with ok true.",
-                "required": ["result"],
-                "not": { "required": ["error"] },
-                "properties": { "ok": { "const": true } }
-            },
-            {
-                "description": "Failure: an error and no result, with ok false.",
-                "required": ["error"],
-                "not": { "required": ["result"] },
-                "properties": { "ok": { "const": false } }
-            }
-        ],
-        "$defs": {
-            "result": {
-                "description": "symbiote_protocol::ResponseBody, which is internally tagged on `kind`.",
-                "type": "object",
-                "required": ["kind"],
-                "properties": {
-                    "kind": {
-                        "description": "The response body variant, snake_case, e.g. `health`, `shutdown`.",
-                        "type": "string",
-                        "minLength": 1
-                    }
-                }
-            },
-            "error": {
-                "description": "The daemon's own ProtocolError, or the CLI's own code when nothing was sent.",
-                "type": "object",
-                "required": ["code", "message"],
-                "additionalProperties": false,
-                "properties": {
-                    "code": {
-                        "description": "The daemon's error code, or one of the CLI's own: `authorization_required` (nothing was sent), `policy_invalid` (the configured policy could not be honored; nothing was sent), `unreachable`.",
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    "message": {
-                        "description": "Human-readable detail. Not stable for automation; branch on `code`.",
-                        "type": "string"
-                    }
-                }
-            }
-        }
-    })
-}
-
-/// The published policy schema. The `authorize` enum is computed from the
-/// operation-risk table rather than transcribed, so promoting a kind to
-/// dangerous — or adding one — makes it nameable by a policy and published in
-/// the same change.
-fn policy_schema() -> serde_json::Value {
-    let mut dangerous: Vec<&str> = OPERATION_RISKS
-        .iter()
-        .filter(|(_, risk)| *risk == Risk::Dangerous)
-        .map(|(kind, _)| *kind)
-        .collect();
-    dangerous.sort_unstable();
-    serde_json::json!({
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://symbiote.dev/schemas/symbiote.cli-policy.v1.schema.json",
-        "title": "symbiote CLI authorization policy (symbiote.cli-policy/v1)",
-        "description": "A document named by `--policy FILE`, or by $SYMBIOTE_CLI_POLICY when the flag is absent, that pre-authorizes dangerous operation kinds for noninteractive runs. It may name only the operation kinds this CLI classifies as dangerous: a read or a mutation is already ungated, so listing one would be a no-op an operator could mistake for coverage; an unknown kind cannot be classified; and a wildcard is deliberately not a syntax. A policy is a pre-authorization, never a widening — it cannot grant a permission the daemon would refuse.",
-        "type": "object",
-        "required": ["schema", "authorize"],
-        "additionalProperties": false,
-        "properties": {
-            "schema": {
-                "description": "Schema identity. A different version is refused rather than reinterpreted.",
-                "const": POLICY_SCHEMA
-            },
-            "authorize": {
-                "description": "The dangerous operation kinds this policy pre-authorizes. At least one. These are kinds, not command names: `shutdown` covers both the typed command and `raw` naming that operation. Repeating a kind is accepted and collapses: the grants are a set.",
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                    "description": "A kind this CLI classifies as dangerous.",
-                    "enum": dangerous
-                }
-            },
-            "expires_at": {
-                "description": "Optional unix-millisecond bound. The expiry instant itself is still authorized; a lapsed policy grants nothing and the refusal names the file and the lapse.",
-                "type": "integer",
-                "minimum": 0,
-                "maximum": u64::MAX
-            }
-        }
-    })
-}
-
-/// A published schema document: its identity, the committed fixture file it is
-/// published as, and the builder that produces it.
-struct PublishedSchema {
-    identity: &'static str,
-    file_name: &'static str,
-    build: fn() -> serde_json::Value,
-}
-
-/// The published documents. One table, so the object `symbiote schema` prints,
-/// the files `symbiote schema --write DIR` writes, and the committed fixtures
-/// cannot drift apart.
-const PUBLISHED_SCHEMAS: &[PublishedSchema] = &[
-    PublishedSchema {
-        identity: CLI_SCHEMA,
-        file_name: "symbiote.cli.v1.schema.json",
-        build: envelope_schema,
-    },
-    PublishedSchema {
-        identity: POLICY_SCHEMA,
-        file_name: "symbiote.cli-policy.v1.schema.json",
-        build: policy_schema,
-    },
-];
-
-/// Both published documents, keyed by the schema identity each declares. This
-/// is exactly what `symbiote schema` prints.
-fn published_schemas() -> serde_json::Value {
-    let mut documents = serde_json::Map::new();
-    for schema in PUBLISHED_SCHEMAS {
-        documents.insert(schema.identity.to_owned(), (schema.build)());
-    }
-    serde_json::Value::Object(documents)
-}
-
-/// Writes each published document to `directory/<fixture file name>` in the
-/// canonical form regeneration produces. Committing exactly what this writes
-/// is what keeps the fixtures generated artifacts: running it again on a clean
-/// tree leaves the files unchanged.
-fn write_schemas(directory: &Path) -> Result<(), Usage> {
-    for schema in PUBLISHED_SCHEMAS {
-        let document = serde_json::to_string_pretty(&(schema.build)()).map_err(|error| {
-            Usage(format!(
-                "cannot serialize the {} schema: {error}",
-                schema.identity
-            ))
-        })?;
-        let path = directory.join(schema.file_name);
-        std::fs::write(&path, format!("{document}\n"))
-            .map_err(|error| Usage(format!("cannot write {}: {error}", path.display())))?;
-    }
-    Ok(())
-}
-
 /// Names BOTH the typed command and the operation that makes it dangerous:
 /// for `raw`, the operation is the whole story and the operator must see it.
 fn confirm(command: &Command, kind: &str) -> bool {
@@ -1023,6 +738,14 @@ fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
         print_help();
         return Ok(EXIT_USAGE);
     };
+    // `--write` publishes the schemas; it means nothing for any other command,
+    // and a flag that means nothing is a usage error rather than a silent
+    // no-op. Checked before the help and unknown-command paths so it can never
+    // be dropped on the floor.
+    if options.write.is_some() && name != "schema" {
+        eprintln!("symbiote: --write is only valid with `schema`");
+        return Ok(EXIT_USAGE);
+    }
     if name == "help" || name == "--help" {
         print_help();
         return Ok(EXIT_OK);
@@ -1033,6 +756,18 @@ fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
     if name == "schema" {
         if !options.args.is_empty() {
             eprintln!("symbiote: schema takes no arguments; try `symbiote help`");
+            return Ok(EXIT_USAGE);
+        }
+        // `schema` prints machine-readable JSON, but it is not the versioned
+        // `--json` envelope: that envelope's `result` must carry a `kind` the
+        // documents do not have, so wrapping them would either break the
+        // published envelope schema or invent a protocol result body. A flag
+        // that cannot be honored is a usage error, never a silent
+        // reinterpretation.
+        if options.json {
+            eprintln!(
+                "symbiote: `schema` already prints machine-readable JSON and does not emit the --json envelope"
+            );
             return Ok(EXIT_USAGE);
         }
         match &options.write {
@@ -1431,27 +1166,6 @@ mod tests {
         );
     }
 
-    /// The table is the single source of truth, so these pin the properties
-    /// the rest of the CLI (and the help text) read out of it.
-    #[test]
-    fn the_operation_table_is_consistent_and_fails_closed() {
-        let mut kinds: Vec<&str> = OPERATION_RISKS.iter().map(|(kind, _)| *kind).collect();
-        let mut sorted = kinds.clone();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(kinds.len(), sorted.len(), "the table has duplicate kinds");
-        kinds.sort_unstable();
-        // Every kind is found by lookup, and the declared entry is the risk.
-        for (kind, risk) in OPERATION_RISKS {
-            assert_eq!(known_risk_of_kind(kind), Some(*risk), "{kind}");
-            assert_eq!(risk_of_kind(kind), *risk, "{kind}");
-        }
-        // A kind this build does not know is Dangerous (fail closed) but is
-        // NOT nameable by a policy, because only `Some(Dangerous)` is.
-        assert_eq!(known_risk_of_kind("delete_everything"), None);
-        assert_eq!(risk_of_kind("delete_everything"), Risk::Dangerous);
-    }
-
     #[test]
     fn only_an_explicit_yes_confirms() {
         assert!(confirmation_accepted("yes"));
@@ -1542,9 +1256,7 @@ mod tests {
     /// contract. These assertions bind them to this binary, so a change here
     /// cannot leave the published documents describing something else.
     fn load_fixture(name: &str) -> serde_json::Value {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../docs/contracts/schemas")
-            .join(name);
+        let path = symbiote_host::cli_schema::fixture_directory().join(name);
         let text = std::fs::read_to_string(&path)
             .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
         serde_json::from_str(&text)
@@ -1616,11 +1328,7 @@ mod tests {
             .map(|kind| kind.as_str().unwrap())
             .collect();
         published.sort_unstable();
-        let mut dangerous: Vec<&str> = OPERATION_RISKS
-            .iter()
-            .filter(|(_, risk)| *risk == Risk::Dangerous)
-            .map(|(kind, _)| *kind)
-            .collect();
+        let mut dangerous = dangerous_kinds();
         dangerous.sort_unstable();
         assert_eq!(published, dangerous);
         assert!(published.contains(&POLICY_EXAMPLE_KIND));
@@ -1711,11 +1419,7 @@ mod tests {
 
     #[test]
     fn every_dangerous_kind_in_the_table_can_be_named_by_a_policy() {
-        let dangerous: Vec<&str> = OPERATION_RISKS
-            .iter()
-            .filter(|(_, risk)| risk.requires_authorization())
-            .map(|(kind, _)| *kind)
-            .collect();
+        let dangerous = dangerous_kinds();
         // Pins the set the help text and the policy schema describe.
         assert_eq!(
             dangerous,

--- a/crates/symbiote-host/src/cli_schema.rs
+++ b/crates/symbiote-host/src/cli_schema.rs
@@ -1,0 +1,401 @@
+//! The `symbiote` CLI's published contract: what operation kinds exist and
+//! which are dangerous, and the two JSON Schema documents the binary emits.
+//!
+//! This module is the ONE owner of that contract. The `symbiote` binary is the
+//! interface: it parses arguments, renders help and envelopes, decides
+//! authorization and talks to the daemon. Keeping the contract here means the
+//! binary, the CLI's own unit tests and the integration suite all read the same
+//! classification and the same documents, and a change to a published schema
+//! lands in one obvious file.
+//!
+//! Data flows one way: nothing here imports the binary, and nothing here reads
+//! the filesystem except the explicit publication helpers, which take the
+//! directory they act on. `published_schemas` renders the object
+//! `symbiote schema` prints; `document_text` produces the canonical bytes that
+//! `write_schemas` writes and the tests compare against the committed fixtures.
+use std::path::{Path, PathBuf};
+
+/// The machine-readable envelope's schema identity. Automation keys on this
+/// string, not on the presence of individual fields.
+pub const CLI_SCHEMA: &str = "symbiote.cli/v1";
+
+/// The authorization policy file's schema identity, versioned independently
+/// of the envelope so either can evolve without silently reinterpreting the
+/// other.
+pub const POLICY_SCHEMA: &str = "symbiote.cli-policy/v1";
+
+/// What a command can do to the Host. The classification decides whether the
+/// CLI sends it without an explicit authorization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Risk {
+    /// Reads only: no daemon state changes.
+    ReadOnly,
+    /// Changes daemon state but starts and stops nothing.
+    Mutation,
+    /// Starts or ends execution — or can express any operation (`raw`).
+    Dangerous,
+}
+
+impl Risk {
+    pub fn requires_authorization(self) -> bool {
+        matches!(self, Risk::Dangerous)
+    }
+}
+
+/// The ONE table of operation kinds this CLI knows and what sending each can
+/// do. Lookups, the dangerous list the help prints, and policy validation all
+/// read this array, so they cannot drift apart. A kind absent from the table
+/// cannot be proven safe and is treated as dangerous.
+pub const OPERATION_RISKS: &[(&str, Risk)] = &[
+    // Reads: no daemon state changes.
+    ("hello", Risk::ReadOnly),
+    ("health", Risk::ReadOnly),
+    ("get_host_pulse", Risk::ReadOnly),
+    ("get_project", Risk::ReadOnly),
+    ("get_task", Risk::ReadOnly),
+    ("read_journal", Risk::ReadOnly),
+    ("get_dispatch_preparation", Risk::ReadOnly),
+    ("get_scheduling_projection", Risk::ReadOnly),
+    ("get_team", Risk::ReadOnly),
+    ("get_task_origin", Risk::ReadOnly),
+    ("get_binding", Risk::ReadOnly),
+    ("get_binding_readiness", Risk::ReadOnly),
+    ("get_task_dependencies", Risk::ReadOnly),
+    ("get_route", Risk::ReadOnly),
+    ("resolve_route", Risk::ReadOnly),
+    ("get_work", Risk::ReadOnly),
+    ("get_provider_connection", Risk::ReadOnly),
+    ("get_billing_entitlement", Risk::ReadOnly),
+    ("get_model_descriptor", Risk::ReadOnly),
+    ("get_resource_consent", Risk::ReadOnly),
+    // Mutations: they change state, but they neither start or end execution
+    // nor widen authority.
+    ("create_task", Risk::Mutation),
+    ("prepare_dispatch", Risk::Mutation),
+    ("request_task_completion", Risk::Mutation),
+    ("request_elevation", Risk::Mutation),
+    ("replace_binding", Risk::Mutation),
+    ("record_route", Risk::Mutation),
+    ("set_task_dependencies", Risk::Mutation),
+    ("acquire_task_lease", Risk::Mutation),
+    ("release_task_lease", Risk::Mutation),
+    ("expire_stale_leases", Risk::Mutation),
+    ("replace_provider_connection", Risk::Mutation),
+    ("replace_billing_entitlement", Risk::Mutation),
+    ("replace_model_descriptor", Risk::Mutation),
+    ("replace_team", Risk::Mutation),
+    ("create_work", Risk::Mutation),
+    ("change_work", Risk::Mutation),
+    ("assign_task_origin", Risk::Mutation),
+    ("register_project", Risk::Mutation),
+    ("observe_root_placement", Risk::Mutation),
+    ("revoke_elevation", Risk::Mutation),
+    ("revoke_resource_consent", Risk::Mutation),
+    // Starting or ending execution, or granting capability.
+    ("start_prepared_task", Risk::Dangerous),
+    ("run_started_dispatch", Risk::Dangerous),
+    ("shutdown", Risk::Dangerous),
+    ("decide_elevation", Risk::Dangerous),
+    ("record_resource_consent", Risk::Dangerous),
+];
+
+/// `None` for a kind this build does not know: the caller must fail closed
+/// rather than assume safety.
+pub fn known_risk_of_kind(kind: &str) -> Option<Risk> {
+    OPERATION_RISKS
+        .iter()
+        .find(|(known, _)| *known == kind)
+        .map(|(_, risk)| *risk)
+}
+
+/// An unknown kind cannot be proven safe, so it is Dangerous rather than
+/// silently allowed — and, for the same reason, it is not *nameable* by a
+/// policy (`known_risk_of_kind` returns `None` for it).
+pub fn risk_of_kind(kind: &str) -> Risk {
+    known_risk_of_kind(kind).unwrap_or(Risk::Dangerous)
+}
+
+/// The dangerous operation kinds, in table order. A kind absent from the table
+/// is dangerous too, but is not nameable by a policy, so it is not listed.
+pub fn dangerous_kinds() -> Vec<&'static str> {
+    OPERATION_RISKS
+        .iter()
+        .filter(|(_, risk)| risk.requires_authorization())
+        .map(|(kind, _)| *kind)
+        .collect()
+}
+
+/// A published schema document: its identity, the committed fixture file it is
+/// published as, and the builder that produces it.
+pub struct PublishedSchema {
+    pub identity: &'static str,
+    pub file_name: &'static str,
+    build: fn() -> serde_json::Value,
+}
+
+/// The published documents. One table, so the object `symbiote schema` prints,
+/// the files `symbiote schema --write DIR` writes, and the committed fixtures
+/// cannot drift apart.
+pub const PUBLISHED_SCHEMAS: &[PublishedSchema] = &[
+    PublishedSchema {
+        identity: CLI_SCHEMA,
+        file_name: "symbiote.cli.v1.schema.json",
+        build: envelope_schema,
+    },
+    PublishedSchema {
+        identity: POLICY_SCHEMA,
+        file_name: "symbiote.cli-policy.v1.schema.json",
+        build: policy_schema,
+    },
+];
+
+/// A published document could not be produced or written. Kept as a value so
+/// the binary maps it to its own usage error rather than matching on strings.
+#[derive(Debug)]
+pub enum SchemaError {
+    Serialize {
+        identity: &'static str,
+        source: serde_json::Error,
+    },
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaError::Serialize { identity, source } => {
+                write!(f, "cannot serialize the {identity} schema: {source}")
+            }
+            SchemaError::Write { path, source } => {
+                write!(f, "cannot write {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+/// The published envelope schema, built here so it has one source. The `const`
+/// reads the same `CLI_SCHEMA` the envelope constructors write, so the two
+/// cannot drift.
+fn envelope_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://symbiote.dev/schemas/symbiote.cli.v1.schema.json",
+        "title": "symbiote CLI JSON envelope (symbiote.cli/v1)",
+        "description": "One envelope printed to stdout by `symbiote --json`, one per invocation. A success carries `result` (the daemon's own response body, unmodified); a failure carries `error` (the daemon's typed error, or one of the CLI's own codes). Exactly one of the two is present, and `ok` agrees with which one it is. The default (non-`--json`) output is the daemon's body alone and is not described here.",
+        "type": "object",
+        "required": ["schema", "command", "command_id", "ok"],
+        "additionalProperties": false,
+        "properties": {
+            "schema": {
+                "description": "Schema identity. Automation keys on this string rather than on the presence of individual fields.",
+                "const": CLI_SCHEMA
+            },
+            "command": {
+                "description": "The command name as invoked, e.g. `health`, or `raw`.",
+                "type": "string",
+                "minLength": 1
+            },
+            "command_id": {
+                "description": "The idempotency key this invocation used: the minted id, or a caller-supplied `--command-id`.",
+                "type": "string",
+                "minLength": 1
+            },
+            "ok": {
+                "description": "True exactly when the command succeeded (exit 0) and `result` is present.",
+                "type": "boolean"
+            },
+            "result": {
+                "description": "The daemon's own response body, unmodified. An internally tagged object whose `kind` names the answer.",
+                "$ref": "#/$defs/result"
+            },
+            "error": {
+                "description": "A failure, whether the daemon refused the command or the CLI could not send it.",
+                "$ref": "#/$defs/error"
+            }
+        },
+        "oneOf": [
+            {
+                "description": "Success: a result and no error, with ok true.",
+                "required": ["result"],
+                "not": { "required": ["error"] },
+                "properties": { "ok": { "const": true } }
+            },
+            {
+                "description": "Failure: an error and no result, with ok false.",
+                "required": ["error"],
+                "not": { "required": ["result"] },
+                "properties": { "ok": { "const": false } }
+            }
+        ],
+        "$defs": {
+            "result": {
+                "description": "symbiote_protocol::ResponseBody, which is internally tagged on `kind`.",
+                "type": "object",
+                "required": ["kind"],
+                "properties": {
+                    "kind": {
+                        "description": "The response body variant, snake_case, e.g. `health`, `shutdown`.",
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            },
+            "error": {
+                "description": "The daemon's own ProtocolError, or the CLI's own code when nothing was sent.",
+                "type": "object",
+                "required": ["code", "message"],
+                "additionalProperties": false,
+                "properties": {
+                    "code": {
+                        "description": "The daemon's error code, or one of the CLI's own: `authorization_required` (nothing was sent), `policy_invalid` (the configured policy could not be honored; nothing was sent), `unreachable`.",
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "message": {
+                        "description": "Human-readable detail. Not stable for automation; branch on `code`.",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// The published policy schema. The `authorize` enum is computed from the
+/// operation-risk table rather than transcribed, so promoting a kind to
+/// dangerous — or adding one — makes it nameable by a policy and published in
+/// the same change.
+fn policy_schema() -> serde_json::Value {
+    let mut dangerous = dangerous_kinds();
+    dangerous.sort_unstable();
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://symbiote.dev/schemas/symbiote.cli-policy.v1.schema.json",
+        "title": "symbiote CLI authorization policy (symbiote.cli-policy/v1)",
+        "description": "A document named by `--policy FILE`, or by $SYMBIOTE_CLI_POLICY when the flag is absent, that pre-authorizes dangerous operation kinds for noninteractive runs. It may name only the operation kinds this CLI classifies as dangerous: a read or a mutation is already ungated, so listing one would be a no-op an operator could mistake for coverage; an unknown kind cannot be classified; and a wildcard is deliberately not a syntax. A policy is a pre-authorization, never a widening — it cannot grant a permission the daemon would refuse.",
+        "type": "object",
+        "required": ["schema", "authorize"],
+        "additionalProperties": false,
+        "properties": {
+            "schema": {
+                "description": "Schema identity. A different version is refused rather than reinterpreted.",
+                "const": POLICY_SCHEMA
+            },
+            "authorize": {
+                "description": "The dangerous operation kinds this policy pre-authorizes. At least one. These are kinds, not command names: `shutdown` covers both the typed command and `raw` naming that operation. Repeating a kind is accepted and collapses: the grants are a set.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "description": "A kind this CLI classifies as dangerous.",
+                    "enum": dangerous
+                }
+            },
+            "expires_at": {
+                "description": "Optional unix-millisecond bound. The expiry instant itself is still authorized; a lapsed policy grants nothing and the refusal names the file and the lapse.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": u64::MAX
+            }
+        }
+    })
+}
+
+/// Both published documents, keyed by the schema identity each declares. This
+/// is exactly what `symbiote schema` prints.
+pub fn published_schemas() -> serde_json::Value {
+    let mut documents = serde_json::Map::new();
+    for schema in PUBLISHED_SCHEMAS {
+        documents.insert(schema.identity.to_owned(), (schema.build)());
+    }
+    serde_json::Value::Object(documents)
+}
+
+/// The canonical bytes of one published document: pretty JSON plus a trailing
+/// newline. `write_schemas` writes exactly this and the contract tests compare
+/// it to the committed fixture, so "what the binary emits" has one producer.
+pub fn document_text(schema: &PublishedSchema) -> Result<String, SchemaError> {
+    let mut text = serde_json::to_string_pretty(&(schema.build)()).map_err(|source| {
+        SchemaError::Serialize {
+            identity: schema.identity,
+            source,
+        }
+    })?;
+    text.push('\n');
+    Ok(text)
+}
+
+/// Writes each published document to `directory/<fixture file name>` in the
+/// canonical form regeneration produces. Committing exactly what this writes
+/// is what keeps the fixtures generated artifacts: running it again on a clean
+/// tree leaves the files unchanged.
+pub fn write_schemas(directory: &Path) -> Result<(), SchemaError> {
+    for schema in PUBLISHED_SCHEMAS {
+        let path = directory.join(schema.file_name);
+        std::fs::write(&path, document_text(schema)?)
+            .map_err(|source| SchemaError::Write { path, source })?;
+    }
+    Ok(())
+}
+
+/// The committed fixtures' directory, resolved from this crate's manifest so
+/// the binary, the unit tests, the integration tests and any tooling agree on
+/// one path instead of each spelling `../../docs/contracts/schemas`.
+pub fn fixture_directory() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/contracts/schemas")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The table is the single source of truth, so these pin the properties the
+    /// rest of the CLI (and the help text) read out of it.
+    #[test]
+    fn the_operation_table_is_consistent_and_fails_closed() {
+        let mut kinds: Vec<&str> = OPERATION_RISKS.iter().map(|(kind, _)| *kind).collect();
+        let mut sorted = kinds.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(kinds.len(), sorted.len(), "the table has duplicate kinds");
+        kinds.sort_unstable();
+        // Every kind is found by lookup, and the declared entry is the risk.
+        for (kind, risk) in OPERATION_RISKS {
+            assert_eq!(known_risk_of_kind(kind), Some(*risk), "{kind}");
+            assert_eq!(risk_of_kind(kind), *risk, "{kind}");
+        }
+        // A kind this build does not know is Dangerous (fail closed) but is
+        // NOT nameable by a policy, because only `Some(Dangerous)` is.
+        assert_eq!(known_risk_of_kind("delete_everything"), None);
+        assert_eq!(risk_of_kind("delete_everything"), Risk::Dangerous);
+        assert!(!dangerous_kinds().is_empty());
+        for kind in dangerous_kinds() {
+            assert!(risk_of_kind(kind).requires_authorization(), "{kind}");
+        }
+    }
+
+    /// The committed fixtures are generated artifacts. This pins the builders
+    /// to them in-process, so a change to a document fails without needing the
+    /// binary or a daemon — the gap the subprocess-only tests left open.
+    #[test]
+    fn the_committed_fixtures_are_exactly_what_the_builders_emit() {
+        for schema in PUBLISHED_SCHEMAS {
+            let path = fixture_directory().join(schema.file_name);
+            let committed = std::fs::read_to_string(&path)
+                .unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+            assert_eq!(
+                committed,
+                document_text(schema).expect("a published document serializes"),
+                "{} is not what the builder emits; regenerate it with `symbiote schema --write`",
+                schema.file_name
+            );
+        }
+        // The printed object is the same documents the writer produces.
+        let printed = published_schemas();
+        assert_eq!(printed.as_object().map(serde_json::Map::len), Some(2));
+    }
+}

--- a/crates/symbiote-host/src/lib.rs
+++ b/crates/symbiote-host/src/lib.rs
@@ -4,6 +4,11 @@ compile_error!(
     "symbiote-host currently requires Linux SO_PEERCRED; other transports remain unimplemented"
 );
 
+/// The `symbiote` CLI's published contract (#54): the schema identities, the
+/// operation-risk classification those identities describe, and the JSON
+/// Schema documents the binary emits. One owner for what the CLI promises
+/// automation, shared by the binary and its test suites.
+pub mod cli_schema;
 /// Context/credential resolution wiring (#217): the store-backed
 /// `ContextSource` and the dispatch-facet resolution the activation path
 /// uses. Credential VALUES live only in the operator's broker.

--- a/crates/symbiote-host/tests/cli_schema_contract.rs
+++ b/crates/symbiote-host/tests/cli_schema_contract.rs
@@ -9,7 +9,6 @@
 mod support;
 
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
 use std::process::{Command as Process, Output, Stdio};
 
 use support::*;
@@ -17,11 +16,11 @@ use support::*;
 const ENVELOPE_SCHEMA: &str = "symbiote.cli.v1.schema.json";
 const POLICY_SCHEMA: &str = "symbiote.cli-policy.v1.schema.json";
 
-/// The path of a published fixture under `docs/contracts/schemas/`.
+/// The path of a published fixture; the contract module owns the directory, so
+/// the binary, its unit tests and this suite cannot disagree about where the
+/// fixtures live.
 fn fixture_path(name: &str) -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../docs/contracts/schemas")
-        .join(name)
+    symbiote_host::cli_schema::fixture_directory().join(name)
 }
 
 /// Loads a published fixture from `docs/contracts/schemas/`.
@@ -466,6 +465,69 @@ fn schema_write_regenerates_the_committed_fixtures_byte_for_byte() {
         );
     }
     let _ = std::fs::remove_dir_all(&directory);
+}
+
+#[test]
+fn write_is_scoped_to_the_schema_command() {
+    // `--write` publishes schemas and means nothing for any other command. A
+    // flag that cannot be honored is a usage error, never a silent no-op: a
+    // regression would let `health` reach the daemon and exit 0, so the fake
+    // daemon seeing no frame is part of the assertion.
+    let directory = unique_directory();
+    std::fs::create_dir_all(&directory).unwrap();
+    for command in ["health", "help"] {
+        let (output, frame) = run_cli(&["--write", directory.to_str().unwrap(), command]);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "--write with `{command}` must be a usage error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            frame.is_none(),
+            "--write with `{command}` must not reach the daemon"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("--write"),
+            "the refusal names the flag: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    assert!(
+        !directory.join(ENVELOPE_SCHEMA).exists(),
+        "a misused --write must not write anything"
+    );
+    let _ = std::fs::remove_dir_all(&directory);
+}
+
+#[test]
+fn json_is_rejected_by_schema_rather_than_reinterpreted() {
+    // `--json` promises the versioned envelope on every invocation; `schema`
+    // prints machine-readable JSON that is not that envelope. The envelope
+    // schema requires a `result.kind` the documents do not carry, so the flag
+    // is a usage error instead of a silent reinterpretation.
+    let output = Process::new(CLI)
+        .args(["schema", "--json"])
+        .stdin(Stdio::null())
+        .env_remove("SYMBIOTE_CLI_POLICY")
+        .output()
+        .expect("the CLI binary runs");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a usage failure prints nothing: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--json"),
+        "the refusal names the flag: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]

--- a/docs/contracts/cli.md
+++ b/docs/contracts/cli.md
@@ -21,7 +21,16 @@ command — no daemon, no `--state-dir`, no authorization — so any installed
 binary can hand out the contract it implements. `symbiote schema --write DIR`
 regenerates the committed fixture files instead of printing them, so the
 fixtures are **generated artifacts**: a contract change is made once in the
-binary and then regenerated, never edited into a fixture by hand.
+binary and then regenerated, never edited into a fixture by hand. `--write`
+is valid only here: with any other command it is a usage error, because a flag
+that means nothing is never silently dropped.
+
+The contract itself lives in `symbiote_host::cli_schema` (`crates/symbiote-host/src/cli_schema.rs`):
+the schema identities, the `OPERATION_RISKS` table that fixes the policy
+schema's `enum`, the document builders, the published-document table, and the
+fixture directory. The `symbiote` binary is the interface — it renders that
+contract, classifies operations with it, and decides authorization — so no
+second owner can hold a copy that drifts.
 
 ## Exit codes
 
@@ -42,6 +51,13 @@ parsing prose.
 daemon's pretty-printed body. The default output is unchanged, so existing
 scripts that read pretty JSON keep working. The envelope is a flat object: four
 keys always present, plus exactly one of `result` and `error`.
+
+The local `schema` command is the one command that does not accept `--json`,
+and it refuses it rather than reinterpreting it: `symbiote schema` already
+prints machine-readable JSON, and that JSON is not this envelope — the
+documents have no `result.kind`, so wrapping them would either violate the
+published envelope schema or invent a protocol result body. `symbiote schema
+--json` is a usage error (exit 1) that prints nothing.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
@@ -128,11 +144,13 @@ drifted is worse than none:
   differently in code — fails the build. A second test runs `symbiote schema
   --write` into a temporary directory and requires the files it writes to be
   byte-for-byte the committed ones, so regenerating a clean tree is a no-op.
-- **Against the code** (`src/bin/symbiote.rs` unit tests): the envelope
-  fixture's `const` must equal `CLI_SCHEMA`, the policy fixture's `const` must
-  equal `POLICY_SCHEMA`, and the policy fixture's `enum` must be exactly the
-  kinds the operation-risk table marks dangerous. A new dangerous kind that is
-  not published fails the build.
+- **Against the code** (`src/cli_schema.rs` unit tests, in the contract
+  module): the builders' canonical bytes must equal the committed fixtures,
+  the envelope fixture's `const` must equal `CLI_SCHEMA`, the policy fixture's
+  `const` must equal `POLICY_SCHEMA`, and the policy fixture's `enum` must be
+  exactly the kinds the operation-risk table marks dangerous. This pins the
+  builders in-process, so drift fails `cargo test --lib` without a binary or a
+  daemon; a new dangerous kind that is not published fails the build.
 - **Against real output** (`tests/cli_schema_contract.rs`): the real
   `symbiote` binary is run against a fake daemon socket and its actual stdout
   envelopes are validated against the envelope fixture — success, daemon
@@ -169,9 +187,10 @@ The agreement test covers the boundaries both sides can represent.
 
 ## Verification and remaining acceptance
 
-`cargo test -p symbiote-host` runs both halves. The unit tests read the fixture
-files from `docs/contracts/schemas/` and pin them to the binary's own
-constants and risk table. The integration test runs the actual binary and
+`cargo test -p symbiote-host` runs both halves. The contract module's unit
+tests compare the builders' canonical bytes to the fixture files under
+`docs/contracts/schemas/` and pin them to its own constants and risk table. The
+integration test runs the actual binary and
 validates its stdout through the bounded checker, including the boundary
 documents the schema and the CLI must classify identically. CI additionally
 regenerates the fixtures with `symbiote schema --write` into a temporary

--- a/docs/contracts/host.md
+++ b/docs/contracts/host.md
@@ -34,7 +34,10 @@ refusal vs transport failure vs a missing authorization.
 dangerous kinds a policy may pre-authorize. `schema` is the one local
 command: it prints the binary's published envelope and policy JSON Schemas
 (see [cli.md](cli.md)) — or regenerates the committed fixtures with `--write
-DIR` — and needs no daemon, no state directory and no authorization. Identity
+DIR` — and needs no daemon, no state directory and no authorization. It is the
+only command for which `--write` is valid, and the one command that refuses
+`--json` (its output is machine-readable JSON, but not the envelope); both are
+usage errors anywhere else, never silently dropped. Identity
 arguments are passed as plain strings and typed on the wire; no caller-supplied
 actor identities exist. The interactive/headless coding-agent experience is
 #467's surface and shares this client plumbing; this binary carries no model
@@ -105,7 +108,8 @@ Flags are recognized before or after the command (`symbiote shutdown
 --yes` works), `--` ends flag parsing so an argument beginning with dashes
 stays expressible, and an unknown flag is a usage error rather than a
 silently-dropped token. `--json` prints one machine-readable envelope per
-invocation on stdout instead of pretty output: `schema` is the versioned
+invocation on stdout instead of pretty output (the local `schema` command
+refuses it; see [cli.md](cli.md)): `schema` is the versioned
 `symbiote.cli/v1`, alongside `command`, `command_id`, `ok`, and either
 `result` (the daemon's own body, unmodified) or `error.code` — the daemon's
 error code, or the CLI's own `authorization_required` (nothing was sent),


### PR DESCRIPTION
Part of #54. This lands the CLI-contract restructure together with two flag behaviors the earlier schema passes left unsettled.

## Structure

The published contract now lives in `symbiote_host::cli_schema` (`crates/symbiote-host/src/cli_schema.rs`): the schema identities, the `OPERATION_RISKS` classification that fixes the policy schema's `enum`, the document builders, the published-document table, the canonical serialization, and the fixture directory. The `symbiote` binary is only the interface now. The fixtures path is named once instead of three times, the repeated dangerous-kind filter is `dangerous_kinds()`, and the builder-equals-fixture check runs in-process under `cargo test --lib` rather than only through the binary.

## Decided behaviors

- **`--write` is scoped to `schema`.** With any other command (`health`, `help`, …) it is a usage error (exit 1) that sends nothing, instead of being accepted and silently discarded — matching the CLI's stated posture that flags are never silently dropped.
- **`schema` refuses `--json`.** `--json` promises the versioned `symbiote.cli/v1` envelope, whose `result` must carry a `kind` the published documents do not have; wrapping them would either violate the published envelope schema or invent a protocol result body. `symbiote schema --json` is a usage error that prints nothing.

Both decisions are pinned by tests (`write_is_scoped_to_the_schema_command`, `json_is_rejected_by_schema_rather_than_reinterpreted`) that fail against the previous behavior.

## Protected bytes unchanged

Plain `symbiote schema` stdout is exactly the canonical committed fixtures (verified byte-for-byte), and `schema --write` still reproduces them exactly, so the `Committed CLI schemas match what the binary emits` step stays green.

## Verification (re-established on this head)

From a clean `symbiote-host` rebuild (2298 files removed): `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean; `cargo test -p symbiote-host --locked` **105 passed / 0 failed**. Mutating `command_id.minLength` 1→2 in the builder fails `cli_schema::tests::the_committed_fixtures_are_exactly_what_the_builders_emit` and makes the CI step's exact commands (`schema --write` into a temp dir, then `diff -ru docs/contracts/schemas <tmp>`) exit 1; restored and green.

🤖 Generated with Codebuff