### PR TITLE
chore(planning): a pull request whose prose negates a closing keyword fails (#54)

### DIFF
--- a/.github/workflows/roadmap-integrity.yml
+++ b/.github/workflows/roadmap-integrity.yml
@@ -9,6 +9,25 @@ permissions:
   contents: read
 
 jobs:
+  closing-keywords:
+    # GitHub's issue parser does not read negation, so a description that says
+    # "This does not close #54." still closes #54 on merge: that is how #54 was
+    # closed one second after PR #530 merged, whose own first line says the
+    # slice does not complete it. Fail the pull request so the wording is
+    # fixed before the merge instead of after it.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: A pull-request description must not negate a closing keyword it states
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+        run: printf '%s' "$PR_BODY" | python3 planning/integrity/closing_keywords.py --base "$PR_BASE"
+
   offline-validation:
     runs-on: ubuntu-latest
     steps:
@@ -21,5 +40,5 @@ jobs:
           node-version: '22'
       - name: Verify historical importers refuse execution
         run: python -m unittest discover -s planning -p 'test_legacy_importers.py' -v
-      - name: Verify registry invariants
+      - name: Verify registry and closing-keyword invariants
         run: python -m unittest discover -s planning/integrity -p 'test_*.py' -v

--- a/planning/integrity/README.md
+++ b/planning/integrity/README.md
@@ -17,4 +17,8 @@ Checks include duplicate canonical keys, missing revisions, issue existence, can
 
 The committed reduced audit fixture reproduces the structural inputs from the after-audit capture; its `source_body_sha256` fields refer to original full bodies, not the deliberately reduced fixture bodies. Default tests compare its full graph, mapping, waves and counts to the generated original-snapshot registry. `--snapshot` additionally checks the full 466-issue audit capture and injects a duplicate-key regression. This optional check is pinned to that audit, not an arbitrary future inventory.
 
+## Pull-request closing keywords
+
+`closing_keywords.py` reads a pull-request description and reports the issues GitHub's parser will close, failing when a keyword it honours is negated by its own clause. GitHub does not read negation, so a description that denies a closure still performs it; PR #530 closed #54 one second after its merge, whose first line disclaimed exactly that. The roadmap-integrity workflow runs it on every pull request, and its tests pin the verbatim descriptions of PR #530 and PR #507. Keywords count only against the default branch, so a non-default base is reported as closing nothing rather than failing.
+
 This implements a bounded portion of #470. It does **not** certify conversation-to-issue coverage, acceptance completion, or exact-body mutation safety. `acceptance_items` is only a checkbox inventory. Safe importer regeneration, three-way merge, stale-revision refusal, concurrent-edit/ambiguous-create reconciliation, and post-mutation readback remain separate work. The original bootstrap importer must not be used to overwrite this registry's newer issue authority.

--- a/planning/integrity/closing_keywords.py
+++ b/planning/integrity/closing_keywords.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""What a pull-request description will close, and where its prose denies it.
+
+GitHub honours a closing keyword — `close[sd]`, `fix(e[sd])`, `resolve[sd]`,
+optionally followed by a colon, in any case — before `#N` (an issue in this
+repository) or `OWNER/REPOSITORY#N` (an issue in that one), and it does not
+read negation. A description that says "This does not close #54." still closes
+#54 when the pull request merges into the default branch. That is how #54 was
+closed one second after PR #530 merged, whose own first line says the slice
+does not complete it.
+
+This tool reports the references GitHub will close and fails when one of them
+sits in a clause that negates the keyword, so the wording can be fixed before
+the merge instead of after it. It reads the description from stdin (or
+--body-file), writes nothing, and implements only the documented syntax table:
+https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+Keywords are honoured only when the pull request targets the default branch,
+so `--base` reports them as ignored rather than failing a description on a
+branch where merging cannot close anything.
+
+    printf '%s' "$PR_BODY" | python3 planning/integrity/closing_keywords.py
+"""
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+KEYWORD = r"close[sd]?|fix(?:e[sd])?|resolve[sd]?"
+CLOSING_REFERENCE = re.compile(
+    rf"(?<![\w-])(?P<keyword>{KEYWORD})\b\s*:?\s*"
+    r"(?P<reference>(?P<repository>[\w.-]+/[\w.-]+)?#(?P<issue>\d+))",
+    re.IGNORECASE,
+)
+NEGATION = re.compile(
+    r"\b(?:not|no|never|without|nor|cannot|can't|won't|don't|doesn't|isn't|aren't|"
+    r"hasn't|haven't|didn't|wouldn't|shouldn't)\b",
+    re.IGNORECASE,
+)
+CLAUSE_END = re.compile(r"[.!?;\n]+")
+
+
+@dataclass(frozen=True)
+class Closing:
+    """One reference GitHub would close, with the clause that states it."""
+
+    keyword: str
+    reference: str
+    clause: str
+
+    def negated(self):
+        return NEGATION.search(self.clause) is not None
+
+
+def closings(body):
+    """The references GitHub will close, in the order the description states
+    them. Only the keyword's own clause is kept, because a negation anywhere
+    else in the description does not stop GitHub from reading the keyword."""
+    found = []
+    for match in CLOSING_REFERENCE.finditer(body):
+        start = 0
+        for end in CLAUSE_END.finditer(body[: match.start()]):
+            start = end.end()
+        found.append(
+            Closing(
+                keyword=match.group("keyword"),
+                reference=match.group("reference"),
+                clause=body[start : match.end()],
+            )
+        )
+    return found
+
+
+def report(closings):
+    """The lines to print for `closings`, and whether any of them is negated."""
+    hazards = [closing for closing in closings if closing.negated()]
+    lines = []
+    if not closings:
+        lines.append("No closing keyword: merging this description closes nothing.")
+    else:
+        for closing in closings:
+            lines.append(
+                f'Merging closes {closing.reference} (keyword "{closing.keyword}").'
+            )
+    for closing in hazards:
+        lines.append(
+            "FAIL: this clause negates a closing keyword, and GitHub's parser "
+            f'does not read negation:\n  "{closing.clause.strip()}"\n'
+            f"It will still close {closing.reference} when this pull request "
+            "merges. Rewrite the clause so the keyword and the number are not "
+            f'adjacent — for example, "leaves {closing.reference} open" — or '
+            "remove the negation if the closure is intended."
+        )
+    return lines, bool(hazards)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--body-file",
+        type=Path,
+        help="pull-request description to read (default: standard input)",
+    )
+    parser.add_argument(
+        "--base",
+        help="the pull request's base branch; keywords count only on the default branch",
+    )
+    parser.add_argument("--default-branch", default="main")
+    arguments = parser.parse_args(argv)
+
+    body = (
+        arguments.body_file.read_text(encoding="utf-8")
+        if arguments.body_file
+        else sys.stdin.read()
+    )
+    if arguments.base and arguments.base != arguments.default_branch:
+        print(
+            f"Base {arguments.base} is not {arguments.default_branch}, the default "
+            "branch, so GitHub ignores these keywords and merging closes nothing."
+        )
+        return 0
+
+    lines, failed = report(closings(body))
+    for line in lines:
+        print(line)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planning/integrity/test_closing_keywords.py
+++ b/planning/integrity/test_closing_keywords.py
@@ -1,0 +1,99 @@
+"""Run: python3 planning/integrity/test_closing_keywords.py."""
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from closing_keywords import closings, main, report
+
+
+def run(body, *arguments):
+    """`main` over `body`, returning its exit code and printed lines."""
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "body.md"
+        path.write_text(body, encoding="utf-8")
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = main(["--body-file", str(path), *arguments])
+    return code, output.getvalue()
+
+
+class ClosingKeywordTests(unittest.TestCase):
+    def test_real_530_description_is_reported_as_closing_54(self):
+        # PR #530's description, verbatim: GitHub's parser ignored the negation
+        # and closed #54 one second after the merge.
+        body = "Refs #54 — a slice, not its completion. This does not close #54.\n\n## Why\n"
+        code, output = run(body)
+        self.assertEqual([closing.reference for closing in closings(body)], ["#54"])
+        self.assertEqual(code, 1)
+        self.assertIn('Merging closes #54 (keyword "close").', output)
+        self.assertIn('"This does not close #54"', output)
+
+    def test_real_507_description_closes_only_the_slice_it_names(self):
+        # PR #507's description, verbatim: an intended closure, and the one
+        # form that is honest about what stays open.
+        body = (
+            "Closes #218 (slice: the sandbox launch executor composition behind "
+            "`WorkerTransports`; #466 approval flows and #465 remain open).\n"
+        )
+        code, output = run(body)
+        self.assertEqual([closing.reference for closing in closings(body)], ["#218"])
+        self.assertEqual(code, 0)
+        self.assertNotIn("FAIL", output)
+
+    def test_a_reference_without_a_keyword_closes_nothing(self):
+        code, output = run("Refs #549 — a slice, not its completion.\n")
+        self.assertEqual(code, 0)
+        self.assertEqual(closings("Refs #549 — a slice, not its completion."), [])
+        self.assertIn("closes nothing", output)
+
+    def test_documented_forms_including_colons_and_case(self):
+        body = "CLOSES: #10, resolves #123, Resolves octo-org/octo-repo#100\n"
+        self.assertEqual(
+            [closing.reference for closing in closings(body)],
+            ["#10", "#123", "octo-org/octo-repo#100"],
+        )
+        self.assertEqual(run(body)[0], 0)
+
+    def test_a_keyword_inside_a_word_is_not_a_keyword(self):
+        code, output = run("The disclosed #5 wording stayed closed-source #5.\n")
+        self.assertEqual(code, 0)
+        self.assertIn("closes nothing", output)
+
+    def test_negation_outside_the_keywords_clause_does_not_flag_it(self):
+        body = "This does not complete the work; the slice is done.\nCloses #12.\n"
+        self.assertEqual([closing.reference for closing in closings(body)], ["#12"])
+        self.assertEqual(run(body)[0], 0)
+
+    def test_each_negated_clause_fails_on_its_own(self):
+        body = "We do NOT fix #7. But this fixes #8.\n"
+        code, output = run(body)
+        self.assertEqual([closing.reference for closing in closings(body)], ["#7", "#8"])
+        self.assertEqual(code, 1)
+        self.assertIn('"We do NOT fix #7"', output)
+        self.assertNotIn('"But this fixes #8"', output)
+
+    def test_keywords_on_a_non_default_base_close_nothing(self):
+        body = "This does not close #54.\n"
+        code, output = run(body, "--base", "release")
+        self.assertEqual(code, 0)
+        self.assertIn("not main, the default branch", output)
+        self.assertNotIn("FAIL", output)
+
+    def test_report_names_every_closure_and_every_hazard(self):
+        lines, failed = report(closings("Closes #1. Does not fix #2.\n"))
+        self.assertTrue(failed)
+        self.assertEqual(
+            lines[0:2],
+            [
+                'Merging closes #1 (keyword "Closes").',
+                'Merging closes #2 (keyword "fix").',
+            ],
+        )
+        self.assertIn('"Does not fix #2"', lines[2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

GitHub honours a closing keyword even when the sentence around it denies the closure, and it has no notion of the negation: #54 was closed one second after PR #530 merged, whose opening line disclaimed exactly that outcome. This repository closes umbrella issues only at capability closure (`docs/contracts/domain.md:90`, `docs/engineering-handoff.md:117`), so an accidental closure is a defect with a live false-positive, not cosmetics. Refs #54, which stays open.

## What this adds

`planning/integrity/closing_keywords.py` reads a pull-request description from stdin (or `--body-file`), reports every issue GitHub's parser will close, and exits non-zero when one of those keywords sits in a clause that negates it. It implements only the documented syntax table — the three keyword families, an optional colon, any case, and the same-repository and `OWNER/REPO` reference forms — and reports keywords as ignored when the base branch is not the default branch, where GitHub honours none of them. It also avoids the two obvious false positives: a keyword inside a word ("disclosed") and a negation in a different clause than the keyword.

## Changed files

- `.github/workflows/roadmap-integrity.yml`: a new `closing-keywords` job that fails a pull request whose description trips the guard. The existing offline-validation step is renamed because it now discovers both suites in `planning/integrity`.
- `planning/integrity/closing_keywords.py`: the parser, the report, and the CLI described above.
- `planning/integrity/test_closing_keywords.py`: nine tests. Two pin verbatim descriptions from real pull requests — the merged PR #530 (which the guard fails, reproducing the #54 closure) and PR #507 (which it passes, naming the one issue it intends to close) — and the rest pin the documented forms and the false-positive cases.
- `planning/integrity/README.md`: documents the tool, the non-default-branch rule, and its scope.

## What it does not do

It reads only the pull-request description, not comments or commit messages, which GitHub scans the same way; it does not judge whether a stated closure is intended; and it does not reopen anything, so it is a guard against new misclosures rather than a correction of past ones. The quoted hazardous phrase lives in the test fixture rather than in this description, because this description is checked by the new job.

## Verification

```
python -m unittest discover -s planning/integrity -p 'test_*.py'   -> Ran 32 tests, OK
gh pr view 530 --json body -q .body | python3 planning/integrity/closing_keywords.py   -> exit 1
gh pr view 550 --json body -q .body | python3 planning/integrity/closing_keywords.py   -> exit 0
gh pr view 507 --json body -q .body | python3 planning/integrity/closing_keywords.py   -> exit 0, closes #218
```

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
