### PR TITLE
fix(sandbox): the device tree is read-only while /dev/shm stays a shared-memory mount (#464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,6 +3175,7 @@ dependencies = [
  "symbiote-protocol",
  "symbiote-repo",
  "symbiote-trust",
+ "symbiote-workflow",
  "symbiote-worktrees",
 ]
 

--- a/crates/symbiote-desktop/Cargo.toml
+++ b/crates/symbiote-desktop/Cargo.toml
@@ -30,6 +30,9 @@ tauri-build = { version = "2", features = [] }
 [dev-dependencies]
 symbiote-client-sdk = { path = "../symbiote-client-sdk" }
 serde_json.workspace = true
+# The controller proof resolves `symbioted` through the workflow crate's
+# freshness check, which only test builds carry.
+symbiote-workflow = { path = "../symbiote-workflow", features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -25,17 +25,18 @@ fn git(repo: &std::path::Path, args: &[&str]) {
 }
 
 fn bin_dir() -> PathBuf {
-    // Workspace target directory: the gauntlet builds every binary.
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for ancestor in manifest.ancestors().skip(1) {
-        let candidate = ancestor.join("target/debug");
-        if candidate.join("symbioted").is_file()
-            && candidate.join("symbiote-sandbox-launch").is_file()
-        {
-            return candidate;
-        }
-    }
-    panic!("workspace binaries not built; run the workspace gauntlet");
+    // The gauntlet builds every binary. Reuse the workflow proof's resolver so
+    // this proof cannot pass against a `symbioted` built from older sources
+    // while the daemon runs code that no longer reflects the repository.
+    let daemon = symbiote_workflow::binaries::daemon_binary();
+    let dir = daemon
+        .parent()
+        .expect("symbioted lives in the workspace target directory");
+    assert!(
+        dir.join("symbiote-sandbox-launch").is_file(),
+        "workspace binaries not built; run the workspace gauntlet"
+    );
+    dir.to_path_buf()
 }
 
 fn test_env(tag: &str) -> TestEnv {

--- a/crates/symbiote-host/src/shell_executor.rs
+++ b/crates/symbiote-host/src/shell_executor.rs
@@ -493,19 +493,19 @@ mod tests {
     // When the launcher binary is absent from a partial build, the test
     // reports the skip loudly instead of pretending to run.
 
-    /// A fixture authority that consents ONLY to /usr/bin/echo as the model
-    /// program (wrapped args index 3) and computes the exact fingerprint the
-    /// sandbox will re-derive — the same authoring flow an operator tool
-    /// would follow.
-    struct EchoOnlyAuthority {
+    /// A fixture authority that consents ONLY to one model program (wrapped
+    /// args index 3) and computes the exact fingerprint the sandbox will
+    /// re-derive — the same authoring flow an operator tool would follow.
+    struct AllowProgramAuthority {
+        allowed_program: &'static str,
         access: AccessSnapshot,
     }
-    impl ShellConsentAuthority for EchoOnlyAuthority {
+    impl ShellConsentAuthority for AllowProgramAuthority {
         fn consent(
             &mut self,
             request: ShellConsentRequest<'_>,
         ) -> Result<ResourceConsent, &'static str> {
-            if request.args.get(3).map(String::as_str) != Some("/usr/bin/echo") {
+            if request.args.get(3).map(String::as_str) != Some(self.allowed_program) {
                 return Err("command not consented");
             }
             let fingerprint = symbiote_sandbox::fingerprint_command(
@@ -670,7 +670,8 @@ mod tests {
         let mut executor = SandboxShellExecutor {
             launcher_path: launcher,
             protected_paths: vec![fixture.base.join("protected-host")],
-            authority: Box::new(EchoOnlyAuthority {
+            authority: Box::new(AllowProgramAuthority {
+                allowed_program: "/usr/bin/echo",
                 access: access.clone(),
             }),
             root_id: root,
@@ -711,7 +712,8 @@ mod tests {
         let mut executor = SandboxShellExecutor {
             launcher_path: launcher,
             protected_paths: vec![fixture.base.join("protected-host")],
-            authority: Box::new(EchoOnlyAuthority {
+            authority: Box::new(AllowProgramAuthority {
+                allowed_program: "/usr/bin/echo",
                 access: access.clone(),
             }),
             root_id: root,
@@ -742,7 +744,8 @@ mod tests {
         let mut executor = SandboxShellExecutor {
             launcher_path: launcher,
             protected_paths: vec![fixture.base.join("protected-host")],
-            authority: Box::new(EchoOnlyAuthority {
+            authority: Box::new(AllowProgramAuthority {
+                allowed_program: "/usr/bin/echo",
                 access: access.clone(),
             }),
             root_id: root,
@@ -761,5 +764,64 @@ mod tests {
             Err(ToolExecError::Refused)
         );
         assert!(!fixture.worktree.join(TOOL_OUTPUT_FILE).exists());
+    }
+
+    /// The real shell tool keeps completing under the hardened mount table: a
+    /// tool that uses `/dev/shm` — the shared-memory surface the hardening
+    /// deliberately keeps — still runs to exit 0 and reports normally through
+    /// the capture path, so the lane the executor drives did not lose a
+    /// capability it uses. The boundary itself is pinned once, in the
+    /// sandbox's own errno table (`symbiote-sandbox/tests/process.rs`): the
+    /// errno rows, the cross-process shared-memory observation and the
+    /// `/dev/pts` exception are asserted there, not restated here.
+    #[test]
+    fn a_real_sandboxed_shell_turn_completes_under_a_read_only_dev() {
+        let launcher = obtain_launcher();
+        let fixture = WorktreeFixture::new("dev-shm");
+        let root = RootId::new("root-shell-dev").unwrap();
+        let project = ProjectId::new("project-shell-dev").unwrap();
+        let access = echo_access(&project, &root);
+        let mut executor = SandboxShellExecutor {
+            launcher_path: launcher,
+            protected_paths: vec![fixture.base.join("protected-host")],
+            authority: Box::new(AllowProgramAuthority {
+                allowed_program: "/usr/bin/python3",
+                access: access.clone(),
+            }),
+            root_id: root,
+            host: HostId::new("host-shell-dev").unwrap(),
+            project_id: project,
+            role_id: RoleId::new("worker-shell-dev").unwrap(),
+            profile_id: RuntimeProfileId::new("profile-shell-dev").unwrap(),
+            user_id: symbiote_domain::UserId::new("operator").unwrap(),
+            access,
+            bound: fixture_bound(),
+        };
+        // The tool's work uses `/dev/shm` and reports its own result: a broken
+        // shared-memory mount raises here and the turn fails instead of
+        // reporting normally.
+        let probe = r#"import json,sys
+path='/dev/shm/'+sys.argv[1]
+open(path,'w').write('shared-memory')
+print(json.dumps({'shm':open(path).read()}),flush=True)
+"#;
+        let name = format!("symbiote-shell-dev-{}", std::process::id());
+        let (output, exit) = executor
+            .run_shell(
+                &invocation("python3", &["-c", probe, name.as_str()]),
+                &fixture.worktree,
+            )
+            .unwrap();
+        assert_eq!(
+            exit,
+            Some(0),
+            "the tool must complete under a read-only /dev: {output:?}"
+        );
+        let report: serde_json::Value = serde_json::from_slice(&output)
+            .unwrap_or_else(|_| panic!("tool report was not JSON: {output:?}"));
+        assert_eq!(
+            report["shm"], "shared-memory",
+            "the tool's own /dev/shm work must succeed: {report}"
+        );
     }
 }

--- a/crates/symbiote-sandbox/src/lib.rs
+++ b/crates/symbiote-sandbox/src/lib.rs
@@ -413,8 +413,18 @@ pub fn launch(request: LaunchRequest<'_>) -> Result<SandboxProcess> {
         "/lib64",
         "--proc",
         "/proc",
+        // The device tree is the sandbox's own tmpfs (`--dev`), then remounted
+        // read-only: the device nodes themselves are separate mounts and stay
+        // usable, but no new entry can be created in `/dev`. Shared memory
+        // needs a writable `/dev/shm`, so it is re-mounted as its own tmpfs on
+        // top of the now read-only `/dev`; the remount is not recursive, which
+        // is exactly why this ordering is required.
         "--dev",
         "/dev",
+        "--remount-ro",
+        "/dev",
+        "--tmpfs",
+        "/dev/shm",
         "--tmpfs",
         "/tmp",
         "--tmpfs",

--- a/crates/symbiote-sandbox/tests/process.rs
+++ b/crates/symbiote-sandbox/tests/process.rs
@@ -565,48 +565,105 @@ fn setup_failure_stderr_is_bounded_explicit_and_debug_redacted() {
 /// reserved worktree, the one Host surface a run may change. Everything else
 /// the mount table leaves reachable inside is either absent (the sandbox root
 /// is a fresh tmpfs, so no Host directory, `/etc` or `/var` exists at all —
-/// errno 2) or read-only (`/usr` is a read-only bind and the root is remounted
-/// read-only — errno 30). The remaining writable paths — `/tmp`, `/home/agent`,
-/// and `/dev` with its `/dev/shm` — are the sandbox's own tmpfs mounts, not the
-/// Host's: the test asserts a run may write there and that the write never
-/// reaches the Host path of the same name. That Host-side assertion, not the
-/// writability itself, is what keeps them off the Host boundary; it is also what
-/// would fail if the inner `/dev` were ever replaced by a bind of the Host's.
-/// Under `ReadOnly` the same table holds minus the worktree, which joins the
-/// refusing side, so a dispatch with no mutation grant gets no Host write at
-/// all.
+/// errno 2) or read-only (`/usr` is a read-only bind, the root is remounted
+/// read-only, and the device tree is the sandbox's own tmpfs remounted
+/// read-only — errno 30). Read-only `/dev` closes the alias threat class the
+/// worktree preflight exists for: a file, directory, symlink, Unix socket and
+/// device node are each attempted inside it and must be refused with the errno
+/// the kernel returned. `/tmp` and `/home/agent` are the sandbox's own writable
+/// tmpfs mounts, not the Host's: the test asserts a run may write there and
+/// that the write never reaches the Host path of the same name. `/dev/shm` is
+/// the named exception to the read-only device tree — its own writable tmpfs,
+/// proven by a forked second process observing what this one wrote — and
+/// `/dev/pts` is the other, a separate writable devpts mount where
+/// pseudo-terminal allocation must still succeed. Under `ReadOnly` the same
+/// table holds minus the worktree, which joins the refusing side, so a dispatch
+/// with no mutation grant gets no Host write at all.
 #[test]
 fn the_mount_boundary_confines_host_writes_to_the_reserved_worktree() {
-    let script = r#"import json,os,sys
+    let script = r#"import json,os,socket,stat,sys
 host_worktree,host_protected,shadow=sys.argv[1],sys.argv[2],sys.argv[3]
 tmp_before=len(os.listdir('/tmp'))
-targets={
- 'reserved_worktree':'/workspace/probe.txt',
- 'worktree_traversal':'/workspace/../probe.txt',
- 'sandbox_root':'/symbiote-probe',
- 'sandbox_usr':'/usr/symbiote-probe',
- 'sandbox_etc':'/etc/symbiote-probe',
- 'sandbox_var':'/var/symbiote-probe',
- 'host_worktree':host_worktree+'/probe.txt',
- 'host_protected':host_protected+'/probe.txt',
- 'sandbox_tmp':'/tmp/'+shadow,
- 'sandbox_home':'/home/agent/'+shadow,
- 'sandbox_dev':'/dev/'+shadow,
- 'sandbox_dev_shm':'/dev/shm/'+shadow,
-}
-def attempt(path):
+def mutation(fn):
     try:
-        with open(path,'w') as handle:
-            handle.write('probe')
-        return 'writable'
+        fn()
+        return 'allowed'
     except OSError as error:
         return error.errno
-json.dump({'cwd':os.getcwd(),'tmp_before':tmp_before,'writes':{name:attempt(path) for name,path in targets.items()}},sys.stdout)
+def write_file(path):
+    def run():
+        with open(path,'w') as handle:
+            handle.write('probe')
+    return run
+def shm_second_process_observation():
+    path='/dev/shm/'+shadow
+    try:
+        with open(path,'w') as handle:
+            handle.write('shared-memory')
+    except OSError as error:
+        return 'errno %d'%error.errno
+    read,write=os.pipe()
+    pid=os.fork()
+    if pid==0:
+        os.close(read)
+        try:
+            with open(path) as handle:
+                seen=handle.read()
+        except OSError as error:
+            seen='errno %d'%error.errno
+        os.write(write,seen.encode())
+        os._exit(0)
+    os.close(write)
+    seen=b''
+    while True:
+        part=os.read(read,64)
+        if not part:
+            break
+        seen+=part
+    os.close(read)
+    os.waitpid(pid,0)
+    return seen.decode()
+probes={
+ 'reserved_worktree':write_file('/workspace/probe.txt'),
+ 'worktree_traversal':write_file('/workspace/../probe.txt'),
+ 'sandbox_root':write_file('/symbiote-probe'),
+ 'sandbox_usr':write_file('/usr/symbiote-probe'),
+ 'sandbox_etc':write_file('/etc/symbiote-probe'),
+ 'sandbox_var':write_file('/var/symbiote-probe'),
+ 'host_worktree':write_file(host_worktree+'/probe.txt'),
+ 'host_protected':write_file(host_protected+'/probe.txt'),
+ 'sandbox_tmp':write_file('/tmp/'+shadow),
+ 'sandbox_home':write_file('/home/agent/'+shadow),
+ 'sandbox_dev':write_file('/dev/'+shadow),
+ 'dev_mkdir':lambda:os.mkdir('/dev/'+shadow),
+ 'dev_symlink':lambda:os.symlink('/workspace','/dev/'+shadow),
+ 'dev_socket':lambda:socket.socket(socket.AF_UNIX).bind('/dev/'+shadow),
+ 'dev_node':lambda:os.mknod('/dev/'+shadow,0o600|stat.S_IFCHR),
+}
+def device_nodes():
+    try:
+        with open('/dev/null','w') as handle:
+            handle.write('probe')
+        with open('/dev/urandom','rb') as handle:
+            handle.read(4)
+        return 'usable'
+    except OSError as error:
+        return error.errno
+def pty_allocation():
+    try:
+        import pty
+        master,slave=pty.openpty()
+        os.close(master)
+        os.close(slave)
+        return 'allocated'
+    except OSError as error:
+        return error.errno if error.errno is not None else 'refused'
+json.dump({'cwd':os.getcwd(),'tmp_before':tmp_before,'shm_observed':shm_second_process_observation(),'device_nodes':device_nodes(),'pty':pty_allocation(),'probes':{name:mutation(fn) for name,fn in probes.items()}},sys.stdout)
 sys.stdout.write('\n')
 sys.stdout.flush()
 "#;
     for (profile, reserved_worktree) in [
-        (Profile::WorktreeWrite, serde_json::json!("writable")),
+        (Profile::WorktreeWrite, serde_json::json!("allowed")),
         (Profile::ReadOnly, serde_json::json!(30)),
     ] {
         let fixture = Fixture::new();
@@ -639,17 +696,33 @@ sys.stdout.flush()
             serde_json::json!(0),
             "the sandbox's /tmp is its own and empty at start: {observed}"
         );
-        let writes = &observed["writes"];
+        let probes = &observed["probes"];
         assert_eq!(
-            writes["reserved_worktree"], reserved_worktree,
+            probes["reserved_worktree"], reserved_worktree,
             "{profile:?}: the reserved worktree is writable exactly under the mutation grant: {observed}"
         );
-        // Read-only surfaces: the read-only `/usr` bind and the fresh root.
-        for target in ["worktree_traversal", "sandbox_root", "sandbox_usr"] {
+        // Read-only surfaces: the read-only `/usr` bind, the fresh root and the
+        // device tree (`/dev` is remounted read-only after `--dev`).
+        for target in [
+            "worktree_traversal",
+            "sandbox_root",
+            "sandbox_usr",
+            "sandbox_dev",
+        ] {
             assert_eq!(
-                writes[target],
+                probes[target],
                 serde_json::json!(30),
                 "{profile:?} {target} must be read-only: {observed}"
+            );
+        }
+        // The alias threat class read-only `/dev` exists to close: no
+        // directory, symlink, Unix socket or device node may be created in the
+        // device tree, each refused with the errno the kernel returned.
+        for target in ["dev_mkdir", "dev_symlink", "dev_socket", "dev_node"] {
+            assert_eq!(
+                probes[target],
+                serde_json::json!(30),
+                "{profile:?} {target} must be refused in the device tree: {observed}"
             );
         }
         // Absent surfaces: nothing of the Host tree, `/etc` or `/var` exists
@@ -661,31 +734,42 @@ sys.stdout.flush()
             "host_protected",
         ] {
             assert_eq!(
-                writes[target],
+                probes[target],
                 serde_json::json!(2),
                 "{profile:?} {target} must be invisible inside the sandbox: {observed}"
             );
         }
-        // The sandbox's own writable tmpfs mounts, not the Host's. `/dev` is
-        // writable on purpose (its device nodes must be usable, and `/dev/shm`
-        // backs shared memory), so this row is pinned rather than refused.
-        for target in [
-            "sandbox_tmp",
-            "sandbox_home",
-            "sandbox_dev",
-            "sandbox_dev_shm",
-        ] {
+        // The sandbox's own writable tmpfs mounts, not the Host's.
+        for target in ["sandbox_tmp", "sandbox_home"] {
             assert_eq!(
-                writes[target], "writable",
+                probes[target], "allowed",
                 "{profile:?} {target} is the sandbox's own mount: {observed}"
             );
         }
+        // A read-only `/dev` does not take the device nodes with it: they are
+        // separate mounts.
+        assert_eq!(
+            observed["device_nodes"], "usable",
+            "{profile:?}: device nodes under a read-only /dev: {observed}"
+        );
+        // `/dev/pts` is the named exception: a separate writable devpts mount
+        // where pseudo-terminal allocation must still succeed.
+        assert_eq!(
+            observed["pty"], "allocated",
+            "{profile:?}: /dev/pts pty allocation under a read-only /dev: {observed}"
+        );
+        // Shared memory is a real cross-process surface: a forked second
+        // process reads back what this one wrote through `/dev/shm`.
+        assert_eq!(
+            observed["shm_observed"], "shared-memory",
+            "{profile:?}: a second process must observe the /dev/shm write: {observed}"
+        );
         assert!(
             !std::path::Path::new("/tmp").join(&shadow).exists()
                 && !std::path::Path::new("/home/agent").join(&shadow).exists()
                 && !std::path::Path::new("/dev").join(&shadow).exists()
                 && !std::path::Path::new("/dev/shm").join(&shadow).exists(),
-            "{profile:?}: a write inside the sandbox's own /tmp, /home or /dev reached the Host"
+            "{profile:?}: a write inside the sandbox's own /tmp, /home, /dev or /dev/shm reached the Host"
         );
         // Under the writable profile the file the probe wrote through
         // `/workspace` is the Host's own file in the reserved worktree; under

--- a/crates/symbiote-workflow/Cargo.toml
+++ b/crates/symbiote-workflow/Cargo.toml
@@ -16,5 +16,16 @@ serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "signal"] }
 
+[features]
+# The daemon-freshness check the end-to-end proofs resolve `symbioted`
+# through. Test support only: a production build (the desktop shell) must not
+# carry it.
+test-support = []
+
+[dev-dependencies]
+# A package may depend on itself in `dev-dependencies` to turn `test-support`
+# on for its own integration tests; resolver 3 keeps it out of normal builds.
+symbiote-workflow = { path = ".", features = ["test-support"] }
+
 [lints]
 workspace = true

--- a/crates/symbiote-workflow/src/binaries.rs
+++ b/crates/symbiote-workflow/src/binaries.rs
@@ -1,0 +1,184 @@
+//! Test support: the daemon binary the end-to-end proofs drive.
+//!
+//! Those proofs assert behavior the binary carries — for `symbioted`, the
+//! sandbox mount policy through `symbiote-host`/`symbiote-sandbox` — so a
+//! binary that does not contain the sources under test would let a proof stay
+//! green while running other code. [`daemon_binary`] refuses such a binary
+//! with the rebuild that fixes it, rather than running it. Gated behind the
+//! `test-support` feature, so a production build does not carry it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::SystemTime;
+
+use serde_json::Value;
+
+/// The workspace-built `symbioted`, or a refusal naming what outdates it.
+pub fn daemon_binary() -> PathBuf {
+    static RESOLVED: OnceLock<PathBuf> = OnceLock::new();
+    RESOLVED.get_or_init(resolve).clone()
+}
+
+fn resolve() -> PathBuf {
+    let metadata = metadata();
+    let binary = path(&metadata["target_directory"]).join("debug/symbioted");
+    let stale = if binary.is_file() {
+        stale_source(
+            &daemon_sources(&metadata, &path(&metadata["workspace_root"])),
+            &binary,
+        )
+        .map(|source| format!("{} changed after it was built", source.display()))
+    } else {
+        Some("it has not been built in this tree".to_owned())
+    };
+    if let Some(reason) = stale {
+        panic!(
+            "symbioted at {} is not current for the sources under test: {reason}. Rebuild it from \
+             sources — `cargo build --locked -p symbiote-host --bin symbioted` (or run \
+             `cargo test --workspace --locked`) — so this proof exercises the current mount \
+             policy instead of an old binary.",
+            binary.display()
+        );
+    }
+    binary
+}
+
+/// Cargo's own resolved view of the workspace. The daemon's sources are then
+/// cargo's definition of them rather than this guard's guess: `cargo test`
+/// builds `target/debug/symbioted` **without** writing its dep-info
+/// (`target/debug/symbioted.d`), so a guard that reads that file refuses the
+/// healthy tree CI has.
+fn metadata() -> Value {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let output = std::process::Command::new(cargo)
+        .args(["metadata", "--locked", "--format-version", "1"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .unwrap_or_else(|error| panic!("cannot run cargo metadata: {error}"));
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "cannot resolve the sources `symbioted` is built from, so no proof can show the \
+             binary reflects them — `cargo metadata --locked` exited with {} ({error}):\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+/// The workspace-local sources of every package `symbiote-host` reaches
+/// through its normal and build dependency edges — exactly what rebuilding the
+/// daemon would consume from this tree. Dev/test edges are excluded, and so are
+/// registry sources: neither is compiled into the binary, so a change there
+/// must not refuse a daemon that is current — a refusal nothing but touching the
+/// binary could clear.
+fn daemon_sources(metadata: &Value, workspace: &Path) -> Vec<PathBuf> {
+    let packages = array(&metadata["packages"]);
+    let mut dependencies = std::collections::BTreeMap::new();
+    for node in array(&metadata["resolve"]["nodes"]) {
+        dependencies.insert(
+            text(&node["id"]).to_owned(),
+            array(&node["deps"])
+                .iter()
+                .filter(|dependency| {
+                    let kinds = array(&dependency["dep_kinds"]);
+                    kinds.is_empty() || kinds.iter().any(|kind| text(&kind["kind"]) != "dev")
+                })
+                .map(|dependency| text(&dependency["pkg"]).to_owned())
+                .collect::<Vec<_>>(),
+        );
+    }
+    let host = packages
+        .iter()
+        .find(|package| text(&package["name"]) == "symbiote-host")
+        .expect("the workspace's symbiote-host package");
+    let (mut pending, mut reached, mut sources) = (
+        vec![text(&host["id"]).to_owned()],
+        BTreeSet::new(),
+        Vec::new(),
+    );
+    while let Some(package) = pending.pop() {
+        if !reached.insert(package.clone()) {
+            continue;
+        }
+        pending.extend(dependencies.get(&package).into_iter().flatten().cloned());
+        let Some(manifest) = packages
+            .iter()
+            .find(|candidate| text(&candidate["id"]) == package)
+            .map(|candidate| path(&candidate["manifest_path"]))
+            .and_then(|manifest| manifest.parent().map(Path::to_path_buf))
+        else {
+            continue;
+        };
+        if manifest.starts_with(workspace) {
+            sources.extend(source_files(&manifest));
+        }
+    }
+    sources
+}
+
+/// Every source file under one workspace crate that its library and binaries
+/// are built from: the `.rs` files cargo would compile and the manifests that
+/// shape them. Test, example and bench targets are skipped because
+/// `cargo build --locked -p symbiote-host --bin symbioted` does not compile
+/// them, so their timestamps say nothing about the daemon.
+fn source_files(crate_directory: &Path) -> Vec<PathBuf> {
+    let mut directories = vec![crate_directory.to_path_buf()];
+    let mut sources = Vec::new();
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(&directory)
+            .into_iter()
+            .flatten()
+            .flatten()
+        {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            match entry.file_type() {
+                Ok(kind) if kind.is_dir() => {
+                    if !matches!(
+                        name.as_ref(),
+                        "target"
+                            | "node_modules"
+                            | "dist"
+                            | ".git"
+                            | "tests"
+                            | "examples"
+                            | "benches"
+                    ) {
+                        directories.push(entry.path());
+                    }
+                }
+                _ if name.ends_with(".rs") || name == "Cargo.toml" => sources.push(entry.path()),
+                _ => {}
+            }
+        }
+    }
+    sources
+}
+
+/// The newest source newer than `binary`, if any: one the binary was not
+/// built from, and so a daemon that no longer reflects the tree under test.
+fn stale_source(sources: &[PathBuf], binary: &Path) -> Option<PathBuf> {
+    let built = binary.metadata().ok()?.modified().ok()?;
+    sources
+        .iter()
+        .filter_map(|source| Some((source.metadata().ok()?.modified().ok()?, source)))
+        .filter(|(modified, _)| *modified > built)
+        .max_by_key(|(modified, _): &(SystemTime, &PathBuf)| *modified)
+        .map(|(_, source)| source.clone())
+}
+
+fn array(value: &Value) -> Vec<&Value> {
+    value
+        .as_array()
+        .map(|array| array.iter().collect())
+        .unwrap_or_default()
+}
+
+fn text(value: &Value) -> &str {
+    value.as_str().unwrap_or_default()
+}
+
+fn path(value: &Value) -> PathBuf {
+    PathBuf::from(text(value))
+}

--- a/crates/symbiote-workflow/src/lib.rs
+++ b/crates/symbiote-workflow/src/lib.rs
@@ -14,6 +14,8 @@
 //! explicit user authorization for credentials and billing. The worktree
 //! status this crate reads is a real filesystem fact of what the run
 //! produced through the sandboxed shell executor.
+#[cfg(feature = "test-support")]
+pub mod binaries;
 pub mod demo;
 pub mod socket;
 

--- a/crates/symbiote-workflow/tests/end_to_end.rs
+++ b/crates/symbiote-workflow/tests/end_to_end.rs
@@ -22,7 +22,7 @@ struct Daemon {
 
 impl Daemon {
     fn spawn(state_dir: &std::path::Path, config_path: &std::path::Path) -> Self {
-        let mut child = Command::new(daemon_binary())
+        let mut child = Command::new(symbiote_workflow::binaries::daemon_binary())
             .arg("--state-dir")
             .arg(state_dir)
             .arg("--operator-config")
@@ -80,20 +80,6 @@ impl Drop for Daemon {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
-}
-
-/// The daemon binary from the workspace target directory (the workspace
-/// gauntlet builds every bin; a partial single-crate run must build the
-/// workspace first).
-fn daemon_binary() -> PathBuf {
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for ancestor in manifest.ancestors().skip(1) {
-        let candidate = ancestor.join("target/debug/symbioted");
-        if candidate.is_file() {
-            return candidate;
-        }
-    }
-    panic!("symbioted not built; run the workspace gauntlet (cargo test --workspace)");
 }
 
 fn launcher_binary() -> PathBuf {
@@ -169,6 +155,11 @@ for line in sys.stdin:
     elif m=="turn/start":
         send({"id":msg["id"],"result":{"turn":{"id":"turn-bounded"}}})
         open("produced.txt","w").write("the external harness wrote its worktree\n")
+        try:
+            open("/dev/harness-probe","w"); dev=None
+        except OSError as error:
+            dev=error.errno
+        open("dev-probe.json","w").write(json.dumps({"dev":dev}))
         send({"method":"item/completed","params":{"threadId":"thr-bounded","turnId":"turn-bounded","item":{"type":"agentMessage","id":"i1","text":"harness address-space ceiling %d"%soft}}})
         send({"method":"turn/completed","params":{"threadId":"thr-bounded","turnId":"turn-bounded","turn":{"id":"turn-bounded","status":"completed","items":[]}}})
 "#;
@@ -1141,5 +1132,20 @@ fn a_started_external_harness_runs_under_the_declared_memory_bound() {
         outcome.worktree.contains("produced.txt"),
         "the external harness's produced file must be visible in its worktree: {:?}",
         outcome.worktree
+    );
+    // The daemon's own launch carries the hardened mount table: the harness it
+    // starts inside the sandbox finds `/dev` read-only. (The rest of the
+    // boundary — errno rows, the cross-process `/dev/shm` observation and the
+    // `/dev/pts` exception — is pinned once in the sandbox's errno table; this
+    // asserts the launch composition the daemon performs, not the table again.)
+    let probe: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(outcome.worktree.worktree.join("dev-probe.json"))
+            .expect("the harness's device probe file"),
+    )
+    .expect("device probe json");
+    assert_eq!(
+        probe,
+        serde_json::json!({"dev": 30}),
+        "the daemon's own launch must carry a read-only device tree: {probe}"
     );
 }

--- a/docs/security/linux-sandbox.md
+++ b/docs/security/linux-sandbox.md
@@ -54,16 +54,26 @@ Namespace isolation does not make a maliciously provisioned mount safe.
 
 The mount boundary's observable consequence is a table, not a profile name:
 the reserved worktree is writable only under worktree-write, the root is a fresh
-tmpfs remounted read-only and `/usr` is a read-only bind, so every Host surface
-— the Host tree, `/etc`, `/var` — is absent inside (errno 2) or read-only
-(errno 30). `/tmp`, `/home/agent` and `/dev` (with its `/dev/shm`) are writable,
-because each is the sandbox's own tmpfs mount rather than the Host's: no write
-there reaches the Host path of the same name. `/dev` is left writable on purpose
-instead of remounted read-only — its device nodes must stay usable, and shared
-memory lives in `/dev/shm`, which a non-recursive `--remount-ro /` does not
-reach. A test in `crates/symbiote-sandbox/tests/process.rs`
+tmpfs remounted read-only, `/usr` is a read-only bind and the device tree is the
+sandbox's own tmpfs remounted read-only, so every Host surface — the Host tree,
+`/etc`, `/var` — is absent inside (errno 2) or read-only (errno 30). `/tmp` and
+`/home/agent` are writable because each is the sandbox's own tmpfs mount rather
+than the Host's: no write there reaches the Host path of the same name. `/dev`
+is hardened deliberately: `--dev` populates a private tmpfs whose device nodes
+are separate mounts, then it is remounted read-only, so the alias threat class
+the worktree preflight rejects — a planted Unix socket, device node, directory
+or symlink — cannot be created there at all (each refused EROFS). The device
+tree has two exceptions. `--tmpfs` re-mounts `/dev/shm` as its own writable
+mount: the test asserts a write there is readable by a forked second process and
+that the Host's `/dev/shm` never sees it. `/dev/pts` is a separate writable
+devpts mount: the test asserts pseudo-terminal allocation succeeds. A test in
+`crates/symbiote-sandbox/tests/process.rs`
 (`the_mount_boundary_confines_host_writes_to_the_reserved_worktree`) pins the
-whole errno table, Host-side effects included, for both profiles.
+whole errno table for both profiles — `/dev` refusing a file, directory, symlink,
+socket and device node with errno 30; `/dev/null` writable and `/dev/urandom`
+readable under the read-only mount; the cross-process `/dev/shm` observation; and
+PTY allocation through `/dev/pts` — and checks that the writes attempted under
+`/tmp`, `/home/agent`, `/dev` and `/dev/shm` never appear on the Host.
 
 A live adversarial probe demonstrated why: a pathname Unix socket inside a
 mounted worktree reached a Host listener despite network namespace isolation,


### PR DESCRIPTION
## The defect

`6e9b805e` measured the mount boundary and left `/dev` **writable**, because
`--dev /dev` creates its own rw tmpfs and `--remount-ro /` does not recurse
into it. `/dev/shm` backing shared memory was the reason it stayed that way.

That is the alias threat class the worktree preflight exists for: an entry
planted inside a mount — a Unix socket, a device node, a directory, a symlink —
reaches the Host. The sandbox's own device tree was the one writable mount
where nothing stopped it, and nothing asserted it either.

## The fix

Two words in the launcher's mount plan, in an order that matters:

```
--dev /dev            # the sandbox's private device tmpfs
--remount-ro /dev     # ... now read-only (non-recursive: nodes are separate mounts)
--tmpfs /dev/shm      # shared memory re-mounted writable on top
```

`/dev/pts` is a separate writable devpts mount and is left alone. The device
nodes, `/dev/shm` and PTY allocation all keep working; nothing new can be
created in `/dev`.

## What each changed file does — object to any of these

- **`crates/symbiote-sandbox/src/lib.rs`** (+10) — the mount plan above and the
  comment explaining why the ordering is required. This is the only production
  behavior change in the PR.
- **`crates/symbiote-sandbox/tests/process.rs`** (+176/−…) — the canonical errno
  table for both profiles gains the alias-surface rows (file, `mkdir`,
  `symlink`, `AF_UNIX` bind, `mknod`, each with the errno the kernel returned),
  a device-node row, a PTY row through `/dev/pts`, and a **cross-process**
  `/dev/shm` observation: a forked second process reads back what the first
  wrote. The old row wrote and read one file in the same process, which would
  have stayed green even if `/dev/shm` were not shared at all.
- **`crates/symbiote-host/src/shell_executor.rs`** (+82) — the fixture consent
  authority is generalized from echo-only to any one program, and one new test
  runs the real shell tool through `SandboxShellExecutor`. It asserts only that
  the lane **completes** (exit 0) under the hardened table while doing `/dev/shm`
  work; the boundary itself is not restated here.
- **`crates/symbiote-workflow/tests/end_to_end.rs`** (+36) — the external-harness
  e2e now has the harness attempt a write inside `/dev` and assert the errno from
  its own worktree evidence, so the proof covers **the daemon's own launch**
  carrying the policy rather than the launcher in isolation.
- **`crates/symbiote-workflow/src/binaries.rs`** (new, 184) — one resolver for
  the workspace-built `symbioted` that **refuses to run a proof against a binary
  that does not contain the sources under test**, naming the source and the
  rebuild that fixes it. It scopes that check to the daemon's own build graph,
  resolved from `cargo metadata`: normal and build dependency edges only, and
  within each crate only the files its libraries and binaries are compiled from.
  So an edit to a crate the daemon does not carry, or to a dev/test edge or a
  `tests`/`examples`/`benches` target, cannot refuse its proofs — no rebuild could
  clear such a refusal. Why it exists: during an earlier mutation run the harness
  proof stayed green against a stale `symbioted`, i.e. it passed without the code
  under test running.
- **`crates/symbiote-workflow/{src/lib.rs,Cargo.toml}`, `crates/symbiote-desktop/Cargo.toml`, `Cargo.lock`** (+17) — `binaries` is **test support** gated behind a
  `test-support` feature, so a production build does not carry it. This is the
  most objectionable part of the PR: it needs a dev-only self-dependency to turn
  the feature on for this crate's own integration tests, and `Cargo.lock` gains
  one line recording it. The alternative was shipping the resolver in production
  builds.
- **`crates/symbiote-desktop/tests/controller.rs`** (+23/−…) — its own
  `is_file()` binary walk is replaced by that resolver, because this proof was
  demonstrably able to pass against the very daemon the workflow guard rejected.
- **`docs/security/linux-sandbox.md`** (+28/−…) — the boundary paragraph now
  states only what the test asserts, including the two writable exceptions
  (`/dev/shm`, `/dev/pts`) instead of calling the whole device tree read-only.

## Evidence

**The real table**, captured from the final launcher flags (both profiles):

```
{"sandbox_dev": 30, "dev_mkdir": 30, "dev_symlink": 30, "dev_socket": 30,
 "dev_node": 30, "device_nodes": "usable", "pty": "allocated",
 "shm_observed": "shared-memory"}
```

**Each new assertion is sensitive — mutations, then byte-identical restore**
(`cmp` clean, sha256 `52cd1784…` on `crates/symbiote-sandbox/src/lib.rs`):

| Mutation | Canonical table | Shell tool | Harness e2e |
|---|---|---|---|
| drop `--remount-ro /dev` | FAILED `"sandbox_dev":"allowed"`, `dev_mkdir:17`, `dev_node:17`, `dev_socket:98`, `dev_symlink:17` | ok | FAILED `{"dev":null}` — the launch no longer carries the policy |
| `--tmpfs /dev/shm` → `--dir` | FAILED `"shm_observed":"errno 30"` | FAILED `OSError: [Errno 30] Read-only file system: '/dev/shm/symbiote-shell-dev-…'`, exit ≠ 0 | ok |
| `--dev` → `--tmpfs` + `--dir /dev/shm` | FAILED `"device_nodes":30` | ok | ok |
| add `--remount-ro /dev/pts` | FAILED `"pty":"refused"` | ok | ok |

The two `ok` cells per mutation are the point of the split: each surface owns
one claim, so no row is asserted three times.

**The freshness guard, both directions**, on a daemon left stale on disk, with
no manual rebuild in between:

- a daemon source newer than the binary (`crates/symbiote-sandbox/src/lib.rs` at
  `15:18:15` vs the binary at `14:36:02`) → the proof **refuses in 0.5s**, naming
  the file: `symbioted at …/target/debug/symbioted is not current for the sources
  under test: …/crates/symbiote-sandbox/src/lib.rs changed after it was built.
  Rebuild it from sources — cargo build --locked -p symbiote-host --bin symbioted
  (or run cargo test --workspace --locked) — so this proof exercises the current
  mount policy instead of an old binary.` The desktop controller proof refuses
  identically, from the same function (`1 failed`, `1 failed`);
- after `cargo build --locked -p symbiote-host --bin symbioted` → both proofs
  pass (`1 passed`, `6 passed`);
- an edit to a crate the daemon does not carry (`crates/symbiote-workflow/src/binaries.rs`,
  newer than the binary) → the proof **passes without a rebuild**, because the
  guard measures the daemon's own inputs rather than the whole tree;
- an edit to a daemon-crate **test** file (`crates/symbiote-sandbox/tests/process.rs`,
  which `cargo build --locked -p symbiote-host --bin symbioted` does not compile)
  → the proof passes, because the source set is the build graph and nothing else.
  Before that scoping it refused, and **the documented rebuild could not clear
  it** (the binary was unchanged at `15:21:32` while the test file sat at
  `15:27:53`). This was CodeRabbit's finding on the first head of this fix; the
  refusal it produced was the exact misfire this guard exists to avoid.

> **First CI run of this PR failed here, and this is what the fix rests on.** The
> guard first compared the binary's mtime against cargo's dep-info
> (`target/debug/symbioted.d`) and refused when it could not read it. That file is
> written by `cargo build`, not by `cargo test`: `contracts (1.85.0)` run
> [34710646320](https://github.com/RepairYourTech/SymbioteIDE/actions/runs/34710646320)
> only ran `cargo test --workspace --locked`, so a *healthy* tree was refused —
> `symbioted.d is unreadable (No such file or directory (os error 2))`, six
> desktop controller proofs failed in 0.03s. Measured in a fresh checkout with an
> empty target directory, after `cargo test --workspace --locked` alone:
> `target/debug/symbioted` exists (mtime `15:22:57`) and no source of its closure
> is newer than it, while `target/debug/symbioted.d` does not exist at all.
> Building the daemon instead would also pass there, but it cannot *refuse* a
> stale binary; the guard does, against the source set cargo itself resolves.

**The feature gate.** With `crates/symbiote-workflow/src/binaries.rs` temporarily
absent: `cargo build --locked -p symbiote-desktop` finishes (production does not
compile the module) and `cargo test -p symbiote-workflow --test end_to_end --no-run`
fails with `error[E0583]: file not found for module 'binaries'` (tests do).

**Local gauntlet**: `cargo test --workspace --locked` exit 0 (79 suites green,
including `the_mount_boundary_confines_host_writes_to_the_reserved_worktree`,
`a_real_sandboxed_shell_turn_completes_under_a_read_only_dev`,
`a_started_external_harness_runs_under_the_declared_memory_bound`), `cargo fmt
--all --check` clean, `cargo clippy --workspace --all-targets --locked -- -D
warnings` clean. No new dependencies.

## Notes

- The sandbox suite skips nothing for want of bubblewrap: the launcher is
  resolved from the workspace target directory and a missing one panics loudly
  rather than passing.
- The errno values are the kernel's, read from the probe: `30` = EROFS on every
  alias surface, `17`/`98` (EEXIST/EADDRINUSE) are what a *writable* `/dev`
  produces, which is how the mutation rows above were recognised.

References #464 — this closes the `/dev` half of the boundary, not the issue.

