### PR TITLE
chore(planning): refuse a closing keyword in a commit message (#54)

### DIFF
--- a/.github/workflows/roadmap-integrity.yml
+++ b/.github/workflows/roadmap-integrity.yml
@@ -10,23 +10,39 @@ permissions:
 
 jobs:
   closing-keywords:
-    # GitHub's issue parser does not read negation, so a description that says
-    # "This does not close #54." still closes #54 on merge: that is how #54 was
-    # closed one second after PR #530 merged, whose own first line says the
-    # slice does not complete it. Fail the pull request so the wording is
-    # fixed before the merge instead of after it.
+    # GitHub honours a closing keyword wherever it appears in the description
+    # or in the messages of the merged commits, and it reads no negation. Both
+    # channels have closed an issue here by accident: #54 by the sentence
+    # "This does not close #54." in PR #530, and #54 again by the sentence
+    # "the defect that closed #54 is reproduced rather than described" in the
+    # commit message of PR #551, which read only descriptions. Fail the pull
+    # request so the wording is fixed before the merge instead of after it.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The commit messages below are read from the pull request's own
+          # range, so its base and head must both be present.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: A pull-request description must not negate a closing keyword it states
+      - name: A pull-request description must state its closures and negate none
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
         run: printf '%s' "$PR_BODY" | python3 planning/integrity/closing_keywords.py --base "$PR_BASE"
+      - name: A commit message may not carry a closing keyword at all
+        env:
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          for sha in $(git log --format=%h "$PR_BASE_SHA..$PR_HEAD"); do
+            git log -1 --format=%B "$sha" | python3 planning/integrity/closing_keywords.py \
+              --commits --label "commit $sha" --base "$PR_BASE"
+          done
 
   offline-validation:
     runs-on: ubuntu-latest

--- a/planning/integrity/README.md
+++ b/planning/integrity/README.md
@@ -19,6 +19,12 @@ The committed reduced audit fixture reproduces the structural inputs from the af
 
 ## Pull-request closing keywords
 
-`closing_keywords.py` reads a pull-request description and reports the issues GitHub's parser will close, failing when a keyword it honours is negated by its own clause. GitHub does not read negation, so a description that denies a closure still performs it; PR #530 closed #54 one second after its merge, whose first line disclaimed exactly that. The roadmap-integrity workflow runs it on every pull request, and its tests pin the verbatim descriptions of PR #530 and PR #507. Keywords count only against the default branch, so a non-default base is reported as closing nothing rather than failing.
+`closing_keywords.py` reports the issues GitHub's parser will close from a pull request's description and from the messages of its commits, which GitHub scans equally and with no reading of negation. Two rules follow.
+
+A description fails when a closing keyword is negated by its own sentence, or when the keyword is buried in prose instead of stated as its own clause: `Closes #54` is a closure both GitHub and a reader can see, while "the defect that closed #54 is fixed" is a remark that closes the issue anyway. Of the last sixty descriptions merged here, exactly one trips this rule — PR #530, whose first line disclaimed the closure it performed one second after its merge.
+
+A commit message (`--commits`) fails on any closing keyword, because nothing in review reads a commit message and the description is where an intended closure belongs. PR #551 landed this guard and was itself caught by that channel: its final sentence, "the defect that closed #54 is reproduced rather than described", closed #54 when the pull request merged. Its tests pin that message, the two real descriptions, and the documented syntax.
+
+Keywords count only against the default branch, so a non-default base is reported as closing nothing rather than failing.
 
 This implements a bounded portion of #470. It does **not** certify conversation-to-issue coverage, acceptance completion, or exact-body mutation safety. `acceptance_items` is only a checkbox inventory. Safe importer regeneration, three-way merge, stale-revision refusal, concurrent-edit/ambiguous-create reconciliation, and post-mutation readback remain separate work. The original bootstrap importer must not be used to overwrite this registry's newer issue authority.

--- a/planning/integrity/closing_keywords.py
+++ b/planning/integrity/closing_keywords.py
@@ -9,16 +9,29 @@ read negation. A description that says "This does not close #54." still closes
 closed one second after PR #530 merged, whose own first line says the slice
 does not complete it.
 
-This tool reports the references GitHub will close and fails when one of them
-sits in a clause that negates the keyword, so the wording can be fixed before
-the merge instead of after it. It reads the description from stdin (or
---body-file), writes nothing, and implements only the documented syntax table:
+This tool reports the references GitHub will close and fails under two rules:
+
+* a description fails when one of them sits in a clause that negates the
+  keyword, so the wording can be fixed before the merge instead of after it;
+* a commit message (`--commits`) fails on any closing keyword at all. GitHub
+  scans the commit messages of the merged commits, nothing in review reads
+  them, and the description is where an intended closure belongs. PR #551 was
+  landed to prevent accidental closures and was itself closed through this
+  channel: its final sentence, "so the defect that closed #54 is reproduced
+  rather than described", closed #54 on merge because the guard read only
+  descriptions. That is also why a description now has to *state* its
+  closures: `Closes #54` opens its own clause, while a keyword buried in a
+  sentence is prose about a closure, and GitHub cannot tell the difference.
+
+It reads the text from stdin (or --body-file), writes nothing, and implements
+only the documented syntax table:
 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
 Keywords are honoured only when the pull request targets the default branch,
-so `--base` reports them as ignored rather than failing a description on a
-branch where merging cannot close anything.
+so `--base` reports them as ignored rather than failing text on a branch where
+merging cannot close anything.
 
     printf '%s' "$PR_BODY" | python3 planning/integrity/closing_keywords.py
+    git log -1 --format=%B "$SHA" | python3 planning/integrity/closing_keywords.py --commits
 """
 
 import argparse
@@ -38,60 +51,109 @@ NEGATION = re.compile(
     r"hasn't|haven't|didn't|wouldn't|shouldn't)\b",
     re.IGNORECASE,
 )
-CLAUSE_END = re.compile(r"[.!?;\n]+")
+CLAUSE_END = re.compile(r"[.!?;\n,]+")
+SENTENCE_END = re.compile(r"[.!?;\n]+")
+# What may precede a keyword that still opens its clause: list markers,
+# quotes, emphasis, an ordered-list number.
+CLAUSE_OPENING = re.compile(r"^[\s>*+`\"'|\-]*(?:\d+\.)?[\s>*+`\"'|\-]*$")
 
 
 @dataclass(frozen=True)
 class Closing:
-    """One reference GitHub would close, with the clause that states it."""
+    """One reference GitHub would close, with the text that carries it."""
 
     keyword: str
     reference: str
     clause: str
+    lead: str
+    sentence: str
 
     def negated(self):
-        return NEGATION.search(self.clause) is not None
+        """Whether the sentence denies the closure GitHub will perform."""
+        return NEGATION.search(self.sentence) is not None
+
+    def denied(self):
+        """Whether the description rule refuses this reference: its sentence
+        denies the closure, or the keyword is prose rather than a statement."""
+        return self.negated() or not self.stated()
+
+    def stated(self):
+        """Whether the keyword opens its clause, as a stated closure does
+        (`Closes #54`) rather than mentioning one (`the defect that closed
+        #54`). GitHub reads both the same way; a reader does not."""
+        return bool(CLAUSE_OPENING.match(self.lead))
 
 
 def closings(body):
-    """The references GitHub will close, in the order the description states
-    them. Only the keyword's own clause is kept, because a negation anywhere
-    else in the description does not stop GitHub from reading the keyword."""
+    """The references GitHub will close, in the order the text states them.
+    Each carries the clause that opens before its keyword and the sentence
+    around it, so a rule can ask whether the closure was stated (clause) or
+    denied (sentence)."""
     found = []
     for match in CLOSING_REFERENCE.finditer(body):
-        start = 0
-        for end in CLAUSE_END.finditer(body[: match.start()]):
-            start = end.end()
+        before = body[: match.start()]
+        clause_start = max((end.end() for end in CLAUSE_END.finditer(before)), default=0)
+        sentence_start = max(
+            (end.end() for end in SENTENCE_END.finditer(before)), default=0
+        )
         found.append(
             Closing(
                 keyword=match.group("keyword"),
                 reference=match.group("reference"),
-                clause=body[start : match.end()],
+                clause=body[clause_start : match.end()],
+                lead=body[clause_start : match.start()],
+                sentence=body[sentence_start : match.end()],
             )
         )
     return found
 
 
-def report(closings):
-    """The lines to print for `closings`, and whether any of them is negated."""
-    hazards = [closing for closing in closings if closing.negated()]
+def report(closings, label="description", refuse_all=False):
+    """The lines to print for `closings`, and whether any of them is refused.
+    `refuse_all` is the commit-message rule: a closing keyword there is
+    honoured on merge and read by nobody, so it is refused whatever the
+    sentence around it means. A description is refused when its sentence
+    denies the closure, or when the keyword is buried in prose rather than
+    stated as its own clause."""
+    hazards = closings if refuse_all else [c for c in closings if c.denied()]
     lines = []
     if not closings:
-        lines.append("No closing keyword: merging this description closes nothing.")
+        lines.append("No closing keyword: merging this text closes nothing.")
     else:
         for closing in closings:
             lines.append(
                 f'Merging closes {closing.reference} (keyword "{closing.keyword}").'
             )
     for closing in hazards:
-        lines.append(
-            "FAIL: this clause negates a closing keyword, and GitHub's parser "
-            f'does not read negation:\n  "{closing.clause.strip()}"\n'
-            f"It will still close {closing.reference} when this pull request "
-            "merges. Rewrite the clause so the keyword and the number are not "
-            f'adjacent — for example, "leaves {closing.reference} open" — or '
-            "remove the negation if the closure is intended."
-        )
+        if refuse_all:
+            lines.append(
+                f"FAIL: the {label} carries a closing keyword, and GitHub closes "
+                "the issue when the pull request merges into the default branch:\n"
+                f'  "{closing.clause.strip()}"\n'
+                "Nothing in review reads a commit message, so state an intended "
+                f"closure in the description instead (\"Closes {closing.reference}\"), "
+                "or rephrase this one so the keyword and the number are not "
+                f'adjacent — for example, "{closing.reference} was closed by …".'
+            )
+        elif closing.negated():
+            lines.append(
+                f"FAIL: the {label} negates a closing keyword in its own sentence, "
+                f"and GitHub's parser does not read negation:\n  "
+                f'"{closing.sentence.strip()}"\n'
+                f"It will still close {closing.reference} when this pull request "
+                "merges. Rewrite the clause so the keyword and the number are not "
+                f'adjacent — for example, "leaves {closing.reference} open" — or '
+                "remove the negation if the closure is intended."
+            )
+        else:
+            lines.append(
+                f"FAIL: the {label} buries a closing keyword in a sentence, and "
+                f"GitHub closes the issue whatever the sentence means:\n  "
+                f'"{closing.clause.strip()}"\n'
+                f"State it as its own clause if the closure is intended (\"Closes "
+                f'{closing.reference}\"), or rephrase the prose so the keyword and '
+                f'the number are not adjacent ("{closing.reference} was closed by…").'
+            )
     return lines, bool(hazards)
 
 
@@ -101,6 +163,15 @@ def main(argv=None):
         "--body-file",
         type=Path,
         help="pull-request description to read (default: standard input)",
+    )
+    parser.add_argument(
+        "--commits",
+        action="store_true",
+        help="the text is a commit message: refuse any closing keyword",
+    )
+    parser.add_argument(
+        "--label",
+        help="what the text is, named in a refusal",
     )
     parser.add_argument(
         "--base",
@@ -121,7 +192,8 @@ def main(argv=None):
         )
         return 0
 
-    lines, failed = report(closings(body))
+    label = arguments.label or ("commit message" if arguments.commits else "description")
+    lines, failed = report(closings(body), label, refuse_all=arguments.commits)
     for line in lines:
         print(line)
     return 1 if failed else 0

--- a/planning/integrity/test_closing_keywords.py
+++ b/planning/integrity/test_closing_keywords.py
@@ -67,13 +67,56 @@ class ClosingKeywordTests(unittest.TestCase):
         self.assertEqual([closing.reference for closing in closings(body)], ["#12"])
         self.assertEqual(run(body)[0], 0)
 
-    def test_each_negated_clause_fails_on_its_own(self):
-        body = "We do NOT fix #7. But this fixes #8.\n"
+    def test_each_sentence_is_judged_on_its_own(self):
+        body = "We do NOT fix #7. Fixes #8.\n"
         code, output = run(body)
         self.assertEqual([closing.reference for closing in closings(body)], ["#7", "#8"])
         self.assertEqual(code, 1)
         self.assertIn('"We do NOT fix #7"', output)
-        self.assertNotIn('"But this fixes #8"', output)
+        self.assertNotIn("Fixes #8", output)
+
+    def test_a_negation_split_across_commas_is_still_read(self):
+        code, output = run("This does not, however, close #54.\n")
+        self.assertEqual(code, 1)
+        self.assertIn('"This does not, however, close #54"', output)
+
+    def test_a_closure_buried_in_a_sentence_is_refused(self):
+        # The description form of the accident: the keyword and the reference
+        # are adjacent inside prose that reads as a remark, and GitHub closes
+        # the issue all the same.
+        code, output = run("This lands the slice, and the defect that closed #54 is fixed.\n")
+        self.assertEqual(code, 1)
+        self.assertIn("buries a closing keyword", output)
+        self.assertIn('"Closes #54"', output)
+
+    def test_the_real_551_commit_message_is_refused_as_a_commit_message(self):
+        # The squash-merge commit of PR #551, verbatim: its last sentence
+        # closed #54 at 2026-09-12T21:00:18Z, the issue that PR was written to
+        # protect.
+        body = (
+            "chore(planning): fail a pull request whose prose negates a closing keyword (#551)\n"
+            "\n"
+            "GitHub's issue parser does not read negation, so a description that denies a\n"
+            "closure still performs it: #54 was closed one second after PR #530 merged,\n"
+            "whose own first line disclaimed the closure. Add planning/integrity/\n"
+            "closing_keywords.py, which reports the issues a description will close and\n"
+            "fails when a keyword it honours sits in a clause that negates it, plus a\n"
+            "roadmap-integrity job that runs it on every pull request. The tests pin the\n"
+            "verbatim descriptions of PR #530 and PR #507, so the defect that closed #54 is\n"
+            "reproduced rather than described.\n"
+        )
+        description, said = run(body)
+        self.assertEqual(description, 1)
+        self.assertIn("buries a closing keyword", said)
+        code, output = run(body, "--commits", "--label", "commit 5bf7437f")
+        self.assertEqual(code, 1)
+        self.assertIn("the commit 5bf7437f carries a closing keyword", output)
+        self.assertIn("so the defect that closed #54", output)
+
+    def test_a_commit_message_may_not_close_anything_even_in_a_stated_clause(self):
+        code, output = run("Closes #218.\n", "--commits")
+        self.assertEqual(code, 1)
+        self.assertIn("Nothing in review reads a commit message", output)
 
     def test_keywords_on_a_non_default_base_close_nothing(self):
         body = "This does not close #54.\n"


### PR DESCRIPTION
## What happened

The guard this pull request extends was landed for #54 and read pull-request descriptions only. #54 was closed by the squash merge of that same work, through the channel the guard did not read: the last sentence of commit `5bf7437f` puts the past tense of a closing keyword immediately before an issue number, and GitHub scans the messages of merged commits. The sentence performed the closure while reading to a human as a remark. The issue is reopened with that explanation.

## What changes

- **A commit message refuses any closing keyword** (`--commits`). Nothing in review reads one, the description is where an intended closure belongs, and a closure stated there is what the guard can judge in context. Across the last 300 commit messages in this repository, exactly one carries the pattern — the one that caused this.
- **A description now refuses a keyword buried in prose**, as well as one its own sentence negates. A keyword that opens its own clause reads the same way to GitHub and to a reviewer; a keyword placed inside a sentence does not, and GitHub closes the issue either way. Measured against the last 60 merged descriptions here, PR #530 is the only one the stricter rule refuses — the accident that started this.
- **The workflow reads the pull request's own commit range** (`git log base..head`, with `fetch-depth: 0`), so the channel GitHub scans is covered, and the tests pin the message that caused this.

This description names no issue number after a keyword, on purpose: it is checked by the guard it documents, and an example written the hazard's way would perform the closure the pull request exists to prevent.

## The guard caught the first draft of this fix

The first commit message written for this change contained the pattern, and running it through the new rule refused it. The wording in the commit came from that refusal, which is also why the rule exists.

## Verification

```
python3 -m unittest discover -s planning/integrity -p 'test_*.py'   -> Ran 36 tests, OK

# the new CI step, over the real range whose merge closed the issue
git log --format=%h 98a33388..5bf7437f
  -> FAIL: the commit 5bf7437f carries a closing keyword, and GitHub closes
     the issue when the pull request merges into the default branch   (exit 1)

# and over the two merges since
5bf7437f..21c3bdb9, 21c3bdb9..f5a1fde8
  -> "No closing keyword: merging this text closes nothing."            (exit 0)

# the stricter description rule against work that already merged
last 60 merged descriptions  ->  1 refused: PR #530
```

## Scope

The guard reads the description and the messages of the commits in the pull request's own range. It does not read review comments, where GitHub also honours keywords, and it does not judge whether a stated closure is intended.
