### PR TITLE
chore(planning): prune the checkouts whose work is already landed

### DIFF
--- a/.github/workflows/roadmap-integrity.yml
+++ b/.github/workflows/roadmap-integrity.yml
@@ -42,3 +42,5 @@ jobs:
         run: python -m unittest discover -s planning -p 'test_legacy_importers.py' -v
       - name: Verify registry and closing-keyword invariants
         run: python -m unittest discover -s planning/integrity -p 'test_*.py' -v
+      - name: Verify merged-checkout housekeeping
+        run: python -m unittest discover -s planning/housekeeping -p 'test_*.py' -v

--- a/planning/housekeeping/README.md
+++ b/planning/housekeeping/README.md
@@ -1,0 +1,17 @@
+# Merged-checkout housekeeping
+
+This Python standard-library maintenance tool prunes local branches and worktrees whose work has already landed, from evidence rather than from a guess. Its only path outside the local repository is reading merged pull-request head names through `gh`; when `gh` cannot answer it says so and falls back to containment in the default branch. Python is used for existing planning maintenance; this does not select the product runtime.
+
+```sh
+python3 planning/housekeeping/prune_merged_checkouts.py            # print the plan
+python3 planning/housekeeping/prune_merged_checkouts.py --apply    # remove what it lists
+python3 planning/housekeeping/test_prune_merged_checkouts.py
+```
+
+Merges in this repository are squashes, so a landed branch tip is never an ancestor of `origin/main`, GitHub deletes the remote branch after the merge, and the branch name is the only remaining link between a local checkout and the merge that landed it. A branch is removed when its tip is contained in the default branch, or when a merged pull request names it as its head. It is kept when it is the current branch, when a worktree holds uncommitted changes on it, or when neither piece of evidence holds. `--apply` removes the worktree first — `git worktree remove` refuses a dirty worktree on its own — and then the branch.
+
+The cleanup that motivated this tool removed 57 clean worktrees and 70 local branches whose content was in `main`; the worktrees alone held about 140 GiB of build caches, and branches pointing at superseded heads produced diffs that read like uncommitted work. This tool is the repeatable form of that cleanup: it never pushes, never rewrites history, and mutates nothing outside the local repository.
+
+## What it does not decide
+
+It does not verify that a merged pull request's diff is the whole of a branch's content, so it should be run when the worktree is clean; a branch whose tip is an ancestor of the default branch is removed on that containment alone. It also does not remove remote branches, which GitHub deletes on merge.

--- a/planning/housekeeping/prune_merged_checkouts.py
+++ b/planning/housekeeping/prune_merged_checkouts.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Prune local branches and worktrees whose work has already landed.
+
+Merges here are squashes, so a landed branch tip is never an ancestor of
+`origin/main`: after the merge GitHub deletes the remote branch and, with it,
+the only cheap signal that the checkout is finished with. 59 registered
+worktrees and 70 local branches survived their merges at once, holding ~330 GB
+of build caches and producing phantom diffs against superseded heads.
+
+This decides what is safe to remove from evidence — the branch tip is
+contained in the default branch, or its pull request is merged — and never
+touches the current branch, a branch checked out in a worktree with
+uncommitted changes, or a branch with no landing evidence. Dry run by default;
+`--apply` removes worktrees first (`git worktree remove`, which refuses a dirty
+worktree on its own) and then the branches. It runs no `git push` and mutates
+nothing outside the local repository.
+
+    python3 planning/housekeeping/prune_merged_checkouts.py [--apply]
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One local branch and the verdict about it."""
+
+    name: str
+    worktree: str = ""
+    remove: bool = False
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class Branch:
+    """One local branch, and the evidence about whether its work landed."""
+
+    name: str
+    current: bool
+    contained: bool
+    upstream_gone: bool
+    worktree: str = ""
+    worktree_dirty: bool = False
+    pull_request_merged: bool = False
+
+    def plan(self):
+        """Whether to remove this branch, and the reason either way."""
+        if self.current:
+            return Decision(self.name, reason="the current branch")
+        if self.worktree and self.worktree_dirty:
+            return Decision(
+                self.name,
+                self.worktree,
+                reason=f"its worktree at {self.worktree} has uncommitted changes",
+            )
+        if self.contained:
+            return Decision(
+                self.name,
+                self.worktree,
+                remove=True,
+                reason="contained in the default branch, so its content is preserved",
+            )
+        if self.pull_request_merged and self.upstream_gone:
+            return Decision(
+                self.name,
+                self.worktree,
+                remove=True,
+                reason="its pull request is merged and its remote branch is gone",
+            )
+        if self.pull_request_merged:
+            return Decision(
+                self.name,
+                self.worktree,
+                remove=True,
+                reason="its pull request is merged",
+            )
+        return Decision(
+            self.name,
+            self.worktree,
+            reason="no merged pull request and not contained in the default branch",
+        )
+
+
+def prune_plan(branches, merged_heads):
+    """The plan for `branches`, given the head branch names of merged pull
+    requests. A merged head is matched by name: the merge is a squash, so the
+    name is the only evidence that a local branch corresponds to the merge."""
+    merged = set(merged_heads)
+    return [
+        replace(branch, pull_request_merged=branch.name in merged).plan()
+        for branch in branches
+    ]
+
+
+def render(plan):
+    """One line per branch: the verdict, the name, and the reason."""
+    return [
+        f"{'remove' if decision.remove else 'keep  '} {decision.name:<40} "
+        f"{decision.reason}"
+        for decision in plan
+    ]
+
+
+def git(*arguments, cwd=None):
+    return subprocess.run(
+        ["git", *arguments], cwd=cwd, capture_output=True, text=True, check=True
+    ).stdout
+
+
+def local_branches(default_branch):
+    """Every local branch with its containment and checkout evidence. The
+    default branch itself is not a candidate: its tip is trivially contained
+    in the default branch, and the only reason a plan would not remove it is
+    that it is checked out here."""
+    default = default_branch.rsplit("/", 1)[-1]
+    worktrees = {}
+    for block in git("worktree", "list", "--porcelain").split("\n\n"):
+        branch = re.search(r"(?m)^branch refs/heads/(.+)$", block)
+        if branch:
+            path = re.search(r"(?m)^worktree (.+)$", block)
+            worktrees[branch.group(1)] = path.group(1) if path else ""
+    branches = []
+    for line in git(
+        "for-each-ref",
+        "--format=%(refname:short)%09%(upstream:track)%09%(HEAD)",
+        "refs/heads",
+    ).splitlines():
+        name, track, head = line.split("\t")
+        if name == default:
+            continue
+        worktree = worktrees.get(name, "")
+        branches.append(
+            Branch(
+                name=name,
+                current=head == "*",
+                contained=subprocess.run(
+                    ["git", "merge-base", "--is-ancestor", name, default_branch]
+                ).returncode
+                == 0,
+                upstream_gone="gone" in track,
+                worktree=worktree,
+                worktree_dirty=bool(worktree)
+                and bool(git("status", "--porcelain", cwd=worktree).strip()),
+            )
+        )
+    return branches
+
+
+def merged_heads(limit):
+    """The head branch names of merged pull requests, or none when `gh` cannot
+    answer: pruning then rests on containment in the default branch alone."""
+    try:
+        output = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--limit",
+                str(limit),
+                "--json",
+                "headRefName",
+                "-q",
+                ".[].headRefName",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as error:
+        print(f"gh cannot list merged pull requests ({error}); containment only")
+        return []
+    return output.split()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="remove what the plan lists (default: print the plan)",
+    )
+    parser.add_argument(
+        "--default-branch",
+        default="origin/main",
+        help="the ref whose content counts as preserved",
+    )
+    parser.add_argument("--merged-limit", type=int, default=500)
+    arguments = parser.parse_args(argv)
+
+    plan = prune_plan(
+        local_branches(arguments.default_branch), merged_heads(arguments.merged_limit)
+    )
+    for line in render(plan):
+        print(line)
+    removals = [decision for decision in plan if decision.remove]
+    print(
+        f"{len(removals)} of {len(plan)} local branches are landed; "
+        f"{'apply with --apply' if removals else 'nothing to do'}"
+    )
+    if arguments.apply:
+        for decision in removals:
+            if decision.worktree:
+                git("worktree", "remove", decision.worktree)
+            git("branch", "-D", decision.name)
+            print(f"removed {decision.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/planning/housekeeping/test_prune_merged_checkouts.py
+++ b/planning/housekeeping/test_prune_merged_checkouts.py
@@ -1,0 +1,136 @@
+"""Run: python3 planning/housekeeping/test_prune_merged_checkouts.py."""
+
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from prune_merged_checkouts import Branch, local_branches, main, prune_plan
+
+
+def branch(name, **evidence):
+    """A branch whose only evidence is what the test states."""
+    return Branch(
+        name=name,
+        current=evidence.pop("current", False),
+        contained=evidence.pop("contained", False),
+        upstream_gone=evidence.pop("upstream_gone", False),
+        **evidence,
+    )
+
+
+def decisions(branches, merged=()):
+    return {decision.name: decision for decision in prune_plan(branches, merged)}
+
+
+class PlanTests(unittest.TestCase):
+    def test_merged_pull_request_with_a_gone_remote_is_removed(self):
+        decision = decisions([branch("landed", upstream_gone=True)], ["landed"])
+        self.assertTrue(decision["landed"].remove)
+        self.assertIn("remote branch is gone", decision["landed"].reason)
+
+    def test_merged_pull_request_in_an_unpushed_branch_is_removed(self):
+        self.assertTrue(decisions([branch("landed")], ["landed"])["landed"].remove)
+
+    def test_contained_branch_is_removed_even_without_a_merged_pull_request(self):
+        # The one branch the earlier cleanup kept, whose tip is an ancestor of
+        # main although no merge names it.
+        decision = decisions([branch("contained", contained=True)])
+        self.assertTrue(decision["contained"].remove)
+        self.assertIn("content is preserved", decision["contained"].reason)
+
+    def test_current_branch_is_kept(self):
+        decision = decisions(
+            [branch("main", current=True, contained=True)], ["main"]
+        )
+        self.assertFalse(decision["main"].remove)
+        self.assertIn("current branch", decision["main"].reason)
+
+    def test_uncommitted_worktree_changes_are_kept(self):
+        decision = decisions(
+            [branch("landed", worktree="/tmp/landed", worktree_dirty=True)], ["landed"]
+        )
+        self.assertFalse(decision["landed"].remove)
+        self.assertIn("/tmp/landed", decision["landed"].reason)
+
+    def test_a_clean_worktree_does_not_block_removal(self):
+        decision = decisions(
+            [branch("landed", worktree="/tmp/landed")], ["landed"]
+        )
+        self.assertTrue(decision["landed"].remove)
+        self.assertEqual(decision["landed"].worktree, "/tmp/landed")
+
+    def test_branch_without_landing_evidence_is_kept(self):
+        decision = decisions([branch("open-pr")], ["some-other-branch"])
+        self.assertFalse(decision["open-pr"].remove)
+        self.assertIn("no merged pull request", decision["open-pr"].reason)
+
+
+class RepositoryTests(unittest.TestCase):
+    """`local_branches` and `--apply` against a real throwaway repository."""
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.previous = os.getcwd()
+        os.chdir(self.directory.name)
+        self.addCleanup(os.chdir, self.previous)
+        self.git("init", "--initial-branch=main", "--quiet")
+        self.git("config", "user.email", "proof@example.invalid")
+        self.git("config", "user.name", "Proof")
+        (Path(self.directory.name) / "file").write_text("one\n")
+        self.git("add", "file")
+        self.git("commit", "--quiet", "-m", "one")
+
+    def git(self, *arguments):
+        subprocess.run(["git", *arguments], check=True, capture_output=True)
+
+    def run_tool(self, *arguments):
+        """`main`, without the plan it prints to standard output."""
+        with mock.patch("prune_merged_checkouts.merged_heads", return_value=[]):
+            with redirect_stdout(io.StringIO()):
+                return main([*arguments, "--default-branch", "main"])
+
+    def test_local_branches_reads_containment_and_the_checkout(self):
+        self.git("branch", "landed")
+        branches = {entry.name: entry for entry in local_branches("main")}
+        self.assertTrue(branches["landed"].contained)
+        self.assertFalse(branches["landed"].current)
+        self.assertNotIn("main", branches)
+
+    def test_the_default_branch_is_not_a_candidate_when_it_is_a_remote_ref(self):
+        self.git("branch", "landed")
+        names = [entry.name for entry in local_branches("origin/main")]
+        self.assertNotIn("main", names)
+        self.assertIn("landed", names)
+
+    def test_apply_removes_a_contained_branch_and_keeps_the_working_tree(self):
+        self.git("branch", "landed")
+        self.assertEqual(self.run_tool("--apply"), 0)
+        listed = subprocess.run(
+            ["git", "branch", "--format=%(refname:short)"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+        self.assertEqual(listed, ["main"])
+        self.assertTrue(Path(self.directory.name, "file").exists())
+
+    def test_dry_run_removes_nothing(self):
+        self.git("branch", "landed")
+        self.run_tool()
+        listed = subprocess.run(
+            ["git", "branch", "--format=%(refname:short)"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.split()
+        self.assertCountEqual(listed, ["main", "landed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Merges here are squashes, so a landed branch tip is not an ancestor of `main`, and GitHub deletes the remote branch after the merge: nothing local marks a checkout as finished. 57 worktrees and 70 local branches survived their merges at once, holding about 140 GiB of build caches, and the stale branches produced diffs that read like uncommitted work against the delivered tree. The cleanup that removed them was ad hoc; this is its repeatable form.

## What this adds

`planning/housekeeping/prune_merged_checkouts.py` decides what is safe to remove from evidence: the branch tip is contained in the default branch, or a merged pull request names the branch as its head. It keeps the current branch, keeps a branch whose worktree has uncommitted changes, and prints its plan unless `--apply` is given. `--apply` removes worktrees first (`git worktree remove` refuses a dirty worktree on its own) and then the branches; it runs no `git push` and touches no remote. When `gh` cannot answer it says so and falls back to containment alone.

## Changed files

- `planning/housekeeping/prune_merged_checkouts.py` (216 lines): the planner, the evidence gathering and the CLI described above.
- `planning/housekeeping/test_prune_merged_checkouts.py` (136 lines, 11 tests): the evidence matrix for the plan, plus `local_branches` and both `--apply` and dry-run against a throwaway repository created in the test.
- `planning/housekeeping/README.md`: what the evidence is, what is kept, and what the tool does not decide.
- `.github/workflows/roadmap-integrity.yml`: one step that runs the suite.

## The bug this draft found

The first dry run against this repository planned to remove `main`, because a branch's tip is trivially an ancestor of itself and only the current-branch rule saved it. The default branch is now excluded from the candidate set — including when it is given as `origin/main` — and a test pins that form.

## Verification

```
python3 -m unittest discover -s planning/housekeeping -p 'test_*.py'   -> Ran 11 tests, OK
python -m unittest discover -s planning/integrity -p 'test_*.py'       -> Ran 32 tests, OK
python3 planning/housekeeping/prune_merged_checkouts.py                (on this head)
keep   content-addressed-freshness              no merged pull request and not contained in the default branch
keep   housekeeping-merged-checkouts            the current branch
0 of 2 local branches are landed; nothing to do
```

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
