### PR TITLE
fix(cli): `schema --check` is two-directional, and a help request honors no other flag

### DIFF
--- a/crates/symbiote-host/src/bin/symbiote.rs
+++ b/crates/symbiote-host/src/bin/symbiote.rs
@@ -561,17 +561,16 @@ fn print_help() {
     println!("  --command-id ID   idempotency key for a retried command");
     println!("  --policy FILE     pre-authorize dangerous operation kinds for noninteractive runs");
     println!("  --write DIR       with `schema`, regenerate the selection into DIR");
-    println!(
-        "  --check DIR       with `schema`, report how DIR differs from the emitted selection"
-    );
-    println!("  --help, -h        print this table and exit 0, connecting to nothing");
+    println!("  --check DIR       with `schema`, compare DIR against the published documents");
+    println!("  --help, -h        print this table; connects to nothing, honors no other flag");
     println!("  --json            one machine-readable envelope per invocation on stdout");
     println!("  --yes             explicit authorization for this one dangerous command");
     println!();
     println!("flags are per command: daemon commands honor --state-dir, --command-id,");
     println!("--policy, --json and --yes; `schema` honors --write and --check; `help` honors");
-    println!("none; `--help`/`-h` is universal. A flag a command cannot honor is a usage");
-    println!("error that names it, never silently dropped.");
+    println!("nothing. `--help`/`-h` is universal, and a help request honors no other flag:");
+    println!("`--json --help health` is refused exactly as `--json help` is. A flag a command");
+    println!("cannot honor is a usage error that names it, never silently dropped.");
     println!();
     println!("responses are the daemon's JSON (pretty-printed). Exit codes:");
     println!("0 success, 1 usage/connection failure, 2 daemon-refused command,");
@@ -880,7 +879,8 @@ fn run_schema(options: &Options) -> Result<i32, Box<dyn std::error::Error>> {
             eprintln!("symbiote: {} {}", entry.file_name, entry.detail);
         }
         eprintln!(
-            "symbiote: {} document(s) do not match this binary; run `symbiote schema --write DIR` to regenerate",
+            "symbiote: {} is not what this binary publishes ({} difference(s)); `symbiote schema --write DIR` regenerates the documents",
+            directory.display(),
             drift.len()
         );
         return Ok(EXIT_USAGE);
@@ -901,33 +901,51 @@ fn run_schema(options: &Options) -> Result<i32, Box<dyn std::error::Error>> {
 
 fn run_with(arguments: Vec<String>) -> Result<i32, Box<dyn std::error::Error>> {
     let options = parse_options(&arguments)?;
-    let Some(name) = options.command.clone() else {
-        // A bare invocation is a usage error; `--help` alone is how the table
-        // is asked for, and that succeeds. Neither reads a state directory or
-        // opens a socket.
-        print_help();
-        return Ok(if options.help { EXIT_OK } else { EXIT_USAGE });
-    };
+    // A help request — the `help` command, or `--help`/`-h` with or without a
+    // command alongside — prints the table and connects to nothing. It cannot
+    // honor any other flag either: help renders the table, not a request, so
+    // `--json`, `--state-dir` and the rest mean nothing to it.
+    let requested_help = options.help || options.command.as_deref() == Some("help");
     // A flag a command cannot honor is a usage error that names it, never a
-    // silent no-op. This is the one place flag applicability is decided, for
-    // the local commands and the daemon commands alike, before any of them is
-    // answered or connects.
-    let unsuited = options.supplied().unsuited_for(honored_flags(&name));
+    // silent no-op. This is the one place flag applicability is decided — for
+    // the local commands, the daemon commands and a help request alike —
+    // before any of them is answered or connects. A help request is validated
+    // against the `help` row, so `--json --help health` is refused by the same
+    // rule as `--json --help help`.
+    let honored = if requested_help {
+        honored_flags("help")
+    } else {
+        match options.command.as_deref() {
+            Some(name) => honored_flags(name),
+            None => {
+                // A bare invocation is a usage error, and the table is shown
+                // either way.
+                print_help();
+                return Ok(EXIT_USAGE);
+            }
+        }
+    };
+    let unsuited = options.supplied().unsuited_for(honored);
     if !unsuited.is_empty() {
+        let named = if requested_help {
+            "help"
+        } else {
+            options.command.as_deref().unwrap_or("help")
+        };
         eprintln!(
-            "symbiote: `{name}` does not accept {}; try `symbiote help`",
+            "symbiote: `{named}` does not accept {}; try `symbiote help`",
             unsuited.join(", ")
         );
         return Ok(EXIT_USAGE);
     }
-    // `--help`/`-h` is universal: the table is printed and no daemon is
-    // consulted, whatever command accompanied it. It is answered AFTER the
-    // applicability check, so a contradictory flag is named rather than
-    // silently dropped by the help request itself.
-    if options.help || name == "help" {
+    if requested_help {
         print_help();
         return Ok(EXIT_OK);
     }
+    let name = options
+        .command
+        .clone()
+        .expect("a non-help invocation names a command");
     // `schema` is local: it emits and compares this binary's own contract and
     // needs no daemon, no state directory and no authorization, so it is
     // answered before any of that is consulted.
@@ -1464,11 +1482,24 @@ mod tests {
         }
         // With no command and no `--help`, the table is still a usage error.
         assert_eq!(run_with(Vec::new()).unwrap(), EXIT_USAGE);
-        // A contradictory flag is named rather than dropped by `--help`.
-        assert_eq!(
-            run_with(vec!["--help".into(), "--json".into(), "help".into()]).unwrap(),
-            EXIT_USAGE
-        );
+        // A help request is validated against the `help` row, so a flag it
+        // cannot honor is refused identically whether the command named honors
+        // that flag or not: `--json --help health` behaves like `--json help`
+        // rather than exiting 0 and dropping `--json`.
+        for arguments in [
+            vec!["--json", "help"],
+            vec!["--json", "--help"],
+            vec!["--json", "--help", "help"],
+            vec!["--json", "--help", "health"],
+            vec!["--help", "health", "--state-dir", "/d"],
+            vec!["--write", "/d", "schema", "--help"],
+        ] {
+            assert_eq!(
+                run_with(arguments.iter().map(|s| s.to_string()).collect()).unwrap(),
+                EXIT_USAGE,
+                "{arguments:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/symbiote-host/src/cli_schema.rs
+++ b/crates/symbiote-host/src/cli_schema.rs
@@ -390,20 +390,26 @@ pub fn write_schemas(directory: &Path, schemas: &[&PublishedSchema]) -> Result<(
     Ok(())
 }
 
-/// One selected document that is not what the binary would write: absent from
-/// the directory, or present with different bytes.
+/// One way a directory fails to be exactly what the binary publishes: a
+/// selected document that is absent or different, or an entry that is not a
+/// published document at all.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Drift {
-    pub file_name: &'static str,
-    /// `is missing`, or `differs at line N`.
+    pub file_name: String,
+    /// `is missing`, `differs at line N`, or `is not a published document`.
     pub detail: String,
 }
 
 /// Compares each selected document's canonical bytes to `directory/<file
-/// name>` and returns every divergence, without writing anything. This is the
-/// local counterpart of the CI drift step — the same comparison, run on
-/// demand, so a contributor can ask "does this tree match the binary?"
-/// without mutating it.
+/// name>` **and** reports every entry in `directory` that is not a published
+/// document, without writing anything.
+///
+/// Both directions are needed for this to be the same verdict the CI drift
+/// step's `diff -ru` reaches for the same tree: with no selector `directory`
+/// must hold exactly the published documents, so a missing, edited, extra or
+/// renamed entry is drift. A selector narrows which documents' bytes are
+/// compared; the other published documents may be present or absent, but an
+/// entry that is not a published document is reported either way.
 pub fn schema_drift(
     directory: &Path,
     schemas: &[&PublishedSchema],
@@ -415,15 +421,51 @@ pub fn schema_drift(
         match std::fs::read_to_string(&path) {
             Ok(actual) if actual == expected => {}
             Ok(actual) => drift.push(Drift {
-                file_name: schema.file_name,
+                file_name: schema.file_name.to_owned(),
                 detail: first_difference(&actual, &expected),
             }),
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => drift.push(Drift {
-                file_name: schema.file_name,
+                file_name: schema.file_name.to_owned(),
                 detail: "is missing".to_owned(),
             }),
             Err(source) => return Err(SchemaError::Read { path, source }),
         }
+    }
+    // The other direction: `diff -ru` reports a file the binary does not write
+    // as "Only in", so an added or renamed fixture is drift here too. A
+    // directory that does not exist is already reported per document above, so
+    // its `NotFound` is nothing further to say.
+    let mut unexpected = Vec::new();
+    match std::fs::read_dir(directory) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry.map_err(|source| SchemaError::Read {
+                    path: directory.to_path_buf(),
+                    source,
+                })?;
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if !PUBLISHED_SCHEMAS
+                    .iter()
+                    .any(|known| known.file_name == name.as_str())
+                {
+                    unexpected.push(name);
+                }
+            }
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(SchemaError::Read {
+                path: directory.to_path_buf(),
+                source,
+            });
+        }
+    }
+    unexpected.sort();
+    for file_name in unexpected {
+        drift.push(Drift {
+            file_name,
+            detail: "is not a published document".to_owned(),
+        });
     }
     Ok(drift)
 }
@@ -551,6 +593,22 @@ mod tests {
         assert_eq!(drift.len(), 1);
         assert_eq!(drift[0].file_name, "symbiote.cli.v1.schema.json");
         assert!(drift[0].detail.starts_with("differs at line "), "{drift:?}");
+
+        // The other direction: an entry the binary does not publish is drift,
+        // however it is named. `diff -ru` reports the same tree as "Only in".
+        std::fs::write(&envelope, &text).unwrap();
+        let renamed = directory.join("symbiote.cli.v1.schema.json.bak");
+        std::fs::write(&renamed, "{}").unwrap();
+        let drift = schema_drift(&directory, &selected).unwrap();
+        assert_eq!(drift.len(), 1);
+        assert_eq!(drift[0].file_name, "symbiote.cli.v1.schema.json.bak");
+        assert_eq!(drift[0].detail, "is not a published document");
+        // A selector narrows the byte comparison but not the entry check, and
+        // the *other* published document is never "unexpected".
+        let policy_only = selected_schemas(Some("policy")).unwrap();
+        assert_eq!(schema_drift(&directory, &policy_only).unwrap().len(), 1);
+        std::fs::remove_file(&renamed).unwrap();
+        assert_eq!(schema_drift(&directory, &policy_only).unwrap(), Vec::new());
 
         // A missing document is reported as such, and checking does NOT
         // recreate it: the gate reads, it never writes.

--- a/crates/symbiote-host/tests/cli_schema_contract.rs
+++ b/crates/symbiote-host/tests/cli_schema_contract.rs
@@ -570,6 +570,34 @@ fn schema_check_is_a_non_mutating_gate_that_names_the_difference() {
         "stderr: {}",
         String::from_utf8_lossy(&policy_only.stderr)
     );
+    // Restore the document, then check the other direction: an entry the
+    // binary does not publish is drift too, so the verdict matches the CI
+    // step's directory diff. This fails against the one-directional gate,
+    // which exited 0 whenever the expected documents were correct.
+    std::fs::write(&envelope, &text).unwrap();
+    let extra = directory.join("symbiote.cli.v1.schema.json.bak");
+    std::fs::write(&extra, "{}\n").unwrap();
+    let with_extra = run_bare(&["schema", "--check", path]);
+    assert_eq!(
+        with_extra.status.code(),
+        Some(1),
+        "an entry the binary does not publish must be drift: {}",
+        String::from_utf8_lossy(&with_extra.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&with_extra.stderr);
+    assert!(
+        stderr.contains("symbiote.cli.v1.schema.json.bak")
+            && stderr.contains("is not a published document"),
+        "{stderr}"
+    );
+    // A selector narrows the byte comparison, not the entry check.
+    assert_eq!(
+        run_bare(&["schema", "policy", "--check", path])
+            .status
+            .code(),
+        Some(1)
+    );
+    std::fs::remove_file(&extra).unwrap();
     // A missing document is reported as missing, and checked-not-recreated.
     std::fs::remove_file(&envelope).unwrap();
     let missing = run_bare(&["schema", "--check", path]);
@@ -612,15 +640,20 @@ fn check_is_scoped_to_the_schema_command() {
 #[test]
 fn help_flag_succeeds_from_any_command_without_connecting() {
     // `--help`/`-h` are universal flags answered from the command table alone:
-    // alone, or with any command. This fails against the earlier parser, which
-    // rejected `--help` as an unknown option and treated `-h` as an unknown
-    // command.
+    // alone, or with any command, daemon ones included. Each of these runs
+    // with no daemon and no state directory, so a zero exit is the evidence
+    // that nothing was consulted. This fails against the earlier parser, which
+    // rejected `--help` as an unknown option and `-h` as an unknown command.
     for arguments in [
         vec!["--help"],
         vec!["-h"],
         vec!["help", "--help"],
         vec!["schema", "--help"],
         vec!["--help", "schema"],
+        vec!["--help", "shutdown"],
+        vec!["shutdown", "--help"],
+        vec!["health", "-h"],
+        vec!["raw", "--help"],
     ] {
         let output = run_bare(&arguments);
         assert_eq!(
@@ -634,17 +667,38 @@ fn help_flag_succeeds_from_any_command_without_connecting() {
             "{arguments:?} must print the table"
         );
     }
-    // With a state directory and a live fake daemon, `--help` still sends
-    // nothing: it is answered before transport.
-    let (output, frame) = run_cli(&["--help", "shutdown"]);
-    assert_eq!(
-        output.status.code(),
-        Some(0),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(frame.is_none(), "`--help` must not reach the daemon");
-    assert!(String::from_utf8_lossy(&output.stdout).contains("commands:"));
+    // A help request honors no other flag, whatever command accompanied it, so
+    // a flag it cannot honor is named by the same rule whether or not that
+    // command would have honored it. This fails against the earlier behavior,
+    // where `--json --help` and `--json --help health` exited 0 and dropped
+    // `--json`.
+    for (arguments, named) in [
+        (vec!["--json", "--help"], "--json"),
+        (vec!["--json", "--help", "help"], "--json"),
+        (vec!["--json", "--help", "health"], "--json"),
+        (
+            vec!["--state-dir", "/tmp", "shutdown", "--help"],
+            "--state-dir",
+        ),
+        (vec!["--write", "/tmp", "schema", "--help"], "--write"),
+    ] {
+        let output = run_bare(&arguments);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{arguments:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "{arguments:?} must print no table"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(named) && stderr.contains("`help`"),
+            "{arguments:?} must refuse {named} as `help`: {stderr}"
+        );
+    }
 }
 
 #[test]

--- a/docs/contracts/cli.md
+++ b/docs/contracts/cli.md
@@ -24,23 +24,29 @@ contract it implements. `symbiote schema --write DIR` regenerates the
 committed fixture files instead of printing them, so the fixtures are
 **generated artifacts**: a contract change is made once in the binary and then
 regenerated, never edited into a fixture by hand. `symbiote schema --check
-DIR` is the non-mutating half: it compares each selected document to `DIR`
-and, on any difference, names the file and the line where it diverges (or that
-it is missing) and exits 1, writing nothing — the local counterpart of the CI
-drift step below. A selector narrows `--write` and `--check` to the document
-it names.
+DIR` is the non-mutating half, and it reaches the same verdict the CI drift
+step's directory diff reaches for the same tree: with no selector `DIR` must
+hold exactly the published documents, so a missing, edited, extra or renamed
+entry is named — with the line where a document diverges — and exits 1,
+reading and writing nothing. A selector narrows which documents' bytes are
+compared, so the other published documents may be present or absent, but any
+entry that is not a published document is reported whatever its name. A
+selector narrows `--write` the same way.
 
 Flags are declared per command, and a flag a command cannot honor is a usage
 error that names it, never a silent no-op. The daemon commands honor the five
 daemon-facing flags (`--state-dir`, `--command-id`, `--policy`, `--json`,
 `--yes`), because each of them is answered by a request over the socket; the
 local `schema` command honors `--write` and `--check`, and the local `help`
-command honors none. `--help`/`-h` is the one universal flag: every command
-honors it, and it is answered from the command table alone — no daemon, no
-state directory — so `symbiote --help`, `symbiote -h` and `symbiote shutdown
---help` all exit 0. So `symbiote --write DIR health`, `symbiote --check DIR
-health`, `symbiote --json help`, `symbiote --state-dir DIR schema` and
-`symbiote schema --yes` each exit 1 printing nothing, while `symbiote
+command honors none. `--help`/`-h` is the one universal flag — every command
+honors it — but a help request honors no other flag, whatever command (if any)
+accompanied it: it renders the table, not a request, so `--json`, `--state-dir`
+and the rest mean nothing to it. `symbiote --help`, `symbiote -h`, `symbiote
+shutdown --help` and `symbiote schema --help` therefore exit 0 without a daemon
+or a state directory, while `--json --help` is refused exactly as `--json help`
+is. So `symbiote --write DIR health`, `symbiote --check DIR health`, `symbiote
+--json help`, `symbiote --state-dir DIR schema`, `symbiote schema --yes` and
+`symbiote --json --help health` each exit 1 printing nothing, while `symbiote
 --state-dir DIR shutdown --yes` and `symbiote --json health` are unaffected.
 
 The contract itself lives in `symbiote_host::cli_schema` (`crates/symbiote-host/src/cli_schema.rs`):
@@ -214,9 +220,10 @@ validates its stdout through the bounded checker, including the boundary
 documents the schema and the CLI must classify identically. CI additionally
 regenerates the fixtures with `symbiote schema --write` into a temporary
 directory and fails on any `diff`, so a hand-edited fixture is rejected even
-before the tests run. The same comparison is available locally and without
-writing as `symbiote schema --check DIR`, which exits 1 naming every document
-that diverges. The default, non-`--json` output is the daemon's body
+before the tests run. The same comparison is available locally, without
+writing, as `symbiote schema --check DIR`, which exits 1 naming every
+difference — a document that is missing or changed, and every entry the
+binary does not publish. The default, non-`--json` output is the daemon's body
 alone and is deliberately not covered by an envelope schema.
 
 Published fixtures are not a compatibility policy: this page documents v1, and

--- a/docs/contracts/host.md
+++ b/docs/contracts/host.md
@@ -35,16 +35,18 @@ dangerous kinds a policy may pre-authorize. `help` is answered locally and
 honors no flags; `schema` is the other local command: it prints the binary's
 published envelope and policy JSON Schemas (see [cli.md](cli.md)) — one of
 them alone with a selector, `envelope` or `policy` — or regenerates the
-committed fixtures with `--write DIR`, or reports how a directory diverges
-from them without writing with `--check DIR`. It needs no daemon, no state
-directory and no authorization. `--write` and `--check` are valid only on
-`schema`, and `--json` is not valid on `schema` or `help` (schema's output is
-machine-readable JSON, but not the envelope). Every flag is declared per
-command: the daemon commands honor the daemon-facing flags, `schema` honors
-`--write` and `--check`, and `help` honors nothing; `--help`/`-h` is universal
-and is answered from the command table alone, connecting to nothing. A flag a
-command cannot honor is a usage error that names it, never silently dropped.
-Identity
+committed fixtures with `--write DIR`, or checks a directory against them with
+`--check DIR`: with no selector that directory must hold exactly the published
+documents, so a missing, edited, extra or renamed entry is named and exits 1,
+reading and writing nothing. It needs no daemon, no state directory and no
+authorization. `--write` and `--check` are valid only on `schema`, and `--json`
+is not valid on `schema` or `help` (schema's output is machine-readable JSON,
+but not the envelope). Every flag is declared per command: the daemon commands
+honor the daemon-facing flags, `schema` honors `--write` and `--check`, and
+`help` honors nothing; `--help`/`-h` is universal, and a help request honors no
+other flag, so `--json --help health` is refused exactly as `--json help` is. A
+flag a command cannot honor is a usage error that names it, never silently
+dropped. Identity
 arguments are passed as plain strings and typed on the wire; no caller-supplied
 actor identities exist. The interactive/headless coding-agent experience is
 #467's surface and shares this client plumbing; this binary carries no model


### PR DESCRIPTION
Refs #54.

The read-only audit of the merged tip found two behaviors that did not match the docs. This fixes both; the CI drift step itself is untouched.

## (1) `schema --check DIR` is now two-directional

It only compared the documents it expected, so a directory holding an **extra or renamed fixture exited 0** while the CI step's `diff -ru` exited 1 for the same tree — the docs' "the same comparison" / "the local counterpart of the CI drift step" were false.

It now also reports every entry in `DIR` that is not a published document. The rule, decided and documented:

- With no selector, `DIR` must hold **exactly** the published documents, so a missing, edited, extra, renamed or otherwise unexpected entry (including a hidden file or a subdirectory) is named and exits 1.
- A selector narrows which documents' **bytes** are compared — the other published documents may be present or absent — but an entry that is not a published document is reported whatever its name.
- It reads only and writes nothing.

Observed: `extra.json`, `symbiote.cli.v1.schema.json.bak`, `README.md`, `.DS_Store` and a subdirectory each exit 1 with `<entry> is not a published document`; the committed `docs/contracts/schemas` still exits 0; a non-existent `DIR` exits 1 with both documents `is missing`.

## (2) A help request honors no other flag

`--json --help` and `--json --help health` exited 0 and silently dropped `--json`, while `--json --help help` named it. A help request is now validated against the `help` row of the same per-command flag table — it renders the table, not a request — so every other flag is refused identically:

- `--json --help`, `--json --help health`, `--json --help help` → exit 1, `` `help` does not accept --json ``
- `--state-dir /tmp shutdown --help`, `--write /tmp schema --help` → exit 1 naming the flag
- `--help`, `-h`, `--help health`, `shutdown --help`, `schema --help` → exit 0 with no daemon or state directory

## Constraints held

- Plain `symbiote schema` stdout and what `--write` writes are **byte-unchanged** (sha256 match against the committed fixtures; the fixtures are not modified).
- `--json health` and `--state-dir DIR shutdown --yes` still work (exit 0 against a live daemon).
- No new dependencies. The CI step is unchanged (`schema --write` into a temp dir + `diff -ru`).

## Tests that fail against the previous behavior

Verified by temporarily restoring the pre-fix code and observing the failures:

- `schema_check_is_a_non_mutating_gate_that_names_the_difference` — failed on "an entry the binary does not publish must be drift".
- `help_flag_succeeds_from_any_command_without_connecting` — failed on `["--json", "--help"]`.
- `help_is_a_universal_flag_that_connects_to_nothing` (unit) — failed on `["--json", "--help"]`.
- `drift_is_named_per_document_and_reads_without_writing` (unit) — failed on the extra-entry assertion.

## Verification (this head, clean rebuild)

- `cargo clean -p symbiote-host` (removed 2401 files / 1.4 GiB), then `cargo test -p symbiote-host --locked`: **114 passed / 0 failed** (lib 37, bin 20, daemon 16, schema-contract 18, authorization 19, transport 4).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- CI's drift step re-proven by mutating `command_id.minLength` 1→2: the module test **FAILED**, `diff -ru` exited **1**, and `schema --check docs/contracts/schemas` exited **1** naming `symbiote.cli.v1.schema.json differs at line 84`; restored, both exit 0.

🤖 Generated with [Codebuff](https://codebuff.com)