### PR TITLE
fix(host): a replayed activation recovers its completed run instead of refusing (#54)

### DIFF
--- a/crates/symbiote-host/src/service.rs
+++ b/crates/symbiote-host/src/service.rs
@@ -568,10 +568,38 @@ fn execute(
             let current = task_record
                 .current_dispatch()
                 .ok_or_else(dispatch_binding_refused)?;
-            if current.id() != dispatch_id
-                || task_record.state() != &symbiote_domain::TaskState::Running
-            {
+            if current.id() != dispatch_id {
+                // A foreign dispatch id never reaches a factory, and never
+                // reads as a replay of this task's own run.
                 return Err(dispatch_binding_refused());
+            }
+            if task_record.state() != &symbiote_domain::TaskState::Running {
+                // A run whose response was lost is recovered by replaying its
+                // command id, and the daemon's own contract on a disconnected
+                // response is that the retry "recovers the durable receipt".
+                // This command has no journaled receipt of its own — the run's
+                // completion is filed under the worker-completion id — so the
+                // durable evidence of it is the task's own state: a task that
+                // is at or past `CompletionRequested` under THIS dispatch had
+                // its run complete, and the outcome the caller is asking for
+                // is exactly the one already recorded. Re-deriving it here is
+                // not a claim: the run either filed completion under this
+                // dispatch (so `completed` was true) or it returned an error
+                // and left the task Running. Refusing instead would report the
+                // replay of a finished run as if the run never happened.
+                return match task_record.state() {
+                    symbiote_domain::TaskState::CompletionRequested
+                    | symbiote_domain::TaskState::Verifying
+                    | symbiote_domain::TaskState::Completed => {
+                        Ok(ResponseBody::WorkerRun(Box::new(WorkerRun {
+                            task_id: task_id.clone(),
+                            dispatch_id: current.id().clone(),
+                            runtime: current.contract().profile().runtime,
+                            completed: true,
+                        })))
+                    }
+                    _ => Err(dispatch_binding_refused()),
+                };
             }
             // The third precondition, and the one that makes #447 real: what
             // executes is the contract's PINNED profile, so its registration

--- a/crates/symbiote-workflow/tests/end_to_end.rs
+++ b/crates/symbiote-workflow/tests/end_to_end.rs
@@ -1014,6 +1014,70 @@ fn a_started_dispatch_runs_its_tools_under_the_declared_memory_bound() {
     );
 }
 
+/// A run whose response was lost is recovered by replaying its command id —
+/// the daemon's own contract on a disconnected response. The activation
+/// command carries no journaled receipt of its own, so the durable evidence a
+/// replay must read is the task state: a task at `CompletionRequested` under
+/// THIS dispatch had its run complete, and the replay must answer with that
+/// recorded outcome. It must not refuse it as "not running", which reads as if
+/// the run never happened and is what a client sees when a response write is
+/// cut short (the daemon's response deadline is seconds; the client's is
+/// longer, so the replay, not the first attempt, is the one that arrives
+/// second).
+#[test]
+fn a_replayed_activation_recovers_the_completed_run_instead_of_refusing() {
+    let env = demo_environment("replayed-activation");
+    let state_dir = &env.state_dir;
+    let reservation_base = &env.reservation_base;
+    let config_path = &env.config_path;
+    write_operator_config(
+        config_path,
+        reservation_base,
+        &launcher_binary(),
+        FIXTURE_TOOL_COMMAND,
+        true,
+        None,
+    );
+
+    let _daemon = Daemon::spawn(state_dir, config_path);
+    let mut workflow =
+        symbiote_workflow::DemoWorkflow::connect(state_dir, reservation_base, &env.repo)
+            .expect("connect");
+    let dispatch_id = workflow.start_demo().expect("demo start half");
+    let first = workflow
+        .finish_demo(&dispatch_id)
+        .expect("demo finish half");
+    assert_eq!(first.task_state, "completion_requested");
+    assert_eq!(
+        first.report.as_deref(),
+        Some(symbiote_workflow::demo::FIXTURE_REPORT)
+    );
+
+    // The identical command id and intent, sent again on the same client path
+    // the daemon's own recovery contract describes — and sent twice, so the
+    // answer is a stable durable outcome rather than a one-shot allowance.
+    let mut driver = symbiote_workflow::Driver::connect(state_dir).expect("driver");
+    let activation = |dispatch_id: &str| {
+        serde_json::json!({"kind":"run_started_dispatch","task_id":"staffing-task",
+        "dispatch_id":dispatch_id})
+    };
+    for attempt in 1..=2 {
+        let body = driver
+            .call("wf-run-staffing-task", activation(&dispatch_id), None)
+            .unwrap_or_else(|error| {
+                panic!("replayed activation {attempt} must recover, not refuse: {error:?}")
+            });
+        match body {
+            ResponseBody::WorkerRun(run) => {
+                assert!(run.completed, "the recorded outcome was a completed run");
+                assert_eq!(run.dispatch_id.as_str(), dispatch_id);
+                assert_eq!(run.task_id.as_str(), "staffing-task");
+            }
+            other => panic!("replayed activation {attempt} answered {other:?}"),
+        }
+    }
+}
+
 /// The external lane's own process carries the ceiling its dispatch declared,
 /// and its work lands in its own reserved worktree: the operator-provisioned
 /// harness is launched by the Host inside the sandbox under the recorded

--- a/docs/contracts/worker-completion-wiring.md
+++ b/docs/contracts/worker-completion-wiring.md
@@ -76,3 +76,17 @@ host-crate tests; the daemon-level path remains scripted because a live
 model turn is still gated on user authorization for credentials and billing.
 Nothing schedules runs automatically. Durable session resume/reconnect and
 multi-turn tool-result round trips remain pending (#465/#464 stay open).
+
+## A lost activation response
+
+A disconnected client does not roll back a committed command, so the
+daemon's contract is that retrying its command ID recovers the durable
+receipt. For `run_started_dispatch` the durable evidence of the run is the
+task itself: a task at or past `CompletionRequested` under the requested
+dispatch had its run complete (a run that fails leaves the task `Running`
+and returns an error). So a replayed activation of that dispatch answers
+with the recorded outcome — the same `worker_run` body with
+`completed: true` — instead of re-executing the run or refusing it. A
+foreign dispatch id is still refused, and any other state still refuses:
+the replay path reads only a state this very dispatch's completed run could
+have produced.


### PR DESCRIPTION
## The defect

`main`'s post-merge `Rust contracts` run (`fcc7a9be`, job `contracts (stable)`) failed step 8 with:

```
a_started_dispatch_runs_its_tools_under_the_declared_memory_bound --- FAILED
demo finish half: Refused(ProtocolError { code: FailedPrecondition,
  message: "task is not running under the requested dispatch" })
```

That refusal is the activation endpoint's state check, and it is reachable on a
**successful** run. The daemon's own contract on a cut-short response is that a
retry "recovers the durable receipt":

```rust
// A disconnected client does not roll back an already committed command.
// Retrying its command ID recovers the durable receipt.
if transport::write_response(&connection, &bytes).is_err() { ... }
```

and the SDK's recovery replays the same command id. `run_started_dispatch` was
the one command that consulted recorded state *before* any receipt (every other
mutating command replays from its journal row first — see `start_prepared_task`).
So when the daemon's response write is cut short — its deadline is **2 seconds**
while the client's read deadline is 30, so the replay, not the first attempt, is
the one that arrives second — the replay meets a task its own first attempt has
already completed and is told the task is "not running", as if the run never
happened.

## The fix

`run_started_dispatch` now separates the two cases it conflated:

- **A foreign dispatch id** still refuses, before anything else — a foreign id
  never reaches a factory and never reads as a replay of this task's own run.
- **The requested dispatch's own completed run** answers with the recorded
  outcome. A task at or past `CompletionRequested` under *this* dispatch had its
  run complete — a run that fails leaves the task `Running` and returns an error
  — so the replay answers with the same `worker_run` body (`completed: true`)
  rather than re-executing or refusing.
- **Every other state** still refuses: the replay path reads only a state this
  very dispatch's completed run could have produced.

## Evidence

**The failure reproduces deterministically, and the fix removes it.** New test
`a_replayed_activation_recovers_the_completed_run_instead_of_refusing` (workflow
end-to-end, real `symbioted`, real worktree provisioning):

- against the old precondition (daemon rebuilt): `replayed activation 1 must
  recover, not refuse: Refused(ProtocolError { code: FailedPrecondition,
  message: "task is not running under the requested dispatch" })` — the exact CI
  message;
- with the fix: passes, and the replay is sent **twice** to show the answer is a
  stable durable outcome rather than a one-shot allowance.

The test drives the real client recovery path (`Driver::call`, the same
command id and intent), not a synthetic request.

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets --locked --
-D warnings` clean; `cargo test --workspace --locked` **560 passed, 0 failed**.
No new dependencies.

## Notes

The doc `worker-completion-wiring.md` now states the replay rule for the
activation endpoint. The pre-existing `.expect("demo finish half")` line and the
daemon's 2-second response deadline are unchanged: the deadline is the mechanism
that makes a lost response ordinary, and the recovery contract is what must hold
when it fires.

References #54.