### PR TITLE
test(sandbox): pin the mount boundary's Host-write confinement for both profiles

### DIFF
--- a/crates/symbiote-sandbox/tests/process.rs
+++ b/crates/symbiote-sandbox/tests/process.rs
@@ -557,3 +557,136 @@ fn setup_failure_stderr_is_bounded_explicit_and_debug_redacted() {
     assert!(setup.truncated());
     assert_eq!(setup.diagnostics()[0].len(), 1024);
 }
+
+/// The mount boundary as an errno table, for both compositions the sandbox
+/// supports: `WorktreeWrite`, which is what a dispatch carrying the mutation
+/// grant runs the external lane's harness under, and `ReadOnly`, which is what
+/// a contract without that grant runs under. `/workspace` is the dispatch's
+/// reserved worktree, the one surface a writable run may change. Everything
+/// else the mount table leaves reachable inside is either absent (the sandbox
+/// root is a fresh tmpfs, so no Host directory, `/etc` or `/var` exists at
+/// all — errno 2) or read-only (`/usr` is a read-only bind and the root is
+/// remounted read-only — errno 30). The only other writable paths are `/tmp`
+/// and `/home/agent`, the sandbox's own tmpfs mounts: the test asserts a run
+/// may write there and that the write never reaches the Host path of the same
+/// name. Under `ReadOnly` the whole table holds and the reserved worktree joins
+/// the refusing side, so a dispatch with no mutation grant gets no write
+/// anywhere at all.
+#[test]
+fn the_mount_boundary_refuses_every_write_outside_a_writable_reserved_worktree() {
+    let script = r#"import json,os,sys
+host_worktree,host_protected,shadow=sys.argv[1],sys.argv[2],sys.argv[3]
+tmp_before=len(os.listdir('/tmp'))
+targets={
+ 'reserved_worktree':'/workspace/probe.txt',
+ 'worktree_traversal':'/workspace/../probe.txt',
+ 'sandbox_root':'/symbiote-probe',
+ 'sandbox_usr':'/usr/symbiote-probe',
+ 'sandbox_etc':'/etc/symbiote-probe',
+ 'sandbox_var':'/var/symbiote-probe',
+ 'host_worktree':host_worktree+'/probe.txt',
+ 'host_protected':host_protected+'/probe.txt',
+ 'sandbox_tmp':'/tmp/'+shadow,
+ 'sandbox_home':'/home/agent/'+shadow,
+}
+def attempt(path):
+    try:
+        with open(path,'w') as handle:
+            handle.write('probe')
+        return 'writable'
+    except OSError as error:
+        return error.errno
+json.dump({'cwd':os.getcwd(),'tmp_before':tmp_before,'writes':{name:attempt(path) for name,path in targets.items()}},sys.stdout)
+sys.stdout.write('\n')
+sys.stdout.flush()
+"#;
+    for (profile, reserved_worktree) in [
+        (Profile::WorktreeWrite, serde_json::json!("writable")),
+        (Profile::ReadOnly, serde_json::json!(30)),
+    ] {
+        let fixture = Fixture::new();
+        // A read-only run models a contract that carries NO mutation grant: the
+        // grant is absent from the consent itself, not merely left unused.
+        let shadow = format!(
+            "{}.probe",
+            fixture.base.file_name().unwrap().to_string_lossy()
+        );
+        let args = vec![
+            "-c".to_owned(),
+            script.to_owned(),
+            fixture.worktree.display().to_string(),
+            fixture.protected[0].display().to_string(),
+            shadow.clone(),
+        ];
+        let mut consent = fixture.consent(profile, &args);
+        if profile == Profile::ReadOnly {
+            consent
+                .snapshot
+                .access
+                .grants
+                .remove(&Permission::MutateStream);
+        }
+        let mut child = launch_ready(fixture.request(&consent, profile, &args));
+        let observed = child.recv(Duration::from_secs(10)).unwrap();
+        assert_eq!(observed["cwd"], "/workspace", "{profile:?}");
+        assert_eq!(
+            observed["tmp_before"],
+            serde_json::json!(0),
+            "the sandbox's /tmp is its own and empty at start: {observed}"
+        );
+        let writes = &observed["writes"];
+        assert_eq!(
+            writes["reserved_worktree"], reserved_worktree,
+            "{profile:?}: the reserved worktree is writable exactly under the mutation grant: {observed}"
+        );
+        // Read-only surfaces: the read-only `/usr` bind and the fresh root.
+        for target in ["worktree_traversal", "sandbox_root", "sandbox_usr"] {
+            assert_eq!(
+                writes[target],
+                serde_json::json!(30),
+                "{profile:?} {target} must be read-only: {observed}"
+            );
+        }
+        // Absent surfaces: nothing of the Host tree, `/etc` or `/var` exists
+        // inside the sandbox root at all.
+        for target in [
+            "sandbox_etc",
+            "sandbox_var",
+            "host_worktree",
+            "host_protected",
+        ] {
+            assert_eq!(
+                writes[target],
+                serde_json::json!(2),
+                "{profile:?} {target} must be invisible inside the sandbox: {observed}"
+            );
+        }
+        // The sandbox's own writable tmpfs mounts, not the Host's.
+        for target in ["sandbox_tmp", "sandbox_home"] {
+            assert_eq!(
+                writes[target], "writable",
+                "{profile:?} {target} is the sandbox's own tmpfs: {observed}"
+            );
+        }
+        assert!(
+            !std::path::Path::new("/tmp").join(&shadow).exists()
+                && !std::path::Path::new("/home/agent").join(&shadow).exists(),
+            "{profile:?}: a write inside the sandbox's /tmp or /home reached the Host"
+        );
+        // Under the writable profile the file the probe wrote through
+        // `/workspace` is the Host's own file in the reserved worktree; under
+        // the read-only profile the worktree has no new file at all.
+        let produced = fixture.worktree.join("probe.txt");
+        match profile {
+            Profile::WorktreeWrite => assert_eq!(
+                fs::read_to_string(&produced).unwrap(),
+                "probe",
+                "the writable worktree write lands on the Host"
+            ),
+            Profile::ReadOnly => assert!(
+                !produced.exists(),
+                "a contract with no mutation grant wrote into its worktree"
+            ),
+        }
+    }
+}

--- a/crates/symbiote-sandbox/tests/process.rs
+++ b/crates/symbiote-sandbox/tests/process.rs
@@ -562,18 +562,21 @@ fn setup_failure_stderr_is_bounded_explicit_and_debug_redacted() {
 /// supports: `WorktreeWrite`, which is what a dispatch carrying the mutation
 /// grant runs the external lane's harness under, and `ReadOnly`, which is what
 /// a contract without that grant runs under. `/workspace` is the dispatch's
-/// reserved worktree, the one surface a writable run may change. Everything
-/// else the mount table leaves reachable inside is either absent (the sandbox
-/// root is a fresh tmpfs, so no Host directory, `/etc` or `/var` exists at
-/// all — errno 2) or read-only (`/usr` is a read-only bind and the root is
-/// remounted read-only — errno 30). The only other writable paths are `/tmp`
-/// and `/home/agent`, the sandbox's own tmpfs mounts: the test asserts a run
-/// may write there and that the write never reaches the Host path of the same
-/// name. Under `ReadOnly` the whole table holds and the reserved worktree joins
-/// the refusing side, so a dispatch with no mutation grant gets no write
-/// anywhere at all.
+/// reserved worktree, the one Host surface a run may change. Everything else
+/// the mount table leaves reachable inside is either absent (the sandbox root
+/// is a fresh tmpfs, so no Host directory, `/etc` or `/var` exists at all —
+/// errno 2) or read-only (`/usr` is a read-only bind and the root is remounted
+/// read-only — errno 30). The remaining writable paths — `/tmp`, `/home/agent`,
+/// and `/dev` with its `/dev/shm` — are the sandbox's own tmpfs mounts, not the
+/// Host's: the test asserts a run may write there and that the write never
+/// reaches the Host path of the same name. That Host-side assertion, not the
+/// writability itself, is what keeps them off the Host boundary; it is also what
+/// would fail if the inner `/dev` were ever replaced by a bind of the Host's.
+/// Under `ReadOnly` the same table holds minus the worktree, which joins the
+/// refusing side, so a dispatch with no mutation grant gets no Host write at
+/// all.
 #[test]
-fn the_mount_boundary_refuses_every_write_outside_a_writable_reserved_worktree() {
+fn the_mount_boundary_confines_host_writes_to_the_reserved_worktree() {
     let script = r#"import json,os,sys
 host_worktree,host_protected,shadow=sys.argv[1],sys.argv[2],sys.argv[3]
 tmp_before=len(os.listdir('/tmp'))
@@ -588,6 +591,8 @@ targets={
  'host_protected':host_protected+'/probe.txt',
  'sandbox_tmp':'/tmp/'+shadow,
  'sandbox_home':'/home/agent/'+shadow,
+ 'sandbox_dev':'/dev/'+shadow,
+ 'sandbox_dev_shm':'/dev/shm/'+shadow,
 }
 def attempt(path):
     try:
@@ -661,17 +666,26 @@ sys.stdout.flush()
                 "{profile:?} {target} must be invisible inside the sandbox: {observed}"
             );
         }
-        // The sandbox's own writable tmpfs mounts, not the Host's.
-        for target in ["sandbox_tmp", "sandbox_home"] {
+        // The sandbox's own writable tmpfs mounts, not the Host's. `/dev` is
+        // writable on purpose (its device nodes must be usable, and `/dev/shm`
+        // backs shared memory), so this row is pinned rather than refused.
+        for target in [
+            "sandbox_tmp",
+            "sandbox_home",
+            "sandbox_dev",
+            "sandbox_dev_shm",
+        ] {
             assert_eq!(
                 writes[target], "writable",
-                "{profile:?} {target} is the sandbox's own tmpfs: {observed}"
+                "{profile:?} {target} is the sandbox's own mount: {observed}"
             );
         }
         assert!(
             !std::path::Path::new("/tmp").join(&shadow).exists()
-                && !std::path::Path::new("/home/agent").join(&shadow).exists(),
-            "{profile:?}: a write inside the sandbox's /tmp or /home reached the Host"
+                && !std::path::Path::new("/home/agent").join(&shadow).exists()
+                && !std::path::Path::new("/dev").join(&shadow).exists()
+                && !std::path::Path::new("/dev/shm").join(&shadow).exists(),
+            "{profile:?}: a write inside the sandbox's own /tmp, /home or /dev reached the Host"
         );
         // Under the writable profile the file the probe wrote through
         // `/workspace` is the Host's own file in the reserved worktree; under

--- a/docs/security/linux-sandbox.md
+++ b/docs/security/linux-sandbox.md
@@ -52,6 +52,15 @@ worktree needs a private parent controlled by the trusted provisioner, which
 must not expose Host IPC endpoints, devices or hardlinks to protected files.
 Namespace isolation does not make a maliciously provisioned mount safe.
 
+The mount boundary's observable consequence is a table, not a profile name:
+the reserved worktree is writable only under worktree-write, the root is a fresh
+tmpfs remounted read-only and `/usr` is a read-only bind, so every other surface
+— the Host tree, `/etc`, `/var` — is absent inside (errno 2) or read-only
+(errno 30). `/tmp` and `/home/agent` are writable, but they are the sandbox's own
+tmpfs mounts, not the Host's. A test in `crates/symbiote-sandbox/tests/process.rs`
+(`the_mount_boundary_refuses_every_write_outside_a_writable_reserved_worktree`)
+pins that errno table for both profiles.
+
 A live adversarial probe demonstrated why: a pathname Unix socket inside a
 mounted worktree reached a Host listener despite network namespace isolation,
 and a writable hardlink changed a file outside that mount. See the

--- a/docs/security/linux-sandbox.md
+++ b/docs/security/linux-sandbox.md
@@ -54,12 +54,16 @@ Namespace isolation does not make a maliciously provisioned mount safe.
 
 The mount boundary's observable consequence is a table, not a profile name:
 the reserved worktree is writable only under worktree-write, the root is a fresh
-tmpfs remounted read-only and `/usr` is a read-only bind, so every other surface
+tmpfs remounted read-only and `/usr` is a read-only bind, so every Host surface
 — the Host tree, `/etc`, `/var` — is absent inside (errno 2) or read-only
-(errno 30). `/tmp` and `/home/agent` are writable, but they are the sandbox's own
-tmpfs mounts, not the Host's. A test in `crates/symbiote-sandbox/tests/process.rs`
-(`the_mount_boundary_refuses_every_write_outside_a_writable_reserved_worktree`)
-pins that errno table for both profiles.
+(errno 30). `/tmp`, `/home/agent` and `/dev` (with its `/dev/shm`) are writable,
+because each is the sandbox's own tmpfs mount rather than the Host's: no write
+there reaches the Host path of the same name. `/dev` is left writable on purpose
+instead of remounted read-only — its device nodes must stay usable, and shared
+memory lives in `/dev/shm`, which a non-recursive `--remount-ro /` does not
+reach. A test in `crates/symbiote-sandbox/tests/process.rs`
+(`the_mount_boundary_confines_host_writes_to_the_reserved_worktree`) pins the
+whole errno table, Host-side effects included, for both profiles.
 
 A live adversarial probe demonstrated why: a pathname Unix socket inside a
 mounted worktree reached a Host listener despite network namespace isolation,


### PR DESCRIPTION
Refs #464 — links the external-lane sandbox boundary work without closing it.

## Why

The external lane's harness runs **writable** inside its sandbox when the dispatch grants stream mutation, and the only thing that makes that safe is the sandbox's mount boundary. A one-off probe measured that boundary during the #464 verification pass; nothing in the repository guarded it, so a future mount or profile change could widen it silently.

## What

One permanent end-to-end regression test in `crates/symbiote-sandbox/tests/process.rs`, `the_mount_boundary_confines_host_writes_to_the_reserved_worktree`. It launches the real `symbiote-sandbox-launch`/bwrap binary over a real worktree under **both** compositions and asserts an errno per surface:

| inside-sandbox target | `WorktreeWrite` | `ReadOnly` |
|---|---|---|
| `/workspace/probe.txt` (the reserved worktree) | writable | errno 30 (EROFS) |
| `/workspace/../probe.txt` (traversal to root) | 30 | 30 |
| `/symbiote-probe` (root) | 30 | 30 |
| `/usr/symbiote-probe` | 30 | 30 |
| `/etc/symbiote-probe` | 2 (ENOENT) | 2 |
| `/var/symbiote-probe` | 2 | 2 |
| `<host worktree>/probe.txt` | 2 | 2 |
| `<host protected>/probe.txt` | 2 | 2 |
| `/tmp/<unique>`, `/home/agent/<unique>` | writable | writable |
| `/dev/<unique>`, `/dev/shm/<unique>` | writable | writable |

The guarantee the test actually checks is **Host-write confinement**: every write either lands in the dispatch's reserved worktree or stays in one of the sandbox's own tmpfs mounts, and the test asserts Host-side that a write to the same path never appears outside. `/tmp`, `/home/agent` and `/dev` (`/dev/shm` included) are writable *because they are the sandbox's own mounts* — the Host-side assertion, not the writability, is what keeps them off the boundary.

The read-only run removes `MutateStream` **from the consent itself**, so it models a contract that carries no mutation grant rather than a writable consent left unused. Under it the worktree joins the refusing side and the Run gains no Host file at all.

The read-only composition is expressed here because it is **not reachable through the product**: `Dispatch::compile` requires `MutateStream`, so every compiled dispatch is stream-mutating and `external_harness::profile_for`'s `ReadOnly` branch is defensive. The launcher is the only surface where both compositions exist. The granted composition's product wiring stays pinned by the existing `a_started_external_harness_runs_under_the_declared_memory_bound` end-to-end test, which proves the Host mounts the dispatch's own reserved worktree writable.

`docs/security/linux-sandbox.md` (the boundary's canonical owner) gains a paragraph stating the errno table and this test.

## Review round: `/dev` was writable, and the first claim said it was not

CodeRabbit flagged that `--dev /dev` makes its own rw tmpfs and `--remount-ro /` does not recurse, so `/dev` stays writable. Confirmed on the real launcher: `/dev/<probe>` and `/dev/shm/<probe>` are writable, `/dev/pts` is `EACCES`, and `/proc/self/mountinfo` shows `/dev` as a separate `rw` mount with the device nodes bound in individually. My first revision claimed `/tmp` and `/home/agent` were the only writable surfaces — false — so this revision pins the real behaviour, adds the Host-side check for `/dev`, and renames the test from "refuses every write outside…" to the guarantee it actually checks.

I did **not** adopt the suggested `--remount-ro /dev` hardening. It works (device writes still function), but it also takes `/dev/shm` — the POSIX shared-memory path — read-only, which can break legitimate workloads inside the lane, and it changes production sandbox behaviour beyond this PR's scope. `/dev` is documented as intentionally private-and-writable instead. Worth a separate, independently verified change if the tradeoff is wanted.

## Verification

`cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` clean; `cargo test --workspace --locked` **561 passed, 0 failed**, with `symbiote-host` and `symbiote-sandbox` force-cleaned and `symbioted` rebuilt from sources first, so no stale-artifact green is involved.

Proven sensitive, not merely green. Three mutations, each reverted byte-identical:

- read-only branch `--ro-bind` → `--bind` → fails with `ReadOnly: the reserved worktree is writable exactly under the mutation grant … left: "writable", right: Number(30)`.
- `--tmpfs /tmp` → `--bind /tmp /tmp` → fails on `the sandbox's /tmp is its own and empty at start: tmp_before 7072`, with `host_protected: "writable"` and `host_worktree: "writable"` — the exact leak the test exists to catch.
- `--dev /dev` → `--bind /dev /dev` → fails on `WorktreeWrite sandbox_dev is the sandbox's own mount … left: Number(13)`.

The `/tmp` proof first failed for an incidental reason (`Transport(FrameTooLarge)`, from serialising the Host's whole `/tmp` listing), so the probe reports an entry count instead; the re-run fails on the boundary assertion.

No new dependencies. Two files.