### PR TITLE
test(proofs): the binary freshness check reads source content, not timestamps (#464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,6 +3029,7 @@ dependencies = [
  "symbiote-runtime-sdk",
  "symbiote-runtime-transport",
  "symbiote-sandbox",
+ "symbiote-source-stamp",
  "symbiote-store",
  "symbiote-trust",
  "symbiote-workflow",
@@ -3137,7 +3138,15 @@ dependencies = [
  "serde_json",
  "symbiote-domain",
  "symbiote-runtime-transport",
+ "symbiote-source-stamp",
  "symbiote-trust",
+]
+
+[[package]]
+name = "symbiote-source-stamp"
+version = "0.1.0"
+dependencies = [
+ "sha2",
 ]
 
 [[package]]
@@ -3175,6 +3184,7 @@ dependencies = [
  "symbiote-domain",
  "symbiote-protocol",
  "symbiote-repo",
+ "symbiote-source-stamp",
  "symbiote-trust",
  "symbiote-workflow",
  "symbiote-worktrees",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/symbiote-context", "crates/symbiote-workflow", "crates/symbiote-worktrees", "crates/symbiote-native-agent", "crates/symbiote-external-agent", "crates/symbiote-client-sdk", "crates/symbiote-repo", "crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce", "crates/symbiote-desktop"]
+members = ["crates/symbiote-context", "crates/symbiote-workflow", "crates/symbiote-worktrees", "crates/symbiote-native-agent", "crates/symbiote-external-agent", "crates/symbiote-client-sdk", "crates/symbiote-repo", "crates/symbiote-domain", "crates/symbiote-config", "crates/symbiote-architecture", "crates/symbiote-store", "crates/symbiote-protocol", "crates/symbiote-host", "crates/symbiote-runtime-sdk", "crates/symbiote-runtime-transport", "crates/symbiote-projection", "crates/symbiote-trust", "crates/symbiote-sandbox", "crates/symbiote-runtime-discovery", "crates/symbiote-host-inventory", "crates/symbiote-workforce", "crates/symbiote-desktop", "crates/symbiote-source-stamp"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/symbiote-host/Cargo.toml
+++ b/crates/symbiote-host/Cargo.toml
@@ -26,6 +26,11 @@ serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "fs"] }
 
+[build-dependencies]
+# Records the content of the sources this crate's binaries are built from, so
+# the proofs that drive them run a binary built from the tree under test.
+symbiote-source-stamp = { path = "../symbiote-source-stamp" }
+
 [dev-dependencies]
 # The real-sandbox proofs resolve the launcher through the workflow crate's
 # freshness check, which only test builds carry.

--- a/crates/symbiote-host/build.rs
+++ b/crates/symbiote-host/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // The daemon's mount policy lives in this crate and in symbiote-sandbox,
+    // so the proofs that drive the built binary check it against the content
+    // this build consumed rather than against file timestamps.
+    symbiote_source_stamp::build_stamp();
+}

--- a/crates/symbiote-sandbox/Cargo.toml
+++ b/crates/symbiote-sandbox/Cargo.toml
@@ -13,5 +13,11 @@ serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["fs", "user", "dir"] }
 
+[build-dependencies]
+# Records the content of the sources this crate's binaries are built from, so
+# the proofs that drive symbiote-sandbox-launch run a binary built from the
+# tree under test.
+symbiote-source-stamp = { path = "../symbiote-source-stamp" }
+
 [lints]
 workspace = true

--- a/crates/symbiote-sandbox/build.rs
+++ b/crates/symbiote-sandbox/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // symbiote-sandbox-launch is the descriptor boundary every sandboxed
+    // process is started through, so the proofs that drive it check the built
+    // binary against the content this build consumed.
+    symbiote_source_stamp::build_stamp();
+}

--- a/crates/symbiote-source-stamp/Cargo.toml
+++ b/crates/symbiote-source-stamp/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "symbiote-source-stamp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+sha2 = "=0.10.9"
+
+[lints]
+workspace = true

--- a/crates/symbiote-source-stamp/src/lib.rs
+++ b/crates/symbiote-source-stamp/src/lib.rs
@@ -1,0 +1,391 @@
+//! A build-time record of the sources a workspace binary was compiled from,
+//! and the check that the binary still matches them.
+//!
+//! The end-to-end proofs drive workspace binaries, so a binary that does not
+//! contain the sources under test would let a proof stay green while running
+//! other code. Comparing timestamps answers "was something touched after the
+//! build", which misses a real change whose timestamp is older than the binary
+//! (a restored file, a checkout with preserved times, a clock skew) and
+//! refuses a binary whose sources were only touched. This crate records the
+//! **content** instead, next to the binary the build produced:
+//!
+//! * [`build_stamp`] is called from a `build.rs`. It walks the package's
+//!   normal and build dependency edges through `path = "..."` manifests,
+//!   hashes every `.rs` file they compile plus the manifests that shape them,
+//!   the package's own `build.rs` and the workspace lockfile, writes
+//!   `<target>/<profile>/<package>.source-stamp`, and asks cargo to rerun when
+//!   any of those files changes. The record sits beside the binary rather
+//!   than in `OUT_DIR` because the proof knows which binary it is about to
+//!   run and nothing else; `OUT_DIR` names a build-script invocation, not the
+//!   artifact that will be driven.
+//! * [`changed_sources`] is called by the proof. It re-hashes what the stamp
+//!   recorded and names every file whose content (or presence) differs, or
+//!   reports that the binary carries no stamp to check.
+//!
+//! The walk states what it covers rather than claiming the whole tree.
+//! Registry dependencies are outside it because `Cargo.lock`, which is inside
+//! it, pins them. Dev-dependency edges are outside it because nothing a binary
+//! compiles comes from them, and so are test, example and bench targets, which
+//! the binary's build does not compile. A file a crate consumes without
+//! compiling it — a fixture read with `include_str!`, say — is outside it too,
+//! and `src/` is walked for `.rs` files only.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// What a build record is called: the package it belongs to plus this suffix,
+/// in the profile directory that holds the binary.
+pub const STAMP_SUFFIX: &str = ".source-stamp";
+
+/// Records the content of the sources this package's binaries are built from,
+/// next to the binaries, and asks cargo to rerun the build script when any of
+/// them changes. Call this from a build script's `main`.
+pub fn build_stamp() {
+    let manifest_dir = PathBuf::from(environment("CARGO_MANIFEST_DIR"));
+    let out_dir = PathBuf::from(environment("OUT_DIR"));
+    let stamp = profile_directory(&out_dir)
+        .join(format!("{}{STAMP_SUFFIX}", environment("CARGO_PKG_NAME")));
+    let workspace = workspace_root(&manifest_dir)
+        .unwrap_or_else(|problem| panic!("cannot record the sources under test: {problem}"));
+
+    let mut record = String::new();
+    for source in closure_sources(&manifest_dir, &workspace) {
+        let content = std::fs::read(&source)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", source.display()));
+        record.push_str(&format!(
+            "{:x}\t{}\n",
+            Sha256::digest(&content),
+            relative_to(&workspace, &source).display()
+        ));
+        println!("cargo:rerun-if-changed={}", source.display());
+    }
+    std::fs::write(&stamp, record).unwrap_or_else(|error| {
+        panic!(
+            "cannot write the source record at {}: {error}",
+            stamp.display()
+        )
+    });
+}
+
+/// Every file whose recorded content no longer matches what is on disk, or an
+/// error naming why the binary at `binary` cannot be checked at all. An empty
+/// list means the binary was built from exactly the content the tree holds.
+pub fn changed_sources(
+    binary: &Path,
+    package: &str,
+    manifest_dir: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let stamp = binary.with_file_name(format!("{package}{STAMP_SUFFIX}"));
+    let recorded = read_stamp(&stamp)?;
+    let workspace = workspace_root(manifest_dir)?;
+    Ok(recorded
+        .into_iter()
+        .filter_map(|(path, hash)| {
+            let source = if Path::new(&path).is_absolute() {
+                PathBuf::from(&path)
+            } else {
+                workspace.join(&path)
+            };
+            (content_hash(&source).as_deref() != Some(hash.as_str())).then_some(source)
+        })
+        .collect())
+}
+
+/// The files recorded in a stamp: `(path, sha256)` per line.
+fn read_stamp(stamp: &Path) -> Result<Vec<(String, String)>, String> {
+    let record = std::fs::read_to_string(stamp)
+        .map_err(|error| format!("there is no source record at {} ({error})", stamp.display()))?;
+    let mut recorded = Vec::new();
+    for line in record.lines().filter(|line| !line.is_empty()) {
+        let Some((hash, path)) = line.split_once('\t') else {
+            return Err(format!("{} is not a source record", stamp.display()));
+        };
+        recorded.push((path.to_owned(), hash.to_owned()));
+    }
+    Ok(recorded)
+}
+
+/// The sha256 of a file's bytes, or `None` when it cannot be read — a file the
+/// build consumed and the tree no longer holds is a difference, not an error.
+fn content_hash(path: &Path) -> Option<String> {
+    std::fs::read(path)
+        .ok()
+        .map(|content| format!("{:x}", Sha256::digest(content)))
+}
+
+/// Every source the binaries built from `manifest_dir` consume: the package,
+/// every workspace package it reaches through normal and build dependency
+/// edges, the lockfile that pins the rest, and nothing else.
+fn closure_sources(manifest_dir: &Path, workspace: &Path) -> Vec<PathBuf> {
+    let (mut pending, mut reached, mut sources) = (
+        vec![manifest_dir.to_path_buf()],
+        BTreeSet::new(),
+        BTreeSet::new(),
+    );
+    while let Some(directory) = pending.pop() {
+        let directory = canonical(&directory);
+        if !reached.insert(directory.clone()) {
+            continue;
+        }
+        sources.extend(package_sources(&directory));
+        let manifest = std::fs::read_to_string(directory.join("Cargo.toml"))
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", directory.display()));
+        for dependency in path_dependencies(&manifest) {
+            pending.push(directory.join(dependency));
+        }
+    }
+    let lockfile = workspace.join("Cargo.lock");
+    if lockfile.is_file() {
+        sources.insert(lockfile);
+    }
+    sources.into_iter().collect()
+}
+
+/// What one package's binaries compile: the `.rs` files under its `src`, the
+/// manifest that declares them, and its build script.
+fn package_sources(directory: &Path) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    let mut directories = vec![directory.join("src")];
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(&directory)
+            .into_iter()
+            .flatten()
+            .flatten()
+        {
+            let name = entry.file_name().to_string_lossy().to_string();
+            match entry.file_type() {
+                Ok(kind) if kind.is_dir() => {
+                    if !matches!(name.as_str(), "target" | "node_modules" | "dist" | ".git") {
+                        directories.push(entry.path());
+                    }
+                }
+                _ if name.ends_with(".rs") => sources.push(entry.path()),
+                _ => {}
+            }
+        }
+    }
+    for name in ["Cargo.toml", "build.rs"] {
+        let file = directory.join(name);
+        if file.is_file() {
+            sources.push(file);
+        }
+    }
+    sources
+}
+
+/// The `path = "..."` values of a manifest's dependency tables. Dev-dependency
+/// tables are skipped: a binary never compiles them, so their content says
+/// nothing about it and refusing a current binary for one would be a refusal
+/// no rebuild could clear.
+fn path_dependencies(manifest: &str) -> Vec<String> {
+    let mut dependencies = Vec::new();
+    let mut table = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            table = is_dependency_table(line);
+            continue;
+        }
+        if !table {
+            continue;
+        }
+        if let Some(value) = inline_table_value(line, "path") {
+            dependencies.push(value);
+        }
+    }
+    dependencies
+}
+
+fn is_dependency_table(header: &str) -> bool {
+    let header = header.trim_start_matches('[').trim_end_matches(']');
+    if header.contains("dev-dependencies") {
+        return false;
+    }
+    header == "dependencies"
+        || header == "build-dependencies"
+        || header.ends_with(".dependencies")
+        || header.ends_with(".build-dependencies")
+}
+
+/// The value of `key` inside a single-line inline table (`{ key = "value" }`).
+/// A dependency written across several lines is not read; no manifest here
+/// uses that form.
+fn inline_table_value(line: &str, key: &str) -> Option<String> {
+    let (_, table) = line.split_once('=')?;
+    let table = table.trim().strip_prefix('{')?.trim_end_matches('}');
+    table.split(',').find_map(|entry| {
+        let (name, value) = entry.split_once('=')?;
+        (name.trim() == key).then(|| value.trim().trim_matches('"').to_owned())
+    })
+}
+
+/// The directory holding the workspace's packages: the nearest ancestor
+/// manifest that declares `[workspace]`.
+fn workspace_root(manifest_dir: &Path) -> Result<PathBuf, String> {
+    let mut directory = Some(canonical(manifest_dir));
+    while let Some(candidate) = directory {
+        let manifest = candidate.join("Cargo.toml");
+        if std::fs::read_to_string(&manifest)
+            .is_ok_and(|manifest| manifest.lines().any(|line| line.trim() == "[workspace]"))
+        {
+            return Ok(candidate);
+        }
+        directory = candidate.parent().map(Path::to_path_buf);
+    }
+    Err(format!(
+        "no [workspace] manifest above {}",
+        manifest_dir.display()
+    ))
+}
+
+/// The directory a build's binaries are written to, from the build script's
+/// `OUT_DIR` (`<target>/<profile>/build/<package>-<hash>/out`).
+fn profile_directory(out_dir: &Path) -> PathBuf {
+    out_dir
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .unwrap_or_else(|| panic!("OUT_DIR {} is not a build directory", out_dir.display()))
+        .to_path_buf()
+}
+
+fn relative_to(workspace: &Path, source: &Path) -> PathBuf {
+    source
+        .strip_prefix(workspace)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| source.to_path_buf())
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn environment(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| panic!("{name} is set when a build script runs"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        let directory =
+            std::env::temp_dir().join(format!("symbiote-stamp-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(&directory).expect("a temporary directory");
+        directory
+    }
+
+    #[test]
+    fn dependency_tables_are_read_and_dev_and_target_tables_are_not() {
+        let manifest = "\
+[package]
+name = \"example\"
+
+[dependencies]
+symbiote-a = { path = \"../a\" }
+serde = { version = \"1\", path = \"../serde\", features = [\"derive\"] }
+nix = \"0.30\"
+
+[build-dependencies]
+stamp = { path = \"../stamp\" }
+
+[dev-dependencies]
+symbiote-test = { path = \"../test\" }
+
+[target.'cfg(unix)'.dependencies]
+unix = { path = \"../unix\" }
+
+[target.'cfg(unix)'.dev-dependencies]
+unix-test = { path = \"../unix-test\" }
+
+[[bin]]
+name = \"example\"
+path = \"src/bin/example.rs\"
+";
+        assert_eq!(
+            path_dependencies(manifest),
+            ["../a", "../serde", "../stamp", "../unix"]
+        );
+    }
+
+    #[test]
+    fn a_path_dependency_split_across_lines_is_not_claimed() {
+        assert!(path_dependencies("[dependencies]\nx = {\n  path = \"../x\"\n}\n").is_empty());
+    }
+
+    #[test]
+    fn the_workspace_root_is_the_nearest_workspace_manifest() {
+        let root = fixture("workspace");
+        std::fs::create_dir_all(root.join("crates/inner/src")).expect("crates");
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/inner\"]\n",
+        )
+        .expect("the root manifest");
+        std::fs::write(
+            root.join("crates/inner/Cargo.toml"),
+            "[package]\nname = \"inner\"\n",
+        )
+        .expect("the package manifest");
+        assert_eq!(
+            workspace_root(&root.join("crates/inner")).expect("the workspace root"),
+            canonical(&root)
+        );
+    }
+
+    #[test]
+    fn a_recorded_source_whose_content_differs_is_named() {
+        let root = fixture("changed");
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").expect("the root manifest");
+        let source = root.join("crate/src/lib.rs");
+        std::fs::create_dir_all(source.parent().expect("src")).expect("src");
+        std::fs::write(&source, "one\n").expect("the source");
+        let stamp = root.join("symbiote-example.source-stamp");
+        std::fs::write(
+            &stamp,
+            format!(
+                "{:x}\tcrate/src/lib.rs\n",
+                Sha256::digest(std::fs::read(&source).expect("the source"))
+            ),
+        )
+        .expect("the stamp");
+
+        let unchanged = changed_sources(&root.join("symbiote-example"), "symbiote-example", &root)
+            .expect("a readable record");
+        assert!(unchanged.is_empty());
+
+        std::fs::write(&source, "two\n").expect("the changed source");
+        assert_eq!(
+            changed_sources(&root.join("symbiote-example"), "symbiote-example", &root)
+                .expect("a readable record"),
+            vec![source.clone()]
+        );
+
+        std::fs::remove_file(&source).expect("the removed source");
+        assert_eq!(
+            changed_sources(&root.join("symbiote-example"), "symbiote-example", &root)
+                .expect("a readable record"),
+            [root.join("crate/src/lib.rs")]
+        );
+    }
+
+    #[test]
+    fn a_binary_without_a_record_cannot_be_checked() {
+        let root = fixture("missing");
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").expect("the root manifest");
+        let problem = changed_sources(&root.join("symbioted"), "symbiote-host", &root)
+            .expect_err("no record");
+        assert!(problem.contains("no source record"), "{problem}");
+    }
+
+    #[test]
+    fn the_profile_directory_is_three_levels_above_out_dir() {
+        assert_eq!(
+            profile_directory(Path::new("/target/debug/build/pkg-1234/out")),
+            Path::new("/target/debug")
+        );
+    }
+}

--- a/crates/symbiote-workflow/Cargo.toml
+++ b/crates/symbiote-workflow/Cargo.toml
@@ -15,12 +15,14 @@ symbiote-worktrees = { path = "../symbiote-worktrees" }
 serde.workspace = true
 serde_json.workspace = true
 nix = { version = "=0.30.1", features = ["socket", "user", "signal"] }
+# Read by the binary-freshness check below; only test builds enable it.
+symbiote-source-stamp = { path = "../symbiote-source-stamp", optional = true }
 
 [features]
-# The daemon-freshness check the end-to-end proofs resolve `symbioted`
-# through. Test support only: a production build (the desktop shell) must not
-# carry it.
-test-support = []
+# The binary-freshness check the end-to-end proofs resolve `symbioted` and
+# `symbiote-sandbox-launch` through. Test support only: a production build
+# (the desktop shell) must not carry it.
+test-support = ["dep:symbiote-source-stamp"]
 
 [dev-dependencies]
 # A package may depend on itself in `dev-dependencies` to turn `test-support`

--- a/crates/symbiote-workflow/src/binaries.rs
+++ b/crates/symbiote-workflow/src/binaries.rs
@@ -5,16 +5,16 @@
 //! `symbiote-sandbox-launch`, the descriptor boundary every sandboxed process
 //! is started through — so a binary that does not contain the sources under
 //! test would let a proof stay green while running other code. The resolvers
-//! here build a binary that is absent and refuse one that is stale, naming the
-//! rebuild that fixes it. Gated behind the `test-support` feature, so a
-//! production build does not carry them.
+//! here build a binary that is absent and refuse one whose recorded source
+//! content no longer matches the tree, naming the rebuild that fixes it. The
+//! record is written by the binary's own build (`symbiote-source-stamp`), so
+//! the check is about content rather than timestamps: a file restored with an
+//! older timestamp still refuses, and a file only touched does not. Gated
+//! behind the `test-support` feature, so a production build does not carry
+//! them.
 
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use std::time::SystemTime;
-
-use serde_json::Value;
 
 /// The workspace-built `symbioted`, or a refusal naming what outdates it.
 pub fn daemon_binary() -> PathBuf {
@@ -42,50 +42,64 @@ pub fn launcher_binary() -> PathBuf {
 }
 
 /// `name` built from `package`, resolved once per test process: built when it
-/// is absent, refused when a source of `package` is newer than it.
+/// is absent, refused when the content it was built from is no longer the
+/// content of the tree.
 fn binary(package: &str, name: &str, subject: &str) -> PathBuf {
-    let metadata = metadata(package);
-    let binary = path(&metadata["target_directory"]).join("debug").join(name);
-    if binary.is_file() {
-        if let Some(source) = stale_source(
-            &sources(&metadata, &path(&metadata["workspace_root"]), package),
-            &binary,
-        ) {
-            panic!(
-                "{name} at {} is not current for the sources under test: {} changed after it was \
-                 built. Rebuild it from sources — `cargo build --locked -p {package} --bin \
-                 {name}` (or run `cargo test --workspace --locked`) — so this proof exercises the \
-                 current {subject} instead of an old binary.",
-                binary.display(),
-                source.display()
-            );
-        }
-    } else {
+    let binary = profile_directory().join(name);
+    if !binary.is_file() {
         build(package, name);
+    }
+    let rebuild = format!(
+        "`cargo build --locked -p {package} --bin {name}` (or run \
+         `cargo test --workspace --locked`)"
+    );
+    let problem = match symbiote_source_stamp::changed_sources(
+        &binary,
+        package,
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+    ) {
+        Ok(changed) if changed.is_empty() => None,
+        Ok(changed) => Some(format!(
+            "the source content it was built from is not the content of the tree: {}",
+            listing(&changed)
+        )),
+        Err(problem) => Some(problem),
+    };
+    if let Some(problem) = problem {
+        panic!(
+            "{name} at {} cannot be shown to reflect the sources under test — {problem}. \
+             Rebuild it from sources — {rebuild} — so this proof exercises the current \
+             {subject} instead of an old binary.",
+            binary.display()
+        );
     }
     binary
 }
 
-/// Cargo's own resolved view of the workspace. The sources of `package` are
-/// then cargo's definition of them rather than this guard's guess: `cargo test`
-/// builds `target/debug/<bin>` **without** writing its dep-info
-/// (`target/debug/<bin>.d`), so a guard that reads that file refuses the
-/// healthy tree CI has.
-fn metadata(package: &str) -> Value {
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
-    let output = std::process::Command::new(cargo)
-        .args(["metadata", "--locked", "--format-version", "1"])
-        .current_dir(env!("CARGO_MANIFEST_DIR"))
-        .output()
-        .unwrap_or_else(|error| panic!("cannot run cargo metadata: {error}"));
-    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
-        panic!(
-            "cannot resolve the sources `{package}` is built from, so no proof can show the \
-             binary reflects them — `cargo metadata --locked` exited with {} ({error}):\n{}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        )
-    })
+/// The directory cargo writes this test's binaries to: the profile directory
+/// two levels above the test executable (`<target>/<profile>/deps/<test>`).
+fn profile_directory() -> PathBuf {
+    std::env::current_exe()
+        .expect("the test executable's path")
+        .parent()
+        .and_then(Path::parent)
+        .expect("the profile directory above the test executable")
+        .to_path_buf()
+}
+
+/// The changed files, named: a refusal that does not say which file outdates
+/// the binary leaves the reader to guess at the rebuild.
+fn listing(changed: &[PathBuf]) -> String {
+    let named = changed
+        .iter()
+        .take(3)
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    match changed.len().saturating_sub(3) {
+        0 => named,
+        more => format!("{named} (and {more} more)"),
+    }
 }
 
 /// Builds one binary, so a partial `-p <crate>` build still runs the proofs
@@ -103,121 +117,4 @@ fn build(package: &str, name: &str) {
         "`cargo build --locked -p {package} --bin {name}` failed; the proof cannot run against \
          the current sources"
     );
-}
-
-/// The workspace-local sources of every package `package` reaches through its
-/// normal and build dependency edges — exactly what rebuilding the binary
-/// would consume from this tree. Dev/test edges are excluded, and so are
-/// registry sources: neither is compiled into the binary, so a change there
-/// must not refuse a binary that is current — a refusal nothing but touching
-/// the binary could clear.
-fn sources(metadata: &Value, workspace: &Path, package: &str) -> Vec<PathBuf> {
-    let packages = array(&metadata["packages"]);
-    let mut dependencies = std::collections::BTreeMap::new();
-    for node in array(&metadata["resolve"]["nodes"]) {
-        dependencies.insert(
-            text(&node["id"]).to_owned(),
-            array(&node["deps"])
-                .iter()
-                .filter(|dependency| {
-                    let kinds = array(&dependency["dep_kinds"]);
-                    kinds.is_empty() || kinds.iter().any(|kind| text(&kind["kind"]) != "dev")
-                })
-                .map(|dependency| text(&dependency["pkg"]).to_owned())
-                .collect::<Vec<_>>(),
-        );
-    }
-    let root = packages
-        .iter()
-        .find(|candidate| text(&candidate["name"]) == package)
-        .unwrap_or_else(|| panic!("the workspace's {package} package"));
-    let (mut pending, mut reached, mut sources) = (
-        vec![text(&root["id"]).to_owned()],
-        BTreeSet::new(),
-        Vec::new(),
-    );
-    while let Some(package) = pending.pop() {
-        if !reached.insert(package.clone()) {
-            continue;
-        }
-        pending.extend(dependencies.get(&package).into_iter().flatten().cloned());
-        let Some(manifest) = packages
-            .iter()
-            .find(|candidate| text(&candidate["id"]) == package)
-            .map(|candidate| path(&candidate["manifest_path"]))
-            .and_then(|manifest| manifest.parent().map(Path::to_path_buf))
-        else {
-            continue;
-        };
-        if manifest.starts_with(workspace) {
-            sources.extend(source_files(&manifest));
-        }
-    }
-    sources
-}
-
-/// Every source file under one workspace crate that its library and binaries
-/// are built from: the `.rs` files cargo would compile and the manifests that
-/// shape them. Test, example and bench targets are skipped because
-/// `cargo build --locked -p <crate> --bin <bin>` does not compile them, so
-/// their timestamps say nothing about the binary.
-fn source_files(crate_directory: &Path) -> Vec<PathBuf> {
-    let mut directories = vec![crate_directory.to_path_buf()];
-    let mut sources = Vec::new();
-    while let Some(directory) = directories.pop() {
-        for entry in std::fs::read_dir(&directory)
-            .into_iter()
-            .flatten()
-            .flatten()
-        {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            match entry.file_type() {
-                Ok(kind) if kind.is_dir() => {
-                    if !matches!(
-                        name.as_ref(),
-                        "target"
-                            | "node_modules"
-                            | "dist"
-                            | ".git"
-                            | "tests"
-                            | "examples"
-                            | "benches"
-                    ) {
-                        directories.push(entry.path());
-                    }
-                }
-                _ if name.ends_with(".rs") || name == "Cargo.toml" => sources.push(entry.path()),
-                _ => {}
-            }
-        }
-    }
-    sources
-}
-
-/// The newest source newer than `binary`, if any: one the binary was not
-/// built from, and so a binary that no longer reflects the tree under test.
-fn stale_source(sources: &[PathBuf], binary: &Path) -> Option<PathBuf> {
-    let built = binary.metadata().ok()?.modified().ok()?;
-    sources
-        .iter()
-        .filter_map(|source| Some((source.metadata().ok()?.modified().ok()?, source)))
-        .filter(|(modified, _)| *modified > built)
-        .max_by_key(|(modified, _): &(SystemTime, &PathBuf)| *modified)
-        .map(|(_, source)| source.clone())
-}
-
-fn array(value: &Value) -> Vec<&Value> {
-    value
-        .as_array()
-        .map(|array| array.iter().collect())
-        .unwrap_or_default()
-}
-
-fn text(value: &Value) -> &str {
-    value.as_str().unwrap_or_default()
-}
-
-fn path(value: &Value) -> PathBuf {
-    PathBuf::from(text(value))
 }


### PR DESCRIPTION
## The defect this replaces

The proofs that drive `symbioted` and `symbiote-sandbox-launch` refuse a binary built from sources other than the tree under test, but they decided that by comparing timestamps. Two failures follow, both measured on this head below: a real content change whose timestamp is older than the binary passes silently, and a binary whose sources were merely touched is refused until it is rebuilt. The check also left `Cargo.lock` outside itself.

## What changes

- **New `crates/symbiote-source-stamp`** (391 lines, 6 unit tests). `build_stamp()` is called from a `build.rs`: it walks the package's normal and build dependency edges through `path = "..."` manifests, hashes every `.rs` file they compile plus the manifests that shape them, the package's own `build.rs` and the workspace lockfile, writes `<target>/<profile>/<package>.source-stamp` beside the binary, and asks cargo to rerun the build script when any recorded file changes. `changed_sources()` re-hashes that record and returns each file whose content (or presence) differs. The record sits beside the binary rather than in `OUT_DIR` because the proof knows which binary it will drive and nothing else.
- **`crates/symbiote-workflow/src/binaries.rs`** (59 added, 162 removed): the guard behind `test-support` drops the metadata closure walk and the timestamp comparison for one call, and resolves the target directory from the test executable instead of spawning `cargo metadata`. The refusal names the file that differs and keeps the rebuild it names.
- **Two build scripts and three manifests**: `crates/symbiote-host/build.rs` and `crates/symbiote-sandbox/build.rs` call the crate; `symbiote-host` and `symbiote-sandbox` take it as a build dependency, and `symbiote-workflow` takes it as an optional dependency behind `test-support`, so a production build does not carry it.

## Measured, on this commit

Sensitivity — a real change the timestamp check cannot see (the source's timestamp is set eleven years before the binary):

```
source mtime: 2020-01-01 00:00:00   binary mtime: 2026-09-12 16:55:29
symbioted ... cannot be shown to reflect the sources under test — the source content
it was built from is not the content of the tree:
/mnt/data/projects/Symbiote/crates/symbiote-sandbox/src/lib.rs. Rebuild it from sources —
`cargo build --locked -p symbiote-sandbox --bin symbiote-sandbox-launch` ...
```

The false refusals the timestamp check produced — content identical, timestamps newer than the binary:

```
touch crates/symbiote-sandbox/src/lib.rs   (mtime 16:56:21, binary 16:55:29)
test result: ok. 9 passed; 0 failed
touch crates/symbiote-sandbox/tests/process.rs
test result: ok. 9 passed; 0 failed
```

Tightness in the other direction — the record follows the build, not the tree:

```
mutate the mount policy, rebuild              -> test result: ok. 9 passed
restore the sources without rebuilding        -> refused, naming src/lib.rs
rebuild from the restored sources             -> test result: ok. 9 passed
```

A binary with no record at all is refused with the rebuild that fixes it:

```
there is no source record at .../target/debug/symbiote-host.source-stamp
```

The lockfile is inside the record, and changing its content refreshes the record rather than wedging the proof: after appending a comment to `Cargo.lock` and running `cargo build --locked -p symbiote-host --bin symbioted`, the recorded hash went from `64697daafe34d923` to `7d6edd70adff2a71` and the proof stayed green.

## What it does not cover

Registry dependencies (their content is pinned by `Cargo.lock`, which is recorded), dev-dependency edges, test/example/bench targets, and files a crate consumes without compiling (a fixture read with `include_str!`). The crate's module documentation states each of these rather than implying whole-tree coverage.

## Verification

```
cargo test --workspace --locked            -> 79 suites ok, 0 failed, 0 refusals
  the_mount_boundary_confines_host_writes_to_the_reserved_worktree ... ok
  shell_executor::tests::a_real_sandboxed_shell_turn_completes_under_a_read_only_dev ... ok
  a_started_external_harness_runs_under_the_declared_memory_bound ... ok
cargo fmt --all --check                    -> clean
cargo clippy --workspace --all-targets --locked -- -D warnings -> clean
cargo test --locked -p symbiote-source-stamp -> 6 passed
```

The mount policy itself and every existing assertion are untouched.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
