### PR TITLE
test(proofs): resolve the sandbox launcher through the freshness guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
  "symbiote-sandbox",
  "symbiote-store",
  "symbiote-trust",
+ "symbiote-workflow",
  "symbiote-workforce",
  "symbiote-worktrees",
 ]

--- a/crates/symbiote-desktop/tests/controller.rs
+++ b/crates/symbiote-desktop/tests/controller.rs
@@ -25,16 +25,19 @@ fn git(repo: &std::path::Path, args: &[&str]) {
 }
 
 fn bin_dir() -> PathBuf {
-    // The gauntlet builds every binary. Reuse the workflow proof's resolver so
-    // this proof cannot pass against a `symbioted` built from older sources
-    // while the daemon runs code that no longer reflects the repository.
+    // The gauntlet builds every binary. Both are resolved through the workflow
+    // proof's freshness check, so this proof cannot pass against a `symbioted`
+    // or a launcher built from older sources while the daemon runs code that no
+    // longer reflects the repository.
     let daemon = symbiote_workflow::binaries::daemon_binary();
+    let launcher = symbiote_workflow::binaries::launcher_binary();
     let dir = daemon
         .parent()
         .expect("symbioted lives in the workspace target directory");
-    assert!(
-        dir.join("symbiote-sandbox-launch").is_file(),
-        "workspace binaries not built; run the workspace gauntlet"
+    assert_eq!(
+        launcher.parent(),
+        Some(dir),
+        "the daemon and the launcher must come from one target directory"
     );
     dir.to_path_buf()
 }

--- a/crates/symbiote-host/Cargo.toml
+++ b/crates/symbiote-host/Cargo.toml
@@ -26,6 +26,11 @@ serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "fs"] }
 
+[dev-dependencies]
+# The real-sandbox proofs resolve the launcher through the workflow crate's
+# freshness check, which only test builds carry.
+symbiote-workflow = { path = "../symbiote-workflow", features = ["test-support"] }
+
 [lints]
 workspace = true
 

--- a/crates/symbiote-host/src/shell_executor.rs
+++ b/crates/symbiote-host/src/shell_executor.rs
@@ -556,10 +556,10 @@ mod tests {
         }
     }
 
-    /// Locates (or builds) the trusted launcher. A partial `-p symbiote-host`
-    /// build may not have compiled the sandbox crate's binary, so the test
-    /// builds it directly — the e2e coverage must not silently degrade to a
-    /// counted-as-passed skip (PR #507 review P2).
+    /// The trusted launcher: `SYMBIOTE_SANDBOX_LAUNCHER` names one explicitly,
+    /// otherwise the workspace build is resolved through the shared freshness
+    /// check (PR #507 review P2 — a missing or stale launcher must not let the
+    /// e2e degrade to a counted-as-passed skip).
     fn obtain_launcher() -> PathBuf {
         if let Ok(path) = std::env::var("SYMBIOTE_SANDBOX_LAUNCHER") {
             let path = PathBuf::from(path);
@@ -567,64 +567,7 @@ mod tests {
                 return path;
             }
         }
-        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        for ancestor in manifest.ancestors().skip(1) {
-            let target = ancestor.join("target");
-            if !target.is_dir() {
-                continue;
-            }
-            let direct = target.join("debug").join("symbiote-sandbox-launch");
-            if direct.is_file() {
-                return direct;
-            }
-            if let Ok(entries) = std::fs::read_dir(&target) {
-                for entry in entries.flatten() {
-                    let candidate = entry.path().join("debug").join("symbiote-sandbox-launch");
-                    if candidate.is_file() {
-                        return candidate;
-                    }
-                }
-            }
-        }
-        // Build the launcher in the workspace target directory. `cargo
-        // test --workspace` has already compiled everything; this only
-        // fires for a partial single-crate build. If even the build fails
-        // the test fails loudly — a skip that looks like a pass is a
-        // coverage hole.
-        let workspace = manifest
-            // ancestors() includes the path itself: crates/symbiote-host →
-            // crates → workspace root, so the root is the second ancestor.
-            .ancestors()
-            .nth(2)
-            .expect("crates/symbiote-host lives two levels below the workspace root");
-        let status = std::process::Command::new("cargo")
-            .args([
-                "build",
-                "-p",
-                "symbiote-sandbox",
-                "--bin",
-                "symbiote-sandbox-launch",
-            ])
-            .current_dir(workspace)
-            .status()
-            .expect("cargo build for the sandbox launcher");
-        assert!(
-            status.success(),
-            "the sandbox launcher could not be built; the real-sandbox e2e cannot run"
-        );
-        workspace
-            .join("target/debug/symbiote-sandbox-launch")
-            .assert_exists()
-    }
-
-    trait AssertExists {
-        fn assert_exists(self) -> PathBuf;
-    }
-    impl AssertExists for PathBuf {
-        fn assert_exists(self) -> PathBuf {
-            assert!(self.is_file(), "launcher missing after build: {self:?}");
-            self
-        }
+        symbiote_workflow::binaries::launcher_binary()
     }
 
     /// A 0o700 private fixture root with a worktree the launch validation

--- a/crates/symbiote-workflow/src/binaries.rs
+++ b/crates/symbiote-workflow/src/binaries.rs
@@ -1,11 +1,13 @@
-//! Test support: the daemon binary the end-to-end proofs drive.
+//! Test support: the workspace-built binaries the end-to-end proofs drive.
 //!
-//! Those proofs assert behavior the binary carries — for `symbioted`, the
-//! sandbox mount policy through `symbiote-host`/`symbiote-sandbox` — so a
-//! binary that does not contain the sources under test would let a proof stay
-//! green while running other code. [`daemon_binary`] refuses such a binary
-//! with the rebuild that fixes it, rather than running it. Gated behind the
-//! `test-support` feature, so a production build does not carry it.
+//! Those proofs assert behavior the binaries carry — for `symbioted`, the
+//! sandbox mount policy through `symbiote-host`/`symbiote-sandbox`; for
+//! `symbiote-sandbox-launch`, the descriptor boundary every sandboxed process
+//! is started through — so a binary that does not contain the sources under
+//! test would let a proof stay green while running other code. The resolvers
+//! here build a binary that is absent and refuse one that is stale, naming the
+//! rebuild that fixes it. Gated behind the `test-support` feature, so a
+//! production build does not carry them.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -17,39 +19,59 @@ use serde_json::Value;
 /// The workspace-built `symbioted`, or a refusal naming what outdates it.
 pub fn daemon_binary() -> PathBuf {
     static RESOLVED: OnceLock<PathBuf> = OnceLock::new();
-    RESOLVED.get_or_init(resolve).clone()
+    RESOLVED
+        .get_or_init(|| binary("symbiote-host", "symbioted", "mount policy"))
+        .clone()
 }
 
-fn resolve() -> PathBuf {
-    let metadata = metadata();
-    let binary = path(&metadata["target_directory"]).join("debug/symbioted");
-    let stale = if binary.is_file() {
-        stale_source(
-            &daemon_sources(&metadata, &path(&metadata["workspace_root"])),
+/// The workspace-built `symbiote-sandbox-launch`, or a refusal naming what
+/// outdates it. The launcher is the boundary a sandboxed process is started
+/// through, so a stale copy would be the boundary under test rather than the
+/// one the sources describe.
+pub fn launcher_binary() -> PathBuf {
+    static RESOLVED: OnceLock<PathBuf> = OnceLock::new();
+    RESOLVED
+        .get_or_init(|| {
+            binary(
+                "symbiote-sandbox",
+                "symbiote-sandbox-launch",
+                "descriptor boundary",
+            )
+        })
+        .clone()
+}
+
+/// `name` built from `package`, resolved once per test process: built when it
+/// is absent, refused when a source of `package` is newer than it.
+fn binary(package: &str, name: &str, subject: &str) -> PathBuf {
+    let metadata = metadata(package);
+    let binary = path(&metadata["target_directory"]).join("debug").join(name);
+    if binary.is_file() {
+        if let Some(source) = stale_source(
+            &sources(&metadata, &path(&metadata["workspace_root"]), package),
             &binary,
-        )
-        .map(|source| format!("{} changed after it was built", source.display()))
+        ) {
+            panic!(
+                "{name} at {} is not current for the sources under test: {} changed after it was \
+                 built. Rebuild it from sources — `cargo build --locked -p {package} --bin \
+                 {name}` (or run `cargo test --workspace --locked`) — so this proof exercises the \
+                 current {subject} instead of an old binary.",
+                binary.display(),
+                source.display()
+            );
+        }
     } else {
-        Some("it has not been built in this tree".to_owned())
-    };
-    if let Some(reason) = stale {
-        panic!(
-            "symbioted at {} is not current for the sources under test: {reason}. Rebuild it from \
-             sources — `cargo build --locked -p symbiote-host --bin symbioted` (or run \
-             `cargo test --workspace --locked`) — so this proof exercises the current mount \
-             policy instead of an old binary.",
-            binary.display()
-        );
+        build(package, name);
     }
     binary
 }
 
-/// Cargo's own resolved view of the workspace. The daemon's sources are then
-/// cargo's definition of them rather than this guard's guess: `cargo test`
-/// builds `target/debug/symbioted` **without** writing its dep-info
-/// (`target/debug/symbioted.d`), so a guard that reads that file refuses the
+/// Cargo's own resolved view of the workspace. The sources of `package` are
+/// then cargo's definition of them rather than this guard's guess: `cargo test`
+/// builds `target/debug/<bin>` **without** writing its dep-info
+/// (`target/debug/<bin>.d`), so a guard that reads that file refuses the
 /// healthy tree CI has.
-fn metadata() -> Value {
+fn metadata(package: &str) -> Value {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
     let output = std::process::Command::new(cargo)
         .args(["metadata", "--locked", "--format-version", "1"])
@@ -58,7 +80,7 @@ fn metadata() -> Value {
         .unwrap_or_else(|error| panic!("cannot run cargo metadata: {error}"));
     serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
         panic!(
-            "cannot resolve the sources `symbioted` is built from, so no proof can show the \
+            "cannot resolve the sources `{package}` is built from, so no proof can show the \
              binary reflects them — `cargo metadata --locked` exited with {} ({error}):\n{}",
             output.status,
             String::from_utf8_lossy(&output.stderr)
@@ -66,13 +88,30 @@ fn metadata() -> Value {
     })
 }
 
-/// The workspace-local sources of every package `symbiote-host` reaches
-/// through its normal and build dependency edges — exactly what rebuilding the
-/// daemon would consume from this tree. Dev/test edges are excluded, and so are
+/// Builds one binary, so a partial `-p <crate>` build still runs the proofs
+/// instead of failing for want of a binary the workspace gauntlet would have
+/// produced.
+fn build(package: &str, name: &str) {
+    let status =
+        std::process::Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned()))
+            .args(["build", "--locked", "-p", package, "--bin", name])
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .status()
+            .unwrap_or_else(|error| panic!("cannot build {name}: {error}"));
+    assert!(
+        status.success(),
+        "`cargo build --locked -p {package} --bin {name}` failed; the proof cannot run against \
+         the current sources"
+    );
+}
+
+/// The workspace-local sources of every package `package` reaches through its
+/// normal and build dependency edges — exactly what rebuilding the binary
+/// would consume from this tree. Dev/test edges are excluded, and so are
 /// registry sources: neither is compiled into the binary, so a change there
-/// must not refuse a daemon that is current — a refusal nothing but touching the
-/// binary could clear.
-fn daemon_sources(metadata: &Value, workspace: &Path) -> Vec<PathBuf> {
+/// must not refuse a binary that is current — a refusal nothing but touching
+/// the binary could clear.
+fn sources(metadata: &Value, workspace: &Path, package: &str) -> Vec<PathBuf> {
     let packages = array(&metadata["packages"]);
     let mut dependencies = std::collections::BTreeMap::new();
     for node in array(&metadata["resolve"]["nodes"]) {
@@ -88,12 +127,12 @@ fn daemon_sources(metadata: &Value, workspace: &Path) -> Vec<PathBuf> {
                 .collect::<Vec<_>>(),
         );
     }
-    let host = packages
+    let root = packages
         .iter()
-        .find(|package| text(&package["name"]) == "symbiote-host")
-        .expect("the workspace's symbiote-host package");
+        .find(|candidate| text(&candidate["name"]) == package)
+        .unwrap_or_else(|| panic!("the workspace's {package} package"));
     let (mut pending, mut reached, mut sources) = (
-        vec![text(&host["id"]).to_owned()],
+        vec![text(&root["id"]).to_owned()],
         BTreeSet::new(),
         Vec::new(),
     );
@@ -120,8 +159,8 @@ fn daemon_sources(metadata: &Value, workspace: &Path) -> Vec<PathBuf> {
 /// Every source file under one workspace crate that its library and binaries
 /// are built from: the `.rs` files cargo would compile and the manifests that
 /// shape them. Test, example and bench targets are skipped because
-/// `cargo build --locked -p symbiote-host --bin symbioted` does not compile
-/// them, so their timestamps say nothing about the daemon.
+/// `cargo build --locked -p <crate> --bin <bin>` does not compile them, so
+/// their timestamps say nothing about the binary.
 fn source_files(crate_directory: &Path) -> Vec<PathBuf> {
     let mut directories = vec![crate_directory.to_path_buf()];
     let mut sources = Vec::new();
@@ -157,7 +196,7 @@ fn source_files(crate_directory: &Path) -> Vec<PathBuf> {
 }
 
 /// The newest source newer than `binary`, if any: one the binary was not
-/// built from, and so a daemon that no longer reflects the tree under test.
+/// built from, and so a binary that no longer reflects the tree under test.
 fn stale_source(sources: &[PathBuf], binary: &Path) -> Option<PathBuf> {
     let built = binary.metadata().ok()?.modified().ok()?;
     sources

--- a/crates/symbiote-workflow/tests/end_to_end.rs
+++ b/crates/symbiote-workflow/tests/end_to_end.rs
@@ -14,6 +14,7 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 use symbiote_protocol::ResponseBody;
+use symbiote_workflow::binaries::{daemon_binary, launcher_binary};
 
 struct Daemon {
     child: Child,
@@ -22,7 +23,7 @@ struct Daemon {
 
 impl Daemon {
     fn spawn(state_dir: &std::path::Path, config_path: &std::path::Path) -> Self {
-        let mut child = Command::new(symbiote_workflow::binaries::daemon_binary())
+        let mut child = Command::new(daemon_binary())
             .arg("--state-dir")
             .arg(state_dir)
             .arg("--operator-config")
@@ -80,19 +81,6 @@ impl Drop for Daemon {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
-}
-
-fn launcher_binary() -> PathBuf {
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for ancestor in manifest.ancestors().skip(1) {
-        let candidate = ancestor.join("target/debug/symbiote-sandbox-launch");
-        if candidate.is_file() {
-            return candidate;
-        }
-    }
-    panic!(
-        "symbiote-sandbox-launch not built; run the workspace gauntlet (cargo test --workspace)"
-    );
 }
 
 fn git(repo: &std::path::Path, args: &[&str]) -> String {


### PR DESCRIPTION
Closes nothing on its own. References #464 (the boundary the proofs cover); the device-tree mount policy itself is untouched by this commit.

## Why

`symbiote-sandbox-launch` is the descriptor boundary every sandboxed proof is started through, but two proofs resolved it by walking ancestor directories for a path that merely exists (`crates/symbiote-host/src/shell_executor.rs:573-617` and `crates/symbiote-workflow/tests/end_to_end.rs:85-95`). A launcher built from older sources therefore passed as if it were the one under test — the same false-pass hazard the daemon guard closed in #549, still open for the second proof binary.

## Changed files, so a reviewer can object to each

- `crates/symbiote-workflow/src/binaries.rs` — the guard becomes `binary(package, name, subject)` with two callers: `daemon_binary()` (unchanged behavior) and the new `launcher_binary()`. A binary that is **absent** is built (`cargo build --locked -p <package> --bin <name>`), one that is **stale** is refused naming the source that outdates it. The freshness set is `package`'s normal + build dependency closure, workspace crates only (dev/test edges and registry sources excluded), and within each crate only the files its libs/binaries compile — so a `tests/` edit cannot produce a refusal no rebuild could clear. Still behind the `test-support` feature.
- `crates/symbiote-workflow/tests/end_to_end.rs` — local `launcher_binary()` deleted; all five call sites now use the shared one (`use symbiote_workflow::binaries::{daemon_binary, launcher_binary}`).
- `crates/symbiote-host/src/shell_executor.rs` — `obtain_launcher()`'s ancestor walk, on-demand `cargo build` and `AssertExists` trait (37 lines) deleted; it keeps the explicit `SYMBIOTE_SANDBOX_LAUNCHER` override and otherwise calls the shared resolver. Net −51 lines here. No mount policy, assertion, or launcher argument changes.
- `crates/symbiote-host/Cargo.toml` — one `[dev-dependencies]` edge to `symbiote-workflow` with `features = ["test-support"]`, so the host proofs use the same check instead of a third copy. `symbiote-workflow` does not depend on `symbiote-host` (verified via `cargo metadata`), so this is not a cycle; dev-dependencies are not built for production.
- `crates/symbiote-desktop/tests/controller.rs` — `bin_dir()` resolves both binaries through the guard and asserts they share one target directory, replacing the `is_file()` assertion on the launcher.
- `Cargo.lock` — the one-line `symbiote-workflow` edge in `symbiote-host`'s dependency list.

## Hazard demonstrated, not assumed

With the launcher's `main` mutated to `exit(9)` and left **unbuilt**, the resolution the old walk approximated (the explicit override) ran the stale binary and the shell proof stayed **green** — a proof green while the launcher source under test is broken. The guarded resolution refuses:

```
symbiote-sandbox-launch at .../target/debug/symbiote-sandbox-launch is not current for the sources under test:
.../crates/symbiote-sandbox/src/bin/symbiote-sandbox-launch.rs changed after it was built. Rebuild it from sources —
`cargo build --locked -p symbiote-sandbox --bin symbiote-sandbox-launch` (or run `cargo test --workspace --locked`) —
so this proof exercises the current descriptor boundary instead of an old binary.
```

Rebuilding from that mutated source **failed** the proof (`shell_executor.rs:757`), so the proof really is sensitive to the launcher's content. Restored byte-identical (`cmp` clean, `git diff` empty) and rebuilt: 9/9 shell_executor tests pass.

## Local verification

- `cargo test --workspace --locked` → exit 0, 79 `test result: ok` suites, 0 `FAILED`, **0 staleness refusals** (the build phase refreshes both binaries, so the guard does not misfire in the gauntlet). The three boundary proofs appear as `ok`: `the_mount_boundary_confines_host_writes_to_the_reserved_worktree`, `a_real_sandboxed_shell_turn_completes_under_a_read_only_dev`, `a_started_external_harness_runs_under_the_declared_memory_bound`.
- `cargo fmt --all --check` → clean; `cargo clippy --workspace --all-targets --locked -- -D warnings` → exit 0.
- Stale-daemon direction unchanged: touching `crates/symbiote-sandbox/src/lib.rs` refused the harness e2e and the desktop proof naming that file; `cargo build --locked -p symbiote-host --bin symbioted` cleared it (9/9 and 6/6 green).
- Net −21 lines (106 insertions, 127 deletions) while extending coverage to a second binary.
