### PR TITLE
fix(cli): a flag a command cannot honor is a usage error, never a silent no-op

### DIFF
--- a/crates/symbiote-host/src/bin/symbiote.rs
+++ b/crates/symbiote-host/src/bin/symbiote.rs
@@ -564,6 +564,11 @@ fn print_help() {
     println!("  --json            one machine-readable envelope per invocation on stdout");
     println!("  --yes             explicit authorization for this one dangerous command");
     println!();
+    println!("flags are per command: daemon commands honor --state-dir, --command-id,");
+    println!("--policy, --json and --yes; `schema` honors only --write; `help` honors none. A");
+    println!("flag a command cannot honor is a usage error that names it, never silently");
+    println!("dropped.");
+    println!();
     println!("responses are the daemon's JSON (pretty-printed). Exit codes:");
     println!("0 success, 1 usage/connection failure, 2 daemon-refused command,");
     println!("3 authorization required (no request was sent).");
@@ -685,6 +690,75 @@ fn parse_options(arguments: &[String]) -> Result<Options, Usage> {
     Ok(options)
 }
 
+/// Which flags an invocation actually supplied. Checked as a whole so flag
+/// applicability is one decision instead of an `if` per flag.
+#[derive(Clone, Copy, Default)]
+struct Flags {
+    state_dir: bool,
+    command_id: bool,
+    policy: bool,
+    write: bool,
+    json: bool,
+    yes: bool,
+}
+
+impl Flags {
+    /// The supplied flags `honored` does not include, named as they are typed,
+    /// in documentation order.
+    fn unsuited_for(self, honored: Flags) -> Vec<&'static str> {
+        [
+            (self.state_dir && !honored.state_dir, "--state-dir"),
+            (self.command_id && !honored.command_id, "--command-id"),
+            (self.policy && !honored.policy, "--policy"),
+            (self.write && !honored.write, "--write"),
+            (self.json && !honored.json, "--json"),
+            (self.yes && !honored.yes, "--yes"),
+        ]
+        .into_iter()
+        .filter(|(supplied, _)| *supplied)
+        .map(|(_, name)| name)
+        .collect()
+    }
+}
+
+impl Options {
+    fn supplied(&self) -> Flags {
+        Flags {
+            state_dir: self.state_dir.is_some(),
+            command_id: self.command_id_override.is_some(),
+            policy: self.policy.is_some(),
+            write: self.write.is_some(),
+            json: self.json,
+            yes: self.yes,
+        }
+    }
+}
+
+/// The flags each command can honor. A flag outside this set is a usage error
+/// that names it, never a silent no-op. Every daemon command maps a request
+/// over the socket, so all five daemon-facing flags apply to each of them
+/// (`--policy` is consulted only for a dangerous operation and `--yes` only
+/// authorizes one, but both are valid flags on any daemon command). The local
+/// commands honor only what they use: `schema` publishes documents, so
+/// `--write`; `help` renders the command table, so nothing.
+fn honored_flags(command: &str) -> Flags {
+    match command {
+        "schema" => Flags {
+            write: true,
+            ..Flags::default()
+        },
+        "help" | "--help" => Flags::default(),
+        _ => Flags {
+            state_dir: true,
+            command_id: true,
+            policy: true,
+            json: true,
+            yes: true,
+            ..Flags::default()
+        },
+    }
+}
+
 /// The versioned success envelope: the daemon's own body, unmodified.
 fn success_envelope(
     command: &str,
@@ -738,12 +812,16 @@ fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
         print_help();
         return Ok(EXIT_USAGE);
     };
-    // `--write` publishes the schemas; it means nothing for any other command,
-    // and a flag that means nothing is a usage error rather than a silent
-    // no-op. Checked before the help and unknown-command paths so it can never
-    // be dropped on the floor.
-    if options.write.is_some() && name != "schema" {
-        eprintln!("symbiote: --write is only valid with `schema`");
+    // A flag a command cannot honor is a usage error that names it, never a
+    // silent no-op. This is the one place flag applicability is decided, for
+    // the local commands and the daemon commands alike, before any of them is
+    // answered or connects.
+    let unsuited = options.supplied().unsuited_for(honored_flags(&name));
+    if !unsuited.is_empty() {
+        eprintln!(
+            "symbiote: `{name}` does not accept {}; try `symbiote help`",
+            unsuited.join(", ")
+        );
         return Ok(EXIT_USAGE);
     }
     if name == "help" || name == "--help" {
@@ -756,18 +834,6 @@ fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
     if name == "schema" {
         if !options.args.is_empty() {
             eprintln!("symbiote: schema takes no arguments; try `symbiote help`");
-            return Ok(EXIT_USAGE);
-        }
-        // `schema` prints machine-readable JSON, but it is not the versioned
-        // `--json` envelope: that envelope's `result` must carry a `kind` the
-        // documents do not have, so wrapping them would either break the
-        // published envelope schema or invent a protocol result body. A flag
-        // that cannot be honored is a usage error, never a silent
-        // reinterpretation.
-        if options.json {
-            eprintln!(
-                "symbiote: `schema` already prints machine-readable JSON and does not emit the --json envelope"
-            );
             return Ok(EXIT_USAGE);
         }
         match &options.write {
@@ -1233,6 +1299,41 @@ mod tests {
         assert_eq!(literal.command_id_override.as_deref(), Some("--yes"));
         assert_eq!(literal.command.as_deref(), Some("health"));
         assert!(!literal.yes);
+    }
+
+    #[test]
+    fn flag_applicability_is_declared_per_command() {
+        // One table decides which flags each command can honor, so adding a
+        // local command means naming its flags there rather than sprinkling
+        // `if` checks through the handler. `schema` honors `--write` alone,
+        // `help` honors nothing, and daemon commands honor the daemon flags.
+        let schema = options(&["--write", "/tmp/s", "schema"]);
+        assert!(
+            schema
+                .supplied()
+                .unsuited_for(honored_flags("schema"))
+                .is_empty()
+        );
+        for (arguments, named) in [
+            (vec!["--json", "schema"], "--json"),
+            (vec!["--yes", "help"], "--yes"),
+            (vec!["--write", "/tmp/s", "health"], "--write"),
+        ] {
+            let supplied = options(&arguments).supplied();
+            let command = arguments.last().unwrap();
+            assert_eq!(
+                supplied.unsuited_for(honored_flags(command)),
+                vec![named],
+                "{arguments:?}"
+            );
+        }
+        let daemon = options(&["--state-dir", "/s", "--json", "--yes", "shutdown"]);
+        assert!(
+            daemon
+                .supplied()
+                .unsuited_for(honored_flags("shutdown"))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/symbiote-host/tests/cli_schema_contract.rs
+++ b/crates/symbiote-host/tests/cli_schema_contract.rs
@@ -531,6 +531,69 @@ fn json_is_rejected_by_schema_rather_than_reinterpreted() {
 }
 
 #[test]
+fn flags_a_command_cannot_honor_are_usage_errors() {
+    // One rule, applied uniformly: each command declares the flags it can
+    // honor, and a supplied flag outside that set is a usage error that names
+    // it, never a silent no-op. Daemon commands honor the daemon-facing flags;
+    // the local `schema` honors `--write` alone; the local `help` honors
+    // nothing. This fails against the earlier behavior, where `--json help`
+    // exited 0 with plain help text and `--state-dir`/`--command-id`/
+    // `--policy`/`--yes` were accepted and discarded by the local commands.
+    let run_bare = |arguments: &[&str]| {
+        Process::new(CLI)
+            .args(arguments)
+            .stdin(Stdio::null())
+            .env_remove("SYMBIOTE_CLI_POLICY")
+            .output()
+            .expect("the CLI binary runs")
+    };
+    for (arguments, named) in [
+        (vec!["--json", "help"], "--json"),
+        (vec!["--state-dir", "/tmp", "help"], "--state-dir"),
+        (vec!["--yes", "help"], "--yes"),
+        (vec!["--yes", "schema"], "--yes"),
+        (vec!["--command-id", "c1", "schema"], "--command-id"),
+        (vec!["--policy", "/tmp/p.json", "schema"], "--policy"),
+    ] {
+        let output = run_bare(&arguments);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{arguments:?} must be a usage error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{arguments:?} must print no result: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(named),
+            "{arguments:?} must name {named}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    // A daemon flag on a local command is refused before any connection, so
+    // the support helper's fake daemon sees no frame.
+    let (help, frame) = run_cli(&["help"]);
+    assert_eq!(help.status.code(), Some(1));
+    assert!(frame.is_none(), "a refused flag must not reach the daemon");
+    // And the flags a command does honor keep working: `--json` on a daemon
+    // command still produces the envelope and reaches the daemon.
+    let (health, frame) = run_cli(&["health", "--json"]);
+    assert_eq!(
+        health.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&health.stderr)
+    );
+    assert!(
+        frame.is_some(),
+        "`--json health` must still reach the daemon"
+    );
+}
+
+#[test]
 fn the_fixtures_stay_within_the_checkers_subset() {
     // If a fixture used a keyword the checker did not implement, "the output
     // validates" would become a claim this test silently ignored. Fail first.

--- a/crates/symbiote-host/tests/daemon.rs
+++ b/crates/symbiote-host/tests/daemon.rs
@@ -1375,8 +1375,17 @@ fn cli_administration_flow_uses_typed_commands_end_to_end() {
         .unwrap();
     assert_eq!(dead.status.code(), Some(1));
 
-    // Help exits 0 with the command table.
-    let help = run(&["help"]);
+    // Help exits 0 with the command table. It is answered locally and honors
+    // no flags, so it is invoked without the `--state-dir` the `run` closure
+    // prepends: a flag a command cannot honor is a usage error, never a silent
+    // no-op (see `flags_a_command_cannot_honor_are_usage_errors` in
+    // `cli_schema_contract`).
+    let help = Command::new(env!("CARGO_BIN_EXE_symbiote"))
+        .arg("help")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
     assert_eq!(help.status.code(), Some(0));
     assert!(String::from_utf8_lossy(&help.stdout).contains("run-started-dispatch"));
 }

--- a/docs/contracts/cli.md
+++ b/docs/contracts/cli.md
@@ -21,9 +21,17 @@ command — no daemon, no `--state-dir`, no authorization — so any installed
 binary can hand out the contract it implements. `symbiote schema --write DIR`
 regenerates the committed fixture files instead of printing them, so the
 fixtures are **generated artifacts**: a contract change is made once in the
-binary and then regenerated, never edited into a fixture by hand. `--write`
-is valid only here: with any other command it is a usage error, because a flag
-that means nothing is never silently dropped.
+binary and then regenerated, never edited into a fixture by hand.
+
+Flags are declared per command, and a flag a command cannot honor is a usage
+error that names it, never a silent no-op. The daemon commands honor the five
+daemon-facing flags (`--state-dir`, `--command-id`, `--policy`, `--json`,
+`--yes`), because each of them is answered by a request over the socket; the
+local `schema` command honors only `--write`, and the local `help` command
+honors nothing. So `symbiote --write DIR health`, `symbiote --json help`,
+`symbiote --state-dir DIR schema` and `symbiote schema --yes` each exit 1
+printing nothing, while `symbiote --state-dir DIR shutdown --yes` and
+`symbiote --json health` are unaffected.
 
 The contract itself lives in `symbiote_host::cli_schema` (`crates/symbiote-host/src/cli_schema.rs`):
 the schema identities, the `OPERATION_RISKS` table that fixes the policy
@@ -52,12 +60,13 @@ daemon's pretty-printed body. The default output is unchanged, so existing
 scripts that read pretty JSON keep working. The envelope is a flat object: four
 keys always present, plus exactly one of `result` and `error`.
 
-The local `schema` command is the one command that does not accept `--json`,
-and it refuses it rather than reinterpreting it: `symbiote schema` already
-prints machine-readable JSON, and that JSON is not this envelope — the
-documents have no `result.kind`, so wrapping them would either violate the
-published envelope schema or invent a protocol result body. `symbiote schema
---json` is a usage error (exit 1) that prints nothing.
+The local `schema` and `help` commands do not accept `--json`; `schema`
+refuses it rather than reinterpreting it: `symbiote schema` already prints
+machine-readable JSON, and that JSON is not this envelope — the documents have
+no `result.kind`, so wrapping them would either violate the published envelope
+schema or invent a protocol result body. `symbiote schema --json` and
+`symbiote --json help` are usage errors (exit 1) that print nothing, per the
+flag rule above.
 
 | Field | Type | Meaning |
 | --- | --- | --- |

--- a/docs/contracts/host.md
+++ b/docs/contracts/host.md
@@ -31,13 +31,16 @@ are distinct: 0 success, 1 usage/connection failure, 2 a daemon-refused
 command (`Err` response), 3 authorization required — scripts branch on
 refusal vs transport failure vs a missing authorization.
 `help` lists the command table, marking dangerous commands and naming the
-dangerous kinds a policy may pre-authorize. `schema` is the one local
-command: it prints the binary's published envelope and policy JSON Schemas
-(see [cli.md](cli.md)) — or regenerates the committed fixtures with `--write
-DIR` — and needs no daemon, no state directory and no authorization. It is the
-only command for which `--write` is valid, and the one command that refuses
-`--json` (its output is machine-readable JSON, but not the envelope); both are
-usage errors anywhere else, never silently dropped. Identity
+dangerous kinds a policy may pre-authorize. `help` is answered locally and
+honors no flags; `schema` is the other local command: it prints the binary's
+published envelope and policy JSON Schemas (see [cli.md](cli.md)) — or
+regenerates the committed fixtures with `--write DIR` — and needs no daemon,
+no state directory and no authorization. `--write` is valid only on `schema`,
+and `--json` is not valid on `schema` or `help` (schema's output is
+machine-readable JSON, but not the envelope). Every flag is declared per
+command: the daemon commands honor the daemon-facing flags, `schema` honors
+`--write` alone, and `help` honors nothing — a flag a command cannot honor is
+a usage error that names it, never silently dropped. Identity
 arguments are passed as plain strings and typed on the wire; no caller-supplied
 actor identities exist. The interactive/headless coding-agent experience is
 #467's surface and shares this client plumbing; this binary carries no model
@@ -108,8 +111,8 @@ Flags are recognized before or after the command (`symbiote shutdown
 --yes` works), `--` ends flag parsing so an argument beginning with dashes
 stays expressible, and an unknown flag is a usage error rather than a
 silently-dropped token. `--json` prints one machine-readable envelope per
-invocation on stdout instead of pretty output (the local `schema` command
-refuses it; see [cli.md](cli.md)): `schema` is the versioned
+invocation on stdout instead of pretty output (the local `schema` and `help`
+commands do not accept it; see [cli.md](cli.md)): `schema` is the versioned
 `symbiote.cli/v1`, alongside `command`, `command_id`, `ok`, and either
 `result` (the daemon's own body, unmodified) or `error.code` — the daemon's
 error code, or the CLI's own `authorization_required` (nothing was sent),


### PR DESCRIPTION
Refs #54.

## What was wrong

Flag applicability was ad hoc. `--write` was scoped to `schema`, but:

- `symbiote --json help` exited 0 with plain help text, silently dropping `--json`.
- `--state-dir`, `--command-id`, `--policy` and `--yes` were accepted and ignored by the local `schema` and `help` paths.

That contradicts the CLI's own posture ("flags are never silently dropped") and made the docs' claim that `schema` is "the one command that does not accept `--json`" an overclaim.

## What changed

- **One applicability table.** `honored_flags(command)` declares the flags each command can honor: daemon commands honor the five daemon-facing flags (`--state-dir`, `--command-id`, `--policy`, `--json`, `--yes`); `schema` honors `--write` alone; `help` honors nothing. Any supplied flag outside that set is a usage error that names it, decided in one place before the command is answered or connects. The per-flag `if` checks in the `schema` handler are gone.
- **Docs and `help` state the rule as it behaves**: `docs/contracts/cli.md`, `docs/contracts/host.md`, and the `symbiote help` output.
- **Tests that fail against the old behavior**:
  - `flags_a_command_cannot_honor_are_usage_errors` (integration) — `--json help`, `--state-dir DIR help`, `--yes help`, `--yes schema`, `--command-id c1 schema` and `--policy f schema` each exit 1 printing nothing and name the flag; a refused flag never reaches the daemon; `--json health` still does.
  - `flag_applicability_is_declared_per_command` (binary unit) pins the table in-process.

## Constraints held

- Plain `symbiote schema` stdout and what `schema --write` writes are **byte-unchanged** (the builders in `cli_schema.rs` are untouched; `schema --write` into a temp dir still diffs clean against `docs/contracts/schemas`).
- `--json health` and `--state-dir DIR shutdown --yes` still work.
- No new dependencies.

## Verification (this head, clean rebuild)

- `cargo fmt --all --check` clean; `cargo clippy -p symbiote-host --all-targets --locked -- -D warnings` clean.
- `cargo clean -p symbiote-host` (removed 2280 files / 1.3 GiB), then `cargo test -p symbiote-host --locked`: **107 passed / 0 failed** (lib 35, bin 19, daemon 16, schema-contract 14, authorization 19, plus transport).
- Drift guard re-proven by mutating `command_id.minLength` 1→2 in the builder: the module test **FAILED** and CI's exact commands (`symbiote schema --write` to a temp dir, then `diff -ru`) exited **1**; restored, `diff` exit 0.

🤖 Generated with [Codebuff](https://codebuff.com)